### PR TITLE
Added indication sync is being run to allow register action logging.

### DIFF
--- a/lib/origen/registers/bit_collection.rb
+++ b/lib/origen/registers/bit_collection.rb
@@ -101,7 +101,7 @@ module Origen
         if tester.try(:link?)
           preserve_flags do
             v = tester.capture do
-              store!
+              store!(sync: true)
             end
             reverse_each.with_index do |bit, i|
               bit.instance_variable_set('@updated_post_reset', true)
@@ -502,15 +502,15 @@ module Origen
       end
 
       # Marks all bits to be stored
-      def store
+      def store(options = {})
         each(&:store)
         self
       end
 
       # Marks all bits to be stored and then calls read!
-      def store!
-        store
-        read!
+      def store!(options = {})
+        store(options)
+        read!(options)
         self
       end
 


### PR DESCRIPTION
Example 'read_register' code making use of new :sync flag to log OrigenLink pattern execution in a readable format:

```
    def read_register(reg, options = {})
      arm_debug.ahbap.read_register(reg, options)          
      if options[:sync] != true and reg.respond_to?('data') and tester.link?
        link_log(reg, :read)
      end
    end

    def link_log(reg, operation, options = {})  
      if operation == :read
        expected = reg.data
        reg.sync!
        printf "Read reg:  %-20s Address: 0x%s %30s\n", reg.name.to_s, reg.address.to_s(16).rjust(8, '0'), "Read Data:  0x" + reg.data.to_s(16).rjust(8, '0')
        if expected != reg.data
          printf "%s %29s\n\n", "----------------------  FAIL  ----------------------".red, "Expected:   0x" + expected.to_s(16).rjust(8, '0')
        end
      else
        printf "Write reg: %-20s Address: 0x%s %30s\n", reg.name.to_s, reg.address.to_s(16).rjust(8, '0'), "Write Data: 0x" + reg.data.to_s(16).rjust(8, '0')
      end
    end
```