### PR TITLE
New Class for Specs Documentation

### DIFF
--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -130,13 +130,13 @@ module Origen
       !!show_specs(options)
     end
 
-    # Adds a new documentation notion to the block 
+    # Adds a new documentation notion to the block
     def documentation(header_info, selection,  link)
       _documentation
       # Create a new documenation and place it in the 5-D hash
       @_documentation[header_info[:section]][header_info[:subsection]][selection[:interface]][selection[:type]][selection[:subtype]][selection[:mode]][selection[:audience]] = Documentation.new(header_info, selection, link)
     end
-    
+
     # Adds a new feature to the block
     def spec_feature(id, attrs, device, text, internal_comment)
       # Welguisz:  No idea why this is here, but keeping it here because it follows other blocks
@@ -378,7 +378,7 @@ module Origen
         return doc_found
       end
     end
-    
+
     def overrides(options = {})
       options = {
         block:    nil,
@@ -510,7 +510,7 @@ module Origen
     def delete_spec_features
       @_spec_features = nil
     end
-    
+
     def delete_all_documentation
       @_documentation = nil
     end
@@ -624,7 +624,7 @@ module Origen
       end
       # rubocop:disable UnusedBlockArgument
       filtered_hash = hash.select do |k, v|
-        #binding.pry if filter == 'SubSection A'
+        # binding.pry if filter == 'SubSection A'
         [TrueClass, FalseClass].include?(select_logic.class) ? select_logic : eval(select_logic)
       end
       filtered_hash

--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -610,11 +610,11 @@ module Origen
     end
 
     # Return a hash based on the filter provided
-    def filter_hash(hash, filter)
+    def filter_hash(hash, filter, debug = false)
       fail 'Hash argument is not a Hash!' unless hash.is_a? Hash
       filtered_hash = {}
       select_logic = case filter
-        when String then 'k[Regexp.new(filter)] && k.length == filter.length unless k.nil?'
+        when String then 'k.nil? ? false : k[Regexp.new(filter)] && k.length == filter.length'
         when (Fixnum || Integer || Float || Numeric) then "k[Regexp.new('#{filter}')]"
         when Regexp then 'k[filter]'
         when Symbol then

--- a/lib/origen/specs/documentation.rb
+++ b/lib/origen/specs/documentation.rb
@@ -2,12 +2,11 @@ module Origen
   module Specs
     # This class is used to store documentation map that the user can change
     class Documentation
-      
       # This is the Section Header for the Documentation Map.  Usually these are main headers
       # Examples:
       #  I. Overall DC Electricals
       #  II. General AC Charactertistics
-      #  III. Power Sequencing 
+      #  III. Power Sequencing
       attr_accessor :section
 
       # This is the subsection header for the Documentation Map.  These are found under main headers
@@ -20,7 +19,7 @@ module Origen
 
       # Exhibit References that should be referenced within the table title
       attr_accessor :interface
-      
+
       # Mode is part of the 4-D Hash for the Tables.  Corresponds to Spec 4-D Hash
       attr_accessor :mode
 
@@ -53,7 +52,6 @@ module Origen
         @audience = selection[:audience]
         @link = link
       end
-
     end
   end
 end

--- a/lib/origen/specs/documentation.rb
+++ b/lib/origen/specs/documentation.rb
@@ -1,0 +1,59 @@
+module Origen
+  module Specs
+    # This class is used to store documentation map that the user can change
+    class Documentation
+      
+      # This is the Section Header for the Documentation Map.  Usually these are main headers
+      # Examples:
+      #  I. Overall DC Electricals
+      #  II. General AC Charactertistics
+      #  III. Power Sequencing 
+      attr_accessor :section
+
+      # This is the subsection header for the Documentation Map.  These are found under main headers
+      # Examples
+      #  I. Overall DC electrical
+      #    A. Absolute Maximum Ratings
+      #    B. Recommend Operating Conditions
+      #    C. Output Driver
+      attr_accessor :subsection
+
+      # Exhibit References that should be referenced within the table title
+      attr_accessor :interface
+      
+      # Mode is part of the 4-D Hash for the Tables.  Corresponds to Spec 4-D Hash
+      attr_accessor :mode
+
+      # Type is part of the 4-D Hash for the Tables.  Corresponds to Spec 4-D Hash
+      # Usual values
+      #
+      # * DC -> Direct Current
+      # * AC -> Alternate Current
+      # * Temp -> Temperature
+      # * Supply -> Supply
+      attr_accessor :type
+
+      # SubType is part of the 4-D Hash for the Tables. Corresponds to Spec 4-D Hash
+      attr_accessor :sub_type
+
+      # Audience is part of the 4-D Hash for the Tables.  Corresponds to Spec 4-D Hash
+      attr_accessor :audience
+
+      # DITA Formatted Text that appears before the table
+      attr_accessor :link
+
+      # Initialize the Class
+      def initialize(header_info = {}, selection = {}, link = nil)
+        @section = header_info[:section]
+        @subsection = header_info[:subsection]
+        @interface = selection[:interface]
+        @mode = selection[:mode]
+        @type = selection[:type]
+        @sub_type = selection[:sub_type]
+        @audience = selection[:audience]
+        @link = link
+      end
+
+    end
+  end
+end

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -410,23 +410,22 @@ describe "Origen Specs Module" do
     get_true_hash_size(@ip.documentations(section: 'Section 3'), Origen::Specs::Documentation).should == 3
     @ip.documentations(section: 'Section 4').should == nil
     get_true_hash_size(@ip.documentations(subsection: 'SubSection A'), Origen::Specs::Documentation).should == 3
-    #get_true_hash_size(@ip.documentations(subsection: 'SubSection B'), Origen::Specs::Documentation).should == 3
-    #get_true_hash_size(@ip.documentations(subsection: 'SubSection C'), Origen::Specs::Documentation).should == 2
-    #get_true_hash_size(@ip.documentations(subsection: 'SubSection D'), Origen::Specs::Documentation).should == 1
-    #@ip.documentations(subsection: 'SubSection E').should == nil
-    #get_true_hash_size(@ip.documentations(interface: 'SoC'), Origen::Specs::Documentation).should == 3
-    #get_true_hash_size(@ip.documentations(interface: 'Block A'), Origen::Specs::Documentation).should == 4
-    #get_true_hash_size(@ip.documentations(interface: 'Block B'), Origen::Specs::Documentation).should == 3
-    #@ip.documentations(interface: 'Block C').should == nil
-    #@ip.documentations(interface: 'Block B', type: :supply, audience: :external).link.should == 'http://link_to_section3c.xml'
-    #@ip.delete_all_documentation
-    #@ip.documentations.should == nil
-    #documentation({section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, nil)
-    #documentation({section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, nil)
-    #documentation({section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2b.xml')
-    #get_true_hash_size(@ip.documentations, Origen::Specs::Documentation).should == 3
-    #get_true_hash_size(@ip.documentations(section: 'Section 1'), Origen::Specs::Documentation).should == 1
-    #get_true_hash_size(@ip.documentations(section: 'Section 2'), Origen::Specs::Documentation).should == 2
+    get_true_hash_size(@ip.documentations(subsection: 'SubSection B'), Origen::Specs::Documentation).should == 3
+    get_true_hash_size(@ip.documentations(subsection: 'SubSection C'), Origen::Specs::Documentation).should == 2
+    get_true_hash_size(@ip.documentations(subsection: 'SubSection D'), Origen::Specs::Documentation).should == 1
+    @ip.documentations(subsection: 'SubSection E').should == nil
+    get_true_hash_size(@ip.documentations(interface: 'SoC'), Origen::Specs::Documentation).should == 3
+    get_true_hash_size(@ip.documentations(interface: 'Block A'), Origen::Specs::Documentation).should == 4
+    get_true_hash_size(@ip.documentations(interface: 'Block B'), Origen::Specs::Documentation).should == 3
+    @ip.documentations(interface: 'Block C').should == nil
+    @ip.delete_all_documentation
+    @ip.documentations.should == nil
+    @ip.documentation({section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, nil)
+    @ip.documentation({section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, nil)
+    @ip.documentation({section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2b.xml')
+    get_true_hash_size(@ip.documentations, Origen::Specs::Documentation).should == 3
+    get_true_hash_size(@ip.documentations(section: 'Section 1'), Origen::Specs::Documentation).should == 1
+    get_true_hash_size(@ip.documentations(section: 'Section 2'), Origen::Specs::Documentation).should == 2
   end
     
 end

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -165,8 +165,16 @@ class IP_With_Specs
     creation_info('Jim Smith', '22 Mar 2015', '1.0', {source: 'block-ref-i2c', ip_block_name: :i2c, revision: 'c'}, {tool: 'ISC App', version: '0.7.5'})
     creation_info('Jim Smith', '29 Apr 2015', '1.0', {source: 'block-ref-ifc', ip_block_name: :ifc, revision: 'g'}, {tool: 'ISC App', version: '0.7.5'})
     creation_info('Jim Smith', '4 Jun 2015', '1.0', {source: 'block-ref-esdhc', ip_block_name: :esdhc, revision: 'b'}, {tool: 'ISC App', version: '0.7.5'})
-
-    
+    documentation({section: 'Section 1', subsection: nil}, {interface: 'SoC', type: nil, subtype: nil, mode: nil, audience: :external}, nil)
+    documentation({section: 'Section 1', subsection: 'SubSection A'}, {interface: 'SoC', type: :dc, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section1a.xml')
+    documentation({section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, nil)
+    documentation({section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, nil)
+    documentation({section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2b.xml')
+    documentation({section: 'Section 2', subsection: 'SubSection C'}, {interface: 'Block A', type: :power, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2c.xml')
+    documentation({section: 'Section 2', subsection: 'SubSection D'}, {interface: 'Block A', type: :impedance, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2d.xml')
+    documentation({section: 'Section 3', subsection: 'SubSection A'}, {interface: 'Block B', type: :ac, subtype: nil, mode: nil, audience: :external}, nil)
+    documentation({section: 'Section 3', subsection: 'SubSection B'}, {interface: 'Block B', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, 'http://link_to_section3b.xml')
+    documentation({section: 'Section 3', subsection: 'SubSection C'}, {interface: 'Block B', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section3c.xml')    
   end
 end
 
@@ -393,6 +401,32 @@ describe "Origen Specs Module" do
     @ip.mode_select({name: :ddr, ds_header: 'DDR Controller', usage: true, location: 'path'}, {mode: :ddr_ddr3, supported: true}, {supply: 'G1VDD', voltage_level: '1.35V', use_diff: true})
     @ip.mode_select({name: :ifc1, ds_header: 'IFC', usage: true, location: 'path'}, {mode: :ifc1_nand, supported: true}, {supply: 'OVDD', voltage_level: '3.0V', use_diff: true})
     get_true_hash_size(@ip.mode_selects, Origen::Specs::Mode_Select).should == 2
+  end
+  
+  it "can see sub_block documentation" do
+    get_true_hash_size(@ip.documentations, Origen::Specs::Documentation).should == 10
+    get_true_hash_size(@ip.documentations(section: 'Section 1'), Origen::Specs::Documentation).should == 3
+    get_true_hash_size(@ip.documentations(section: 'Section 2'), Origen::Specs::Documentation).should == 4
+    get_true_hash_size(@ip.documentations(section: 'Section 3'), Origen::Specs::Documentation).should == 3
+    @ip.documentations(section: 'Section 4').should == nil
+    get_true_hash_size(@ip.documentations(subsection: 'SubSection A'), Origen::Specs::Documentation).should == 3
+    #get_true_hash_size(@ip.documentations(subsection: 'SubSection B'), Origen::Specs::Documentation).should == 3
+    #get_true_hash_size(@ip.documentations(subsection: 'SubSection C'), Origen::Specs::Documentation).should == 2
+    #get_true_hash_size(@ip.documentations(subsection: 'SubSection D'), Origen::Specs::Documentation).should == 1
+    #@ip.documentations(subsection: 'SubSection E').should == nil
+    #get_true_hash_size(@ip.documentations(interface: 'SoC'), Origen::Specs::Documentation).should == 3
+    #get_true_hash_size(@ip.documentations(interface: 'Block A'), Origen::Specs::Documentation).should == 4
+    #get_true_hash_size(@ip.documentations(interface: 'Block B'), Origen::Specs::Documentation).should == 3
+    #@ip.documentations(interface: 'Block C').should == nil
+    #@ip.documentations(interface: 'Block B', type: :supply, audience: :external).link.should == 'http://link_to_section3c.xml'
+    #@ip.delete_all_documentation
+    #@ip.documentations.should == nil
+    #documentation({section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, nil)
+    #documentation({section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, nil)
+    #documentation({section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2b.xml')
+    #get_true_hash_size(@ip.documentations, Origen::Specs::Documentation).should == 3
+    #get_true_hash_size(@ip.documentations(section: 'Section 1'), Origen::Specs::Documentation).should == 1
+    #get_true_hash_size(@ip.documentations(section: 'Section 2'), Origen::Specs::Documentation).should == 2
   end
     
 end


### PR DESCRIPTION
This class allows for documentation to control how the map output and the topic output would look.  This is just the base class and individual companies and people can add on to make it specific to their strategy.