### PR TITLE
Added capability to find specs using :symbol attribute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     netrc (0.10.3)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.7.2-x86-mingw32)
+      mini_portile2 (~> 2.0.0.rc2)
     origen_core_support (0.2.3)
       origen (>= 0.2.6)
     origen_debuggers (0.5.1)
@@ -187,6 +189,3 @@ DEPENDENCIES
   origen_doc_helpers (>= 0.2.0)
   origen_testers (~> 0)
   stackprof (~> 0)
-
-BUNDLED WITH
-   1.11.2

--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -48,6 +48,7 @@ module Origen
         sub_type:      nil,
         mode:          current_mode.nil? ? nil : current_mode.name,
         spec:          nil,
+        symbol:        nil,
         creating_spec: false
       }.update(options || {})
       _specs
@@ -102,6 +103,7 @@ module Origen
         sub_type:      nil,
         mode:          current_mode.nil? ? nil : current_mode.name,
         spec:          nil,
+        symbol:        nil,
         creating_spec: false
       }.update(options)
       if @_specs.nil? || @_specs == {}
@@ -124,6 +126,7 @@ module Origen
         sub_type:      nil,
         mode:          current_mode.nil? ? nil : current_mode.name,
         spec:          nil,
+        symbol:        nil,
         creating_spec: false
       }.update(options)
       options[:spec] = s
@@ -635,6 +638,7 @@ module Origen
       options = {
         mode:              nil,
         spec:              nil,
+        symbol:            nil,
         type:              nil,
         sub_type:          nil,
         specs_to_be_shown: SpecArray.new,
@@ -646,7 +650,13 @@ module Origen
         filter_hash(hash, options[:mode]).each do |_mode, hash_|
           filter_hash(hash_, options[:type]).each do |_type, hash__|
             filter_hash(hash__, options[:sub_type]).each do |_sub_type, spec|
-              specs_to_be_shown << spec
+              if options[:symbol]
+                if spec.symbol && (spec.symbol.gsub(/<.*?>/, '').downcase.to_sym == options[:symbol])
+                  specs_to_be_shown << spec
+                end
+              else
+                specs_to_be_shown << spec
+              end
             end
           end
         end

--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -48,7 +48,7 @@ module Origen
         sub_type:      nil,
         mode:          current_mode.nil? ? nil : current_mode.name,
         spec:          nil,
-        symbol:        nil,
+        symbol:        false,
         creating_spec: false
       }.update(options || {})
       _specs
@@ -103,7 +103,7 @@ module Origen
         sub_type:      nil,
         mode:          current_mode.nil? ? nil : current_mode.name,
         spec:          nil,
-        symbol:        nil,
+        symbol:        false,
         creating_spec: false
       }.update(options)
       if @_specs.nil? || @_specs == {}
@@ -126,7 +126,7 @@ module Origen
         sub_type:      nil,
         mode:          current_mode.nil? ? nil : current_mode.name,
         spec:          nil,
-        symbol:        nil,
+        symbol:        false,
         creating_spec: false
       }.update(options)
       options[:spec] = s
@@ -638,20 +638,21 @@ module Origen
       options = {
         mode:              nil,
         spec:              nil,
-        symbol:            nil,
         type:              nil,
         sub_type:          nil,
         specs_to_be_shown: SpecArray.new,
         owner:             nil,
+        symbol:            false,
         creating_spec:     false
       }.update(options)
+      options[:symbol] ? symbol = options.delete(:spec) : symbol = nil
       specs_to_be_shown = options[:specs_to_be_shown]
       filter_hash(_specs, options[:spec]).each do |_spec, hash|
         filter_hash(hash, options[:mode]).each do |_mode, hash_|
           filter_hash(hash_, options[:type]).each do |_type, hash__|
             filter_hash(hash__, options[:sub_type]).each do |_sub_type, spec|
-              if options[:symbol]
-                if spec.symbol && (spec.symbol.gsub(/<.*?>/, '').downcase.to_sym == options[:symbol])
+              if symbol
+                if spec.symbol && (spec.symbol.gsub(/<.*?>/, '').downcase.to_sym == symbol)
                   specs_to_be_shown << spec
                 end
               else

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -293,6 +293,11 @@ describe "Origen Specs Module" do
     $dut.has_spec?(:tnikhov2).should == true
     $dut.has_spec?(/tnikhov/).should == true
   end
+
+  it "finding specs via :symbol option works" do
+    $dut.has_spec?(nil, symbol: :gvdd).should == true  
+    $dut.has_spec?(nil, symbol: :dvdd).should == false  
+  end
   
   it "can see sub_block features" do
     @ip.spec_features(id: :feature1).class.should == Origen::Specs::Spec_Features

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -295,8 +295,8 @@ describe "Origen Specs Module" do
   end
 
   it "finding specs via :symbol option works" do
-    $dut.has_spec?(nil, symbol: :gvdd).should == true  
-    $dut.has_spec?(nil, symbol: :dvdd).should == false  
+    $dut.has_spec?(:gvdd, symbol: true).should == true  
+    $dut.has_spec?(:dvdd, symbol: true).should == false  
   end
   
   it "can see sub_block features" do


### PR DESCRIPTION
Added capability to the 'show_specs' method to allow the user to find all the specs wth a given spec symbol, rather than by spec name.