### PR TITLE
Remotes Manager Fix For Windows

### DIFF
--- a/lib/origen/remote_manager.rb
+++ b/lib/origen/remote_manager.rb
@@ -319,12 +319,16 @@ module Origen
             FileUtils.rm_f(version_file) if File.exist?(version_file)
             rc = RevisionControl.new remote: rc_url, local: dir
             rc.checkout version: prefix_tag(tag), force: true
-            `echo "#{tag}" >> "#{version_file}"`
+            File.open(version_file, 'w') do |f|
+              f.write tag
+            end
           else
             rc = RevisionControl.new remote: rc_url, local: dir
             rc.checkout version: prefix_tag(tag), force: true
-            `touch "#{dir}/.initial_populate_successful"`
-            `echo "#{tag}" >> "#{version_file}"`
+            FileUtils.touch "#{dir}/.initial_populate_successful"
+            File.open(version_file, 'w') do |f|
+              f.write tag
+            end
           end
         end
       end


### PR DESCRIPTION
Fixed issue with the remotes manager on Windows that was causing
Origen to infinitely populate the remotes, never allowing Origen to actually
startup.

The issue's source was using Unix commands, whose results were slightly different
between Linux and Windows, causing the .current_version data to be slightly different
than expected. The use of quotation varied slightly as in the example below:

![image](https://cloud.githubusercontent.com/assets/13453967/25096736/29479be4-2367-11e7-9d91-fecaf5b55b4f.png)

![image](https://cloud.githubusercontent.com/assets/13453967/25096747/31f913da-2367-11e7-8fc6-e9e718be90a7.png)

The extra quotations on Wiindows are throwing off the remote manager. The manager would keep trying to compare, for example, 0.1.1 with "0.1.1" and never getting the "correct" version, causing it to spin infinitely as it repeatedly populates the remotes.

The solution was to just use a straight Ruby approach to write the .current_version file instead of Unix commands. Ruby's results are stable across operating systems, allowing the remotes manager to function correctly. Although removing the quotations in the command may also have worked, I used to a straight Ruby approach to bypass other potential issues altogether. For consistency, I used FileUilts.touch instead of `touch' as well, even though this was working correctly.

This issue was observed using UnxUtils and ConsoleZ, both recommended in Origen's Window's install guide. So, these aren't just some off-the-wall tools behaving oddly, this is actually Origen's Windows-recommended tool set.