### PR TITLE
Issue seen in add_pin_group when pins is empty.

### DIFF
--- a/lib/origen/pins.rb
+++ b/lib/origen/pins.rb
@@ -471,6 +471,7 @@ module Origen
           end
         end
       end
+      group = Origen.pin_bank.find_or_create_pin_group(id, self, options) if group.nil?
       group
       # Origen.pin_bank.add_pin_group(group, self, {:pins_exist => true}.merge(options))
     end


### PR DESCRIPTION
When running tests, there was an issue when pins is empty.  When pins is empty, group will always be nil.  With fix, it will check to see if group is nil, if nil, then check to find the expected group.