### PR TITLE
Fixed a bug where the file handler was erroring when it found the sam…

### DIFF
--- a/lib/origen/file_handler.rb
+++ b/lib/origen/file_handler.rb
@@ -171,8 +171,8 @@ module Origen
                     Dir.glob("#{options[:default_dir]}/#{file}")).sort
         if matches.size == 0
           matches = Dir.glob("#{options[:default_dir]}/**{,/*/**}/#{file}").sort # Takes symlinks into consideration
-          matches = matches.flatten.uniq
         end
+        matches = matches.flatten.uniq
       end
 
       if matches.size == 0


### PR DESCRIPTION
…e file twice with Dir.glob.  Was due to the matches.flatten.uniq call being inside a conditional.  Bug only occurred if user does not specify the program dir when running origen -p

I looked to add in a spec test but wasn't sure where to put it.