### PR TITLE
Modified initialize method in revision_control/git

### DIFF
--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -229,7 +229,7 @@ module Origen
 
       def initialized?
         File.exist?("#{local}/.git") &&
-      #    git('remote -v', verbose: false).any? { |r| r =~ /#{remote_without_protocol_and_user}/ || r =~ /#{remote_without_protocol_and_user.to_s.gsub(':', "\/")}/ } &&
+          #    git('remote -v', verbose: false).any? { |r| r =~ /#{remote_without_protocol_and_user}/ || r =~ /#{remote_without_protocol_and_user.to_s.gsub(':', "\/")}/ } &&
           !git('status', verbose: false).any? { |l| l =~ /^#? ?Initial commit$/ }
       end
 

--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -229,7 +229,7 @@ module Origen
 
       def initialized?
         File.exist?("#{local}/.git") &&
-          git('remote -v', verbose: false).any? { |r| r =~ /#{remote_without_protocol_and_user}/ || r =~ /#{remote_without_protocol_and_user.to_s.gsub(':', "\/")}/ } &&
+      #    git('remote -v', verbose: false).any? { |r| r =~ /#{remote_without_protocol_and_user}/ || r =~ /#{remote_without_protocol_and_user.to_s.gsub(':', "\/")}/ } &&
           !git('status', verbose: false).any? { |l| l =~ /^#? ?Initial commit$/ }
       end
 


### PR DESCRIPTION
- The initialize method will return true if
 - .git exists
  - it is NOT the Initial Commit.

Any reason why the check requires that the remote URL matches https://github.com/Origen-SDK/origen.git?  

From my understanding, the remote origin by default will point to the forked repository URL. 
I do not think this check is required. Not sure if I am missing something obvious.