### PR TITLE
Fix issue if a global variable is nil.

### DIFF
--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -215,6 +215,7 @@ module Origen
         id:   nil,
         type: nil
       }.update(options)
+      return nil if @_notes.empty?
       # Empty 2-D Hash to be used for notes found based on id and type
       notes_found = Hash.new do |h, k|
         # h is the id portion of the hash
@@ -244,6 +245,7 @@ module Origen
         device: nil
       }.update(options)
       return @_spec_features if options[:id].nil? && options[:device].nil?
+      return nil if @_spec_features.empty?
       features_found = Hash.new do |h, k|
         h[k] = {}
       end
@@ -267,12 +269,13 @@ module Origen
         id:    nil,
         type:  nil
       }.update(options)
+      return nil if @_exhibits.empty?
       ex_found = Hash.new do |h, k|
         h[k] = Hash.new do |hh, kk|
           hh[kk] = {}
         end
       end
-      filter_hash(_exhibits, options[:block]).each do |_block, hash|
+      filter_hash(@_exhibits, options[:block]).each do |_block, hash|
         filter_hash(hash, options[:id]).each do |_id, hash_|
           filter_hash(hash_, options[:type]).each do |_type, exh|
             ex_found[_block][_id][_type] = exh
@@ -293,6 +296,7 @@ module Origen
         sub_type: nil,
         audience: nil
       }.update(options)
+      return nil if @_doc_resources.empty?
       dr_found = Hash.new do |h, k|
         h[k] = Hash.new do |hh, kk|
           hh[kk] = Hash.new do |hhh, kkk|
@@ -300,7 +304,7 @@ module Origen
           end
         end
       end
-      filter_hash(_doc_resources, options[:mode]).each do |_mode, hash|
+      filter_hash(@_doc_resources, options[:mode]).each do |_mode, hash|
         filter_hash(hash, options[:type]).each do |_type, hash_|
           filter_hash(hash_, options[:sub_type]).each do |_sub_type, hash__|
             filter_hash(hash__, options[:audience]).each do |_audience, spec|
@@ -324,6 +328,7 @@ module Origen
         sub_type: nil,
         audience: nil
       }.update(options)
+      return nil if @_overrides.empty?
       overrides_found = Hash.new do |h, k|
         h[k] = Hash.new do |hh, kk|
           hh[kk] = Hash.new do |hhh, kkk|
@@ -333,7 +338,7 @@ module Origen
           end
         end
       end
-      filter_hash(_overrides, options[:block]).each do |_block, hash|
+      filter_hash(@_overrides, options[:block]).each do |_block, hash|
         filter_hash(hash, options[:spec_ref]).each do |_spec_ref, hash_|
           filter_hash(hash_, options[:mode_ref]).each do |_mode_ref, hash__|
             filter_hash(hash__, options[:sub_type]).each do |_sub_type, hash___|
@@ -356,10 +361,11 @@ module Origen
         block: nil,
         mode:  nil
       }.update(options)
+      return nil if @_mode_selects.empty?
       modes_found = Hash.new do|h, k|
         h[k] = {}
       end
-      filter_hash(_mode_selects, options[:block]).each do |block, hash|
+      filter_hash(@_mode_selects, options[:block]).each do |block, hash|
         filter_hash(hash, options[:mode]).each do |mode, sel|
           modes_found[block][mode] = sel
         end
@@ -379,7 +385,8 @@ module Origen
       ps_found = Hash.new do|h, k|
         h[k] = {}
       end
-      filter_hash(_power_supplies, options[:gen]).each do |gen, hash|
+      return nil if @_power_supplies.empty?
+      filter_hash(@_power_supplies, options[:gen]).each do |gen, hash|
         filter_hash(hash, options[:act]).each do |act, sel|
           ps_found[gen][act] = sel
         end

--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -215,6 +215,7 @@ module Origen
         id:   nil,
         type: nil
       }.update(options)
+      return nil if @_notes.nil?
       return nil if @_notes.empty?
       # Empty 2-D Hash to be used for notes found based on id and type
       notes_found = Hash.new do |h, k|
@@ -245,6 +246,7 @@ module Origen
         device: nil
       }.update(options)
       return @_spec_features if options[:id].nil? && options[:device].nil?
+      return nil if @_spec_features.nil?
       return nil if @_spec_features.empty?
       features_found = Hash.new do |h, k|
         h[k] = {}
@@ -269,6 +271,7 @@ module Origen
         id:    nil,
         type:  nil
       }.update(options)
+      return nil if @_exhibits.nil?
       return nil if @_exhibits.empty?
       ex_found = Hash.new do |h, k|
         h[k] = Hash.new do |hh, kk|
@@ -296,6 +299,7 @@ module Origen
         sub_type: nil,
         audience: nil
       }.update(options)
+      return nil if @_doc_resources.nil?
       return nil if @_doc_resources.empty?
       dr_found = Hash.new do |h, k|
         h[k] = Hash.new do |hh, kk|
@@ -328,6 +332,7 @@ module Origen
         sub_type: nil,
         audience: nil
       }.update(options)
+      return nil if @_overrides.nil?
       return nil if @_overrides.empty?
       overrides_found = Hash.new do |h, k|
         h[k] = Hash.new do |hh, kk|
@@ -361,6 +366,7 @@ module Origen
         block: nil,
         mode:  nil
       }.update(options)
+      return nil if @_mode_selects.nil?
       return nil if @_mode_selects.empty?
       modes_found = Hash.new do|h, k|
         h[k] = {}
@@ -385,6 +391,7 @@ module Origen
       ps_found = Hash.new do|h, k|
         h[k] = {}
       end
+      return nil if @_power_supplies.nil?
       return nil if @_power_supplies.empty?
       filter_hash(@_power_supplies, options[:gen]).each do |gen, hash|
         filter_hash(hash, options[:act]).each do |act, sel|

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -296,6 +296,7 @@ describe "Origen Specs Module" do
    @ip.notes(id: :note1).class.should == Origen::Specs::Note 
    @ip.notes(type: :spec).size.should == 7
    @ip.delete_all_notes
+   @ip.notes(type: :spec).should == nil
    @ip.note(:note1, :spec, {mode: :default, audience: :external, text: 'Note 1', markup: 'Not<sub>e</sub> 1', internal_comment: 'Reason for note'})
    @ip.notes(type: :spec).class.should == Origen::Specs::Note 
   end
@@ -306,6 +307,7 @@ describe "Origen Specs Module" do
     get_true_hash_size(@ip.exhibits(type: :table), Origen::Specs::Exhibit).should == 3
     get_true_hash_size(@ip.exhibits(id: :exhibit5), Origen::Specs::Exhibit).should == 1
     @ip.delete_all_exhibits
+    @ip.exhibits(id: :exhibit4).should == nil
     @ip.exhibit(:exhibit4, :table, {}, {title: 'Exhibit 4', description: 'Exhibit 4 Description', reference: 'link4', markup: 'markup', block_id: :esdhc})
     get_true_hash_size(@ip.exhibits, Origen::Specs::Exhibit).should == 1
   end
@@ -324,6 +326,7 @@ describe "Origen Specs Module" do
     get_true_hash_size(@ip.doc_resources(mode: :default, type: :ac, sub_type: 'input'), Origen::Specs::Doc_Resource).should == 2
     get_true_hash_size(@ip.doc_resources(mode: :default, type: :dc, audience: :external), Origen::Specs::Doc_Resource).should == 2
     @ip.delete_all_doc_resources
+    @ip.doc_resources(type: :dc).should == nil
     @ip.doc_resource({mode: :high_performance, type: :dc, sub_type: 'input', audience: :external}, {title: 'Title for Table 1', note_refs: nil, exhibit_refs: nil}, {before: nil, after: nil}, {})
     @ip.doc_resource({mode: :default, type: :dc, sub_type: 'input', audience: :internal}, {title: 'Title for Table 1', note_refs: nil, exhibit_refs: nil}, {before: nil, after: nil}, {})
     @ip.doc_resource({mode: :low_power, type: :dc, sub_type: 'input', audience: :internal}, {title: 'Title for Table 1', note_refs: nil, exhibit_refs: nil}, {before: nil, after: nil}, {})
@@ -338,6 +341,7 @@ describe "Origen Specs Module" do
     get_true_hash_size(@ip.power_supplies(gen: 'SVDD'), Origen::Specs::Power_Supply).should ==  6
     get_true_hash_size(@ip.power_supplies(act: 'X4VDD'), Origen::Specs::Power_Supply).should == 1
     @ip.delete_all_power_supplies    
+    @ip.power_supplies(gen: 'SVDD').should == nil
     @ip.power_supply('GVDD', 'G1VDD')
     @ip.power_supply('GVDD', 'G2VDD')
     @ip.power_supply('DVDD', 'D1VDD')
@@ -358,6 +362,7 @@ describe "Origen Specs Module" do
     get_true_hash_size(@ip.overrides(audience: :external), Origen::Specs::Override).should == 6
     get_true_hash_size(@ip.overrides(audience: :internal), Origen::Specs::Override).should == 0
     @ip.delete_all_overrides
+    @ip.overrides(block: :esdhc).should == nil
     @ip.override({block: :esdhc, usage: true}, {spec_id: :vdd_lp, mode_ref: :low_power, sub_type: 'input', audience: :external}, {min: 0.97}, {disable: false})
     @ip.override({block: :i2c, usage: true}, {spec_id: :clk_rise, mode_ref: :high_performance, sub_type: 'input', audience: :external}, {min: 0.97}, {disable: true})
     @ip.override({block: :ddr, usage: true}, {spec_id: :vdd, mode_ref: :high_performance, sub_type: 'output', audience: :external}, {min: 0.97}, {disable: true})
@@ -384,6 +389,7 @@ describe "Origen Specs Module" do
     get_true_hash_size(@ip.mode_selects(block: :i2c1), Origen::Specs::Mode_Select).should == 1
     get_true_hash_size(@ip.mode_selects(mode: :ddr_ddr4), Origen::Specs::Mode_Select).should == 1
     @ip.delete_all_mode_selects
+    @ip.mode_selects(block: :ddr).should == nil
     @ip.mode_select({name: :ddr, ds_header: 'DDR Controller', usage: true, location: 'path'}, {mode: :ddr_ddr3, supported: true}, {supply: 'G1VDD', voltage_level: '1.35V', use_diff: true})
     @ip.mode_select({name: :ifc1, ds_header: 'IFC', usage: true, location: 'path'}, {mode: :ifc1_nand, supported: true}, {supply: 'OVDD', voltage_level: '3.0V', use_diff: true})
     get_true_hash_size(@ip.mode_selects, Origen::Specs::Mode_Select).should == 2


### PR DESCRIPTION
There is an issue if the global variable (e.g. @_notes, @_doc_resources, ..) is nil.  Currently, the tool will respond with a Fail that "Hash argument is not a Hash".  This has been changed so that the script looks to see if the variable is nil or empty before doing filter_hash.