### PR TITLE
Remove limit checker on Nokogiri::XML::NodeSet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,3 @@ DEPENDENCIES
   origen_doc_helpers (>= 0.2.0)
   origen_testers (~> 0)
   stackprof (~> 0)
-
-BUNDLED WITH
-   1.11.2

--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -137,7 +137,7 @@ module Origen
     def documentation(header_info, selection,  link)
       _documentation
       # Create a new documenation and place it in the 5-D hash
-      @_documentation[header_info[:section]][header_info[:subsection]][selection[:interface]][selection[:type]][selection[:subtype]][selection[:mode]][selection[:audience]] = Documentation.new(header_info, selection, link)
+      @_documentation[header_info[:section]][header_info[:subsection]][selection[:interface]][selection[:type]][selection[:sub_type]][selection[:mode]][selection[:audience]] = Documentation.new(header_info, selection, link)
     end
 
     # Adds a new feature to the block

--- a/lib/origen/specs.rb
+++ b/lib/origen/specs.rb
@@ -134,10 +134,10 @@ module Origen
     end
 
     # Adds a new documentation notion to the block
-    def documentation(header_info, selection,  link)
+    def documentation(header_info, selection, applicable_devices, link)
       _documentation
       # Create a new documenation and place it in the 5-D hash
-      @_documentation[header_info[:section]][header_info[:subsection]][selection[:interface]][selection[:type]][selection[:sub_type]][selection[:mode]][selection[:audience]] = Documentation.new(header_info, selection, link)
+      @_documentation[header_info[:section]][header_info[:subsection]][selection[:interface]][selection[:type]][selection[:sub_type]][selection[:mode]][selection[:audience]] = Documentation.new(header_info, selection, applicable_devices, link)
     end
 
     # Adds a new feature to the block

--- a/lib/origen/specs/checkers.rb
+++ b/lib/origen/specs/checkers.rb
@@ -70,7 +70,7 @@ module Origen
       end
 
       def evaluate_limit(limit)
-        return limit if limit.is_a?(Numeric) || limit.is_a?(Symbol)
+        return limit if [Numeric, Symbol, Nokogiri::XML::NodeSet].include? limit.class
         return nil if limit.nil?
         limit.gsub!("\n", ' ')
         limit.scrub!

--- a/lib/origen/specs/checkers.rb
+++ b/lib/origen/specs/checkers.rb
@@ -1,6 +1,8 @@
 module Origen
   module Specs
     module Checkers
+      require 'nokogiri'
+
       # rubocop:disable Style/RescueModifier:
       def name_audit(name)
         return name if name.nil?
@@ -70,8 +72,9 @@ module Origen
       end
 
       def evaluate_limit(limit)
-        return limit if [Float, Numeric, Symbol, Nokogiri::XML::NodeSet].include? limit.class
+        return limit if [Fixnum, Float, Numeric, Symbol].include? limit.class
         return nil if limit.nil?
+        limit = limit.to_s if [Nokogiri::XML::NodeSet, Nokogiri::XML::Text, Nokogiri::XML::Element].include? limit.class
         limit.gsub!("\n", ' ')
         limit.scrub!
         result = false

--- a/lib/origen/specs/checkers.rb
+++ b/lib/origen/specs/checkers.rb
@@ -70,7 +70,7 @@ module Origen
       end
 
       def evaluate_limit(limit)
-        return limit if [Numeric, Symbol, Nokogiri::XML::NodeSet].include? limit.class
+        return limit if [Float, Numeric, Symbol, Nokogiri::XML::NodeSet].include? limit.class
         return nil if limit.nil?
         limit.gsub!("\n", ' ')
         limit.scrub!

--- a/lib/origen/specs/documentation.rb
+++ b/lib/origen/specs/documentation.rb
@@ -44,8 +44,11 @@ module Origen
       # DITA Formatted Text that appears before the table
       attr_accessor :link
 
+      # Applicable Devices for the map
+      attr_accessor :applicable_devices
+
       # Initialize the Class
-      def initialize(header_info = {}, selection = {}, link = nil)
+      def initialize(header_info = {}, selection = {}, applicable_devs = [], link = nil)
         @level = header_info[:level]
         @section = header_info[:section]
         @subsection = header_info[:subsection]
@@ -54,6 +57,7 @@ module Origen
         @type = selection[:type]
         @sub_type = selection[:sub_type]
         @audience = selection[:audience]
+        @applicable_devices = applicable_devs
         @link = link
       end
     end

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -165,16 +165,16 @@ class IP_With_Specs
     creation_info('Jim Smith', '22 Mar 2015', '1.0', {source: 'block-ref-i2c', ip_block_name: :i2c, revision: 'c'}, {tool: 'ISC App', version: '0.7.5'})
     creation_info('Jim Smith', '29 Apr 2015', '1.0', {source: 'block-ref-ifc', ip_block_name: :ifc, revision: 'g'}, {tool: 'ISC App', version: '0.7.5'})
     creation_info('Jim Smith', '4 Jun 2015', '1.0', {source: 'block-ref-esdhc', ip_block_name: :esdhc, revision: 'b'}, {tool: 'ISC App', version: '0.7.5'})
-    documentation({level: 1, section: 'Section 1', subsection: nil}, {interface: 'SoC', type: nil, subtype: nil, mode: nil, audience: :external}, nil)
-    documentation({level: 3, section: 'Section 1', subsection: 'SubSection A'}, {interface: 'SoC', type: :dc, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section1a.xml')
-    documentation({level: 4, section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, nil)
-    documentation({level: 5, section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, nil)
-    documentation({level: 8, section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2b.xml')
-    documentation({level: 6, section: 'Section 2', subsection: 'SubSection C'}, {interface: 'Block A', type: :power, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2c.xml')
-    documentation({level: 0, section: 'Section 2', subsection: 'SubSection D'}, {interface: 'Block A', type: :impedance, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2d.xml')
-    documentation({level: 1, section: 'Section 3', subsection: 'SubSection A'}, {interface: 'Block B', type: :ac, subtype: nil, mode: nil, audience: :external}, nil)
-    documentation({level: 2, section: 'Section 3', subsection: 'SubSection B'}, {interface: 'Block B', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, 'http://link_to_section3b.xml')
-    documentation({level: 4, section: 'Section 3', subsection: 'SubSection C'}, {interface: 'Block B', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section3c.xml')    
+    documentation({level: 1, section: 'Section 1', subsection: nil}, {interface: 'SoC', type: nil, subtype: nil, mode: nil, audience: :external}, [:device1], nil)
+    documentation({level: 3, section: 'Section 1', subsection: 'SubSection A'}, {interface: 'SoC', type: :dc, subtype: nil, mode: nil, audience: :external}, [:device1], 'http://link_to_section1a.xml')
+    documentation({level: 4, section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, [:device2], nil)
+    documentation({level: 5, section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, [:device1], nil)
+    documentation({level: 8, section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, [:device1, :device2], 'http://link_to_section2b.xml')
+    documentation({level: 6, section: 'Section 2', subsection: 'SubSection C'}, {interface: 'Block A', type: :power, subtype: nil, mode: nil, audience: :external}, [:device1, :device2], 'http://link_to_section2c.xml')
+    documentation({level: 0, section: 'Section 2', subsection: 'SubSection D'}, {interface: 'Block A', type: :impedance, subtype: nil, mode: nil, audience: :external}, [:device1, :device2], 'http://link_to_section2d.xml')
+    documentation({level: 1, section: 'Section 3', subsection: 'SubSection A'}, {interface: 'Block B', type: :ac, subtype: nil, mode: nil, audience: :external}, [:device1, :device2], nil)
+    documentation({level: 2, section: 'Section 3', subsection: 'SubSection B'}, {interface: 'Block B', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, [:device1, :device2], 'http://link_to_section3b.xml')
+    documentation({level: 4, section: 'Section 3', subsection: 'SubSection C'}, {interface: 'Block B', type: :supply, subtype: nil, mode: nil, audience: :external}, [:device1, :device2], 'http://link_to_section3c.xml')    
   end
 end
 
@@ -425,9 +425,9 @@ describe "Origen Specs Module" do
     @ip.documentations(interface: 'Block C').should == nil
     @ip.delete_all_documentation
     @ip.documentations.should == nil
-    @ip.documentation({section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, nil)
-    @ip.documentation({section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, nil)
-    @ip.documentation({section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, 'http://link_to_section2b.xml')
+    @ip.documentation({section: 'Section 1', subsection: 'SubSection B'}, {interface: 'SoC', type: :supply, subtype: :abs_max_ratings, mode: nil, audience: :external}, [:device1, :device2], nil)
+    @ip.documentation({section: 'Section 2', subsection: 'SubSection A'}, {interface: 'Block A', type: :dc, subtype: :V3p3V, mode: nil, audience: :internal}, [:device1, :device2], nil)
+    @ip.documentation({section: 'Section 2', subsection: 'SubSection B'}, {interface: 'Block A', type: :supply, subtype: nil, mode: nil, audience: :external}, [:device1, :device2], 'http://link_to_section2b.xml')
     get_true_hash_size(@ip.documentations, Origen::Specs::Documentation).should == 3
     get_true_hash_size(@ip.documentations(section: 'Section 1'), Origen::Specs::Documentation).should == 1
     get_true_hash_size(@ip.documentations(section: 'Section 2'), Origen::Specs::Documentation).should == 2


### PR DESCRIPTION
Added Nokogiri::XML::NodeSet as a class to ignore when evaluating limits.