### PR TITLE
Add Other Pins to Pin Group

### DIFF
--- a/lib/origen/pins.rb
+++ b/lib/origen/pins.rb
@@ -176,6 +176,7 @@ module Origen
     autoload :PinClock,      'origen/pins/pin_clock'
     autoload :PowerPin,      'origen/pins/power_pin'
     autoload :GroundPin,     'origen/pins/ground_pin'
+    autoload :OtherPin,      'origen/pins/other_pin'
     autoload :VirtualPin,    'origen/pins/virtual_pin'
     autoload :FunctionProxy, 'origen/pins/function_proxy'
 
@@ -215,6 +216,7 @@ module Origen
       power_pin = options.delete(:power_pin)
       ground_pin = options.delete(:ground_pin)
       virtual_pin = options.delete(:virtual_pin)
+      other_pin = options.delete(:other_pin)
       if options[:size] && options[:size] > 1
         group = PinCollection.new(self, options.merge(placeholder: true))
         group.id = id if id
@@ -231,6 +233,8 @@ module Origen
             group[i] = GroundPin.new(i, self, options)
           elsif virtual_pin
             group[i] = VirtualPin.new(i, self, options)
+          elsif other_pin
+            group[i] = OtherPin.new(i, self, options)
           else
             group[i] = Pin.new(i, self, options)
           end
@@ -253,6 +257,8 @@ module Origen
           pin = GroundPin.new(id || :temp, self, options)
         elsif virtual_pin
           pin = VirtualPin.new(id || :temp, self, options)
+        elsif other_pin
+          pin = OtherPin.new(id || :temp, self, options)
         else
           pin = Pin.new(id || :temp, self, options)
         end
@@ -280,6 +286,15 @@ module Origen
       add_pin(id, options, &block)
     end
     alias_method :add_ground_pins, :add_ground_pin
+
+    def add_other_pin(id = nil, options = {}, &block)
+      id, options = nil, id if id.is_a?(Hash)
+      options = {
+        other_pin: true
+      }.merge(options)
+      add_pin(id, options, &block)
+    end
+    alias_method :add_other_pins, :add_other_pin
 
     def add_virtual_pin(id = nil, options = {}, &block)
       id, options = nil, id if id.is_a?(Hash)
@@ -399,6 +414,11 @@ module Origen
     end
     alias_method :has_ground_pins?, :has_ground_pin?
 
+    def has_other_pin?(id)
+      !!Origen.pin_bank.find(id, other_pin: true)
+    end
+    alias_method :has_other_pins?, :has_other_pin?
+
     # Equivalent to the has_pin? method but considers virtual pins rather than regular pins
     def has_virtual_pin?(id)
       !!Origen.pin_bank.find(id, virtual_pin: true)
@@ -478,6 +498,18 @@ module Origen
       add_pin_group(id, *pins, options, &block)
     end
 
+    def add_other_pin_group(id, *pins, &block)
+      if pins.last.is_a?(Hash)
+        options = pins.pop
+      else
+        options = {}
+      end
+      options = {
+        other_pin: true
+      }.merge(options)
+      add_pin_group(id, *pins, options, &block)
+    end
+
     def add_virtual_pin_group(id, *pins, &block)
       if pins.last.is_a?(Hash)
         options = pins.pop
@@ -518,6 +550,15 @@ module Origen
         pin = Origen.pin_bank.find(id, ignore_context: true, ground_pin: true)
       else
         Origen.pin_bank.all_ground_pins
+      end
+    end
+
+    # Equivalent to the all_pins method but considers other pins rather than regular pins
+    def all_other_pins(id = nil, _options = {}, &_block)
+      if id
+        pin = Origen.pin_bank.find(id, ignore_context: true, other_pin: true)
+      else
+        Origen.pin_bank.all_other_pins
       end
     end
 
@@ -595,6 +636,28 @@ If you meant to define the ground_pin_group then use the add_ground_pin_group me
     end
     alias_method :ground_pin_group, :ground_pin_groups
 
+    # Equivalent to the pin_groups method but considers other pins rather than regular pins
+    def other_pin_groups(id = nil, options = {}, &_block)
+      id, options = nil, id if id.is_a?(Hash)
+      if id
+        pin = Origen.pin_bank.find(id, options.merge(other_pin: true))
+        unless pin
+          puts <<-END
+    You have tried to reference other_pin_group :#{id} within #{self.class} but it does not exist, this could be
+    because the pin group has not been defined yet or it is an alias that is not available in the current context.
+
+    If you meant to define the other_pin_group then use the add_other_pin_group method instead.
+
+          END
+          fail 'Other pin group not found'
+        end
+        pin
+      else
+        Origen.pin_bank.other_pin_groups(options)
+      end
+    end
+    alias_method :other_pin_group, :other_pin_groups
+
     # Equivalent to the pin_groups method but considers virtual pins rather than regular pins
     def virtual_pin_groups(id = nil, options = {}, &_block)
       id, options = nil, id if id.is_a?(Hash)
@@ -645,6 +708,8 @@ If you meant to define the pin then use the add_pin method instead.
           Origen.pin_bank.ground_pins
         elsif options[:virtual_pin]
           Origen.pin_bank.virtual_pins
+        elsif options[:other_pin]
+          Origen.pin_bank.other_pins
         else
           Origen.pin_bank.pins
         end
@@ -666,6 +731,15 @@ If you meant to define the pin then use the add_pin method instead.
       id, options = nil, id if id.is_a?(Hash)
       options = {
         ground_pin: true
+      }.merge(options)
+      pins(id, options, &block)
+    end
+
+    # Equivalent to the pins method but considers other pins rather than regular pins
+    def other_pins(id = nil, options = {}, &block)
+      id, options = nil, id if id.is_a?(Hash)
+      options = {
+        other_pin: true
       }.merge(options)
       pins(id, options, &block)
     end

--- a/lib/origen/pins/other_pin.rb
+++ b/lib/origen/pins/other_pin.rb
@@ -1,0 +1,6 @@
+module Origen
+  module Pins
+    class OtherPin < Pin
+    end
+  end
+end

--- a/lib/origen/pins/pin_bank.rb
+++ b/lib/origen/pins/pin_bank.rb
@@ -25,6 +25,8 @@ module Origen
           bank = all_ground_pins
         elsif pin.is_a?(VirtualPin)
           bank = all_virtual_pins
+        elsif pin.is_a?(OtherPin)
+          bank = all_other_pins
         else
           bank = all_pins
         end
@@ -75,6 +77,12 @@ module Origen
         end
       end
 
+      def other_pins(options = {})
+        all_other_pins.select do |_id, pin|
+          pin.enabled?(options)
+        end
+      end
+
       def virtual_pins(options = {})
         all_virtual_pins.select do |_id, pin|
           pin.enabled?(options)
@@ -98,6 +106,13 @@ module Origen
       # Returns a hash containing all ground_pin_groups available in the current context stored by their primary ID
       def ground_pin_groups(options = {})
         current_pin_group_store(all_ground_pin_groups, options).select do |_id, group|
+          group.enabled?(options)
+        end
+      end
+
+      # Returns a hash containing all ground_pin_groups available in the current context stored by their primary ID
+      def other_pin_groups(options = {})
+        current_pin_group_store(all_other_pin_groups, options).select do |_id, group|
           group.enabled?(options)
         end
       end
@@ -129,6 +144,11 @@ module Origen
         @all_ground_pins ||= {}
       end
 
+      # Returns a hash containing all other pins stored by their primary ID
+      def all_other_pins
+        @all_other_pins ||= {}
+      end
+
       # Returns a hash containing all virtual pins stored by their primary ID
       def all_virtual_pins
         @all_virtual_pins ||= {}
@@ -144,6 +164,11 @@ module Origen
         @all_ground_pin_groups ||= {}
       end
 
+      # Returns a hash containing all other pin groups stored by context
+      def all_other_pin_groups
+        @all_other_pin_groups ||= {}
+      end
+
       # Returns a hash containing all virtual pin groups stored by context
       def all_virtual_pin_groups
         @all_virtual_pin_groups ||= {}
@@ -157,6 +182,8 @@ module Origen
           pin = all_ground_pins[id] || find_pin_group(id, options)
         elsif options[:virtual_pin]
           pin = all_virtual_pins[id] || find_pin_group(id, options)
+        elsif options[:other_pin]
+          pin = all_other_pins[id] || find_pin_group(id, options)
         else
           pin = all_pins[id] || find_by_alias(id, options) || find_pin_group(id, options)
         end
@@ -175,6 +202,8 @@ module Origen
           base = all_power_pin_groups
         elsif options[:ground_pin]
           base = all_ground_pin_groups
+        elsif options[:other_pin]
+          base = all_other_pin_groups
         elsif options[:virtual_pin]
           base = all_virtual_pin_groups
         else
@@ -209,6 +238,8 @@ module Origen
           bank = all_power_pins
         elsif pin.is_a?(GroundPin)
           bank = all_ground_pins
+        elsif pin.is_a?(OtherPin)
+          bank = all_other_pins
         elsif pin.is_a?(VirtualPin)
           bank = all_virtual_pins
         else
@@ -240,6 +271,8 @@ module Origen
           base = all_power_pin_groups
         elsif group.ground_pins?
           base = all_ground_pin_groups
+        elsif group.other_pins?
+          base = all_other_pin_groups
         elsif group.virtual_pins?
           base = all_virtual_pin_groups
         else
@@ -285,6 +318,8 @@ module Origen
           base = all_power_pin_groups
         elsif group.ground_pins?
           base = all_ground_pin_groups
+        elsif group.other_pins?
+          base = all_other_pin_groups
         elsif group.virtual_pins?
           base = all_virtual_pin_groups
         else
@@ -367,10 +402,12 @@ module Origen
         @all_pins = nil
         @all_power_pins = nil
         @all_ground_pins = nil
+        @all_other_pins = nil
         @all_virtual_pins = nil
         @all_pin_groups = nil
         @all_power_pin_groups = nil
         @all_ground_pin_groups = nil
+        @all_other_pin_groups = nil
         @all_virtual_pin_groups = nil
       end
 

--- a/lib/origen/pins/pin_collection.rb
+++ b/lib/origen/pins/pin_collection.rb
@@ -17,6 +17,7 @@ module Origen
         @power_pins = options.delete(:power_pin) || options.delete(:power_pins)
         @ground_pins = options.delete(:ground_pin) || options.delete(:ground_pins)
         @virtual_pins = options.delete(:virtual_pin) || options.delete(:virtual_pins)
+        @other_pins = options.delete(:other_pin) || options.delete(:other_pins)
         @endian = options[:endian]
         @description = options[:description] || options[:desc]
         @options = options
@@ -85,6 +86,11 @@ module Origen
       # Returns true if the pin collection contains virtual pins rather than regular pins
       def virtual_pins?
         @virtual_pins
+      end
+
+      # Returns true if the pin collection contains other pins rather than regular pins
+      def other_pins?
+        @other_pins
       end
 
       def id
@@ -182,6 +188,8 @@ module Origen
             pin = owner.power_pins(pin)
           elsif ground_pins?
             pin = owner.ground_pins(pin)
+          elsif other_pins?
+            pin = owner.other_pins(pin)
           elsif virtual_pins?
             pin = owner.virtual_pins(pin)
           else

--- a/spec/pins_v3_spec.rb
+++ b/spec/pins_v3_spec.rb
@@ -708,7 +708,7 @@ describe "Origen Pin API v3" do
       $dut.ground_pins(:gnd0).should == gnd0
     end
 
-    it "power pin groups can be added" do
+    it "ground pin groups can be added" do
       $dut.add_ground_pin(:gnd1)
       $dut.add_ground_pin(:gnd2)
       $dut.add_ground_pin(:gnd3)
@@ -762,6 +762,40 @@ describe "Origen Pin API v3" do
 
   end
 
+  
+  describe "other pins" do
+  
+    it "other pins can be added" do
+      $dut.add_pin :pinx
+      $dut.add_pin :piny
+      other0 = $dut.add_other_pin(:other0)
+      $dut.add_other_pin(:other1)
+      $dut.add_other_pin(:other2)
+      $dut.pins.size.should == 2
+      $dut.other_pins.size.should == 3
+      $dut.other_pins(:other0).should == other0
+    end
+  
+    it "other pin groups can be added" do
+      $dut.add_other_pin(:other1)
+      $dut.add_other_pin(:other2)
+      $dut.add_other_pin(:other3)
+      $dut.add_other_pin_group :other, :other1, :other2, package: :p1
+      $dut.add_other_pin_group :other, :other1, :other2, :other3, package: :p2
+      $dut.other_pins.size.should == 3
+      $dut.other_pin_groups.size.should == 0
+      $dut.other_pin_groups(package: :p1).size.should == 1
+      $dut.package = :p1
+      $dut.other_pins(:other).size.should == 2
+      $dut.other_pin_groups.size.should == 1
+      $dut.package = :p2
+      $dut.other_pins(:other).size.should == 3
+      $dut.other_pin_groups.size.should == 1
+    end
+  
+  end
+
+  
   it "driving or asserting nil is the same as 0" do
     pin = $dut.add_pin :pinx
     pin.drive(1)

--- a/spec/pins_v3_spec.rb
+++ b/spec/pins_v3_spec.rb
@@ -791,6 +791,8 @@ describe "Origen Pin API v3" do
       $dut.package = :p2
       $dut.other_pins(:other).size.should == 3
       $dut.other_pin_groups.size.should == 1
+      $dut.has_other_pin?(:other1).should == true
+      $dut.has_other_pin?(:other5).should == false
     end
   
   end

--- a/spec/pins_v3_spec.rb
+++ b/spec/pins_v3_spec.rb
@@ -791,7 +791,7 @@ describe "Origen Pin API v3" do
       $dut.package = :p2
       $dut.other_pins(:other).size.should == 3
       $dut.other_pin_groups.size.should == 1
-      $dut.has_other_pin?(:other1).should == true
+      $dut.has_other_pin?(:other).should == true
       $dut.has_other_pin?(:other5).should == false
     end
   


### PR DESCRIPTION
In prepping for a new project, I needed the ability to handle Other Pins.  Other pins include the following types:

*  No-Connects
*  Reserved
*  DePopulated Pins

Used Virtual Pin as a base for the Other Pins and copied its spec tests to ensure that the code works as expected.