### PR TITLE
Have the ability to checkin to a branch that is not master

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,3 @@ DEPENDENCIES
   origen_doc_helpers (>= 0.2.0)
   origen_testers (~> 0)
   stackprof (~> 0)
-
-BUNDLED WITH
-   1.11.2

--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -88,7 +88,7 @@ module Origen
           git("checkout #{local_rev} -- #{paths.join(' ')}", check_errors: false)
           # Then proceed with checking them in as latest
         else
-          checkout unless options[:initial]
+          checkout options unless options[:initial]
         end
         cmd = 'add'
         if options[:unmanaged]


### PR DESCRIPTION
I was working on some code and no matter what I did, I could not get Origen to check in the file on a different branch than master.  When I did the following things, I was able to get Origen to check in the file on a different branch:

* Added 'options' to the _checkout unless options[:initial]_ to allow for version to be passed
* In my code, added version option to the checkin command.

When I did that I got the ability to check in files on a different branch.