### PR TITLE
Minor update to regression manager

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,3 @@ DEPENDENCIES
   origen_doc_helpers (>= 0.2.0)
   origen_testers (~> 0)
   stackprof (~> 0)
-
-BUNDLED WITH
-   1.12.5


### PR DESCRIPTION
- added capability to provide the reference workspace path and version number.
- fixed minor bug while setting up the origen workspace. For some reason, bundle install is also needed along with origen -v in a newly built workspace.