### PR TITLE
Store Log Messages into a Hash for debug purposes

### DIFF
--- a/lib/origen/log.rb
+++ b/lib/origen/log.rb
@@ -12,11 +12,25 @@ module Origen
     require 'log4r'
     require 'log4r/outputter/fileoutputter'
 
+    attr_accessor :msg_hash
+
     LEVELS = [:normal, :verbose, :silent]
 
     def initialize
       @log_time_0 = @t0 = Time.new
       self.level = :normal
+      @msg_hash = init_msg_hash
+    end
+
+    def init_msg_hash
+      msg_types = [:info, :warn, :error, :deprecate, :debug, :success]
+      msg_hash = {}
+      msg_types.each do |m|
+        msg_hash[m] = Hash.new do |h, k|
+          h[k] = []
+        end
+      end
+      msg_hash
     end
 
     def console_only?
@@ -74,50 +88,56 @@ module Origen
       @level
     end
 
-    def debug(string = '')
+    def debug(string = '', msg_type = nil)
       msg = format_msg('DEBUG', string)
       log_files.debug msg unless console_only?
       console.debug msg
+      @msg_hash[:debug][msg_type] << msg
       nil
     end
 
-    def info(string = '')
+    def info(string = '', msg_type = nil)
       msg = format_msg('INFO', string)
       log_files.info msg unless console_only?
       console.info msg
+      @msg_hash[:info][msg_type] << msg
       nil
     end
     # Legacy methods
     alias_method :lputs, :info
     alias_method :lprint, :info
 
-    def success(string = '')
+    def success(string = '', msg_type = nil)
       msg = format_msg('SUCCESS', string)
       log_files.info msg unless console_only?
       console.info msg.green
+      @msg_hash[:success][msg_type] << msg
       nil
     end
 
-    def deprecate(string = '')
+    def deprecate(string = '', msg_type = nil)
       msg = format_msg('DEPRECATED', string)
       log_files.warn msg unless console_only?
       console.warn msg.yellow
+      @msg_hash[:deprecate][msg_type] << msg
       nil
     end
     alias_method :deprecated, :deprecate
 
-    def warn(string = '')
+    def warn(string = '', msg_type = nil)
       msg = format_msg('WARNING', string)
       log_files.warn msg unless console_only?
       console.warn msg.yellow
+      @msg_hash[:warn][msg_type] << msg
       nil
     end
     alias_method :warning, :warn
 
-    def error(string = '')
+    def error(string = '', msg_type = nil)
       msg = format_msg('ERROR', string)
       log_files.error msg unless console_only?
       console.error msg.red
+      @msg_hash[:error][msg_type] << msg
       nil
     end
 

--- a/lib/origen/log.rb
+++ b/lib/origen/log.rb
@@ -88,7 +88,13 @@ module Origen
       @level
     end
 
+    def validate_args(string, msg_type)
+      return string, msg_type unless string.is_a? Symbol
+      ['', string]
+    end
+
     def debug(string = '', msg_type = nil)
+      string, msg_type = validate_args(string, msg_type)
       msg = format_msg('DEBUG', string)
       log_files.debug msg unless console_only?
       console.debug msg
@@ -97,6 +103,7 @@ module Origen
     end
 
     def info(string = '', msg_type = nil)
+      string, msg_type = validate_args(string, msg_type)
       msg = format_msg('INFO', string)
       log_files.info msg unless console_only?
       console.info msg
@@ -108,6 +115,7 @@ module Origen
     alias_method :lprint, :info
 
     def success(string = '', msg_type = nil)
+      string, msg_type = validate_args(string, msg_type)
       msg = format_msg('SUCCESS', string)
       log_files.info msg unless console_only?
       console.info msg.green
@@ -116,6 +124,7 @@ module Origen
     end
 
     def deprecate(string = '', msg_type = nil)
+      string, msg_type = validate_args(string, msg_type)
       msg = format_msg('DEPRECATED', string)
       log_files.warn msg unless console_only?
       console.warn msg.yellow
@@ -125,6 +134,7 @@ module Origen
     alias_method :deprecated, :deprecate
 
     def warn(string = '', msg_type = nil)
+      string, msg_type = validate_args(string, msg_type)
       msg = format_msg('WARNING', string)
       log_files.warn msg unless console_only?
       console.warn msg.yellow
@@ -134,6 +144,7 @@ module Origen
     alias_method :warning, :warn
 
     def error(string = '', msg_type = nil)
+      string, msg_type = validate_args(string, msg_type)
       msg = format_msg('ERROR', string)
       log_files.error msg unless console_only?
       console.error msg.red

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper.rb'
+
+describe 'Check that the msg_hash in Origen.log stores messages correctly' do
+  attr_accessor :msg_type
+  @msg_type = [:info, :warn, :error,  :deprecate, :debug, :success]
+  @msg_type.each do |m|
+    it "Will check that the msg_hash[:#{m}] updates correctly for default message type" do
+      initial_count = {}
+      type = [:info, :warn, :error,  :deprecate, :debug, :success]
+      type.each do |k|
+        initial_count[k] = Origen.log.msg_hash[k][nil].size
+      end
+      Origen.log.send(m, 'Test message')
+      Origen.log.msg_hash[m][nil].last.include?(m.to_s.upcase).should == true
+      type.each do |k|
+        if k == m
+          Origen.log.msg_hash[k][nil].size.should == initial_count[k] + 1
+        else
+          Origen.log.msg_hash[k][nil].size.should == initial_count[k]
+        end
+      end
+    end
+  end
+
+  @msg_type.each do |m|
+    it "Will check that the msg_hash[:#{m}] for a non-default size is nil if not set" do
+      initial_count = {}
+      type = [:info, :warn, :error,  :deprecate, :debug, :success]
+      type.each do |k|
+        Origen.log.msg_hash[k][:section3].nil? == true
+      end
+    end
+  end
+
+  
+  @msg_type.each do |m|
+    it "Will check that the msg_hash[:#{m}] updates correctly for section message code" do
+      initial_count = {}
+      type = [:info, :warn, :error,  :deprecate, :debug, :success]
+      type.each do |k|
+        initial_count[k] = Origen.log.msg_hash[k][:section1].size
+      end
+      Origen.log.send(m, 'Test message', :section1)
+      Origen.log.msg_hash[m][:section1].last.include?(m.to_s.upcase).should == true
+      type.each do |k|
+        if k == m
+          Origen.log.msg_hash[k][:section1].size.should == initial_count[k] + 1
+        else
+          Origen.log.msg_hash[k][:section1].size.should == initial_count[k]
+        end
+      end
+      type.each do |k|
+        Origen.log.msg_hash[k][:section3].nil? == true
+      end
+    end
+  end
+
+  
+  
+end

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -23,6 +23,26 @@ describe 'Check that the msg_hash in Origen.log stores messages correctly' do
   end
 
   @msg_type.each do |m|
+    it "Will check that the #{m} can handle nil for both msg and msg_type" do
+      initial_count = {}
+      type = [:info, :warn, :error,  :deprecate, :debug, :success]
+      type.each do |k|
+        initial_count[k] = Origen.log.msg_hash[k][nil].size
+      end
+      Origen.log.send(m)
+      Origen.log.msg_hash[m][nil].last.include?(m.to_s.upcase).should == true
+      Origen.log.msg_hash[m][nil].last[-8..-1].should == ']    || '
+      type.each do |k|
+        if k == m
+          Origen.log.msg_hash[k][nil].size.should == initial_count[k] + 1
+        else
+          Origen.log.msg_hash[k][nil].size.should == initial_count[k]
+        end
+      end
+    end
+  end
+  
+  @msg_type.each do |m|
     it "Will check that the msg_hash[:#{m}] for a non-default size is nil if not set" do
       initial_count = {}
       type = [:info, :warn, :error,  :deprecate, :debug, :success]

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -43,6 +43,32 @@ describe 'Check that the msg_hash in Origen.log stores messages correctly' do
   end
   
   @msg_type.each do |m|
+    it "Will check that the #{m} can handle nil for msg and msg_type set with a symbol.  Padding example" do
+      initial_count = Hash.new do |h, k|
+        h[k]= {}
+      end
+      type = [:info, :warn, :error,  :deprecate, :debug, :success]
+      type.each do |k|
+        [nil, :check2].each do |k1|
+          initial_count[k][k1] = Origen.log.msg_hash[k][k1].size
+        end
+      end
+      Origen.log.send(m, :check2)
+      Origen.log.msg_hash[m][:check2].last.include?(m.to_s.upcase).should == true
+      Origen.log.msg_hash[m][:check2].last[-8..-1].should == ']    || '
+      type.each do |k|
+        if k == m
+          Origen.log.msg_hash[k][nil].size.should == initial_count[k][nil]
+          Origen.log.msg_hash[k][:check2].size.should == initial_count[k][:check2] + 1
+        else
+          Origen.log.msg_hash[k][nil].size.should == initial_count[k][nil]
+          Origen.log.msg_hash[k][:check2].size.should == initial_count[k][:check2]
+        end
+      end
+    end
+  end
+  
+  @msg_type.each do |m|
     it "Will check that the msg_hash[:#{m}] for a non-default size is nil if not set" do
       initial_count = {}
       type = [:info, :warn, :error,  :deprecate, :debug, :success]


### PR DESCRIPTION
In an application, I need to be able to parse the log messages being sent.  At the end of my app, I need to go through and categorize Error, Warning, and Success messages depending on where they occur.

For example, if I am importing something and it passes, I want to be able to write:
`
   Origen.log.success('Block A', :import)
`

If it fails, I want to write:
`
   Origen.log.error('Block B', :import)
`

At the end of my app, I want to output the errors depending on the section.
~~~~
Origen.log.msg_hash[:error].each do |section, arr|
   arr.each do |a|
    p "#{section.to_s.upcase}::: #{a}"
  end
end
~~~~