### PR TITLE
Add mention and link about pin clock setup in the Pattern Generation Section

### DIFF
--- a/templates/web/guides/pattern/common.md.erb
+++ b/templates/web/guides/pattern/common.md.erb
@@ -265,4 +265,11 @@ $tester.microcode 'set_cpu (cpuC)'
 $tester.microcode 'set_cpu (cpuB)', offset: -2
 ~~~
 
+##### Free-Running Clock on Existing Pin
+
+Set up a pin to be a free-running clock with the vector generation (with respect to toggling
+the pin at the appropriate intervals) automatically taken care of.
+
+See [Pin Clock Functionality](/guides/models/pins/#Pin_Clock_Functionality) for details on the API.
+
 % end


### PR DESCRIPTION
Not sure how, but this commit didn't get included in PR #75.  Simple documentation update.