### PR TITLE
App generators

### DIFF
--- a/bin/origen
+++ b/bin/origen
@@ -61,7 +61,7 @@ if origen_root
 elsif Origen.site_config.gem_manage_bundler && (Origen.site_config.user_install_enable || Origen.site_config.tool_repo_install_dir)
   # Force everyone to have a consistent way of installing gems with bundler.
   # In this case, we aren't running from an Origen application, so build everything at Origen.home instead
-  # Have two options here: if user_install_enable is tru, use user_install_dir. Otherwise, use the tool_repo_install_dir
+  # Have two options here: if user_install_enable is true, use user_install_dir. Otherwise, use the tool_repo_install_dir
   Origen.site_config.user_install_enable ? origen_root = File.expand_path(Origen.site_config.user_install_dir) : origen_root = File.expand_path(Origen.site_config.tool_repo_install_dir)
   unless Dir.exists?(origen_root)
     load File.expand_path('../../lib/origen/utility/input_capture.rb', __FILE__)
@@ -174,7 +174,11 @@ begin
     require 'origen/commands_global'
   end
 rescue Exception => e
-  unless e.is_a?(SystemExit) && e.status == 0
+  # A formatted stack dump will not be printed if the application ends via 'exit 0' or 'exit 1'. In that
+  # case the application code is responsible for printing a helpful error message.
+  # This will intercept all other exits, e.g. via 'fail "Something has done wrong"', and split the stack
+  # dump to separate all in-application references from Origen core/plugin references.
+  unless e.is_a?(SystemExit)
     puts
     if Origen.app_loaded?
       puts 'COMPLETE CALL STACK'

--- a/lib/origen/commands/new.rb
+++ b/lib/origen/commands/new.rb
@@ -3,6 +3,7 @@ require 'fileutils'
 require 'httparty'
 require 'digest'
 require 'gems'
+require 'time'
 
 include Origen::Utility::InputCapture
 
@@ -25,7 +26,7 @@ http://origen-sdk.org/origen_app_generators
 Usage: origen new [APP_NAME] [options]
 END
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
-  opts.on('-v', '--version TAG', String, 'Use a specific version of Origen App Generators') { |f| options[:version] = f }
+  opts.on('-f', '--fetch', 'Fetch the latest versions of the app generators, otherwise happens every 24hrs') { options[:fetch] = true }
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end
@@ -45,69 +46,85 @@ unless Dir["#{dir}/*"].empty?
   exit 1
 end
 
-version = options[:version] || begin
-  (Gems.info 'origen_app_generators')['version']
-end
+generators_dir = "#{Origen.home}/app_generators"
+update_required = false
 
-version ||= '0.0.0'
-
-version.sub!(/^v/, '')
-
-if Origen.running_on_windows?
-  tmp = 'C:/tmp/origen_app_generators'
+# Update the generators every 24hrs unless specifically requested
+if options[:fetch] || !File.exist?(generators_dir)
+  update_required = true
 else
-  tmp = '/tmp/origen_app_generators'
-end
-
-tmp_dir = "#{tmp}/app_gen#{version}"
-lib = "#{tmp_dir}/lib"
-md5 = "#{tmp}/md5#{version}"
-
-# If the app generators already exists in /tmp, check that all files are still there.
-# This deals with the problem of some files being swept up by the tmp cleaner while
-# leaving the top-level folder there.
-if File.exist?(tmp_dir) && File.exist?(md5)
-  old_sig = File.read(md5)
-  hash = Digest::MD5.new
-  Dir["#{tmp_dir}/**/{*,.*}"].each do |f|
-    hash << File.read(f) unless File.directory?(f)
-  end
-  new_sig = hash.hexdigest
-  all_present = old_sig == new_sig
-else
-  all_present = false
-end
-
-unless all_present
-
-  FileUtils.rm_rf(tmp_dir) if File.exist?(tmp_dir)
-  FileUtils.mkdir_p(tmp) unless File.exist?(tmp)
-
-  File.open("#{tmp}/app_gen#{version}.gem", 'wb') do |f|
-    response = HTTParty.get("http://rubygems.org/downloads/origen_app_generators-#{version}.gem")
-    if response.success?
-      f.write response.parsed_response
-    else
-      puts "Sorry, could not find app generators version #{version}"
-      exit 1
+  if Origen.session.app_generators[generators_dir]
+    if Time.now - Origen.session.app_generators[generators_dir] > 60 * 60 * 24
+      update_required = true
     end
+  else
+    update_required = true
   end
-
-  Dir.chdir tmp do
-    `gem unpack app_gen#{version}.gem`
-    `rm -f app_gen#{version}.gem`
-  end
-
-  hash = Digest::MD5.new
-  Dir["#{tmp_dir}/**/{*,.*}"].each do |f|
-    hash << File.read(f) unless File.directory?(f)
-  end
-  File.open(md5, 'w') { |f| f.write(hash.hexdigest) }
 end
 
-$LOAD_PATH.unshift(lib)
+generators = [['http://rubygems.org', 'origen_app_generators']] + Array(Origen.site_config.app_generators)
+
+if update_required
+  puts 'Fetching the latest app generators...'
+  FileUtils.rm_rf(generators_dir) if File.exist?(generators_dir)
+  FileUtils.mkdir(generators_dir)
+
+  Dir.chdir generators_dir do
+    generators.each_with_index do |gen, i|
+      # If a reference to a gem from a gem server
+      if gen.is_a?(Array)
+        response = HTTParty.get("#{gen[0]}/api/v1/dependencies.json?gems=#{gen[1]}")
+
+        if response.success?
+          latest_version = JSON.parse(response.body).map { |v| v['number'] }.max
+
+          response = HTTParty.get("#{gen[0]}/gems/#{gen[1]}-#{latest_version}.gem")
+          if response.success?
+            File.open("#{gen[1]}-#{latest_version}.gem", 'wb') do |f|
+              f.write response.parsed_response
+            end
+          else
+            puts "Sorry, could not find generator #{gen[1]} version #{latest_version}"
+          end
+
+          `gem unpack #{gen[1]}-#{latest_version}.gem`
+          FileUtils.rm_rf("#{gen[1]}-#{latest_version}.gem")
+          FileUtils.mv("#{gen[1]}-#{latest_version}", i.to_s)
+
+        else
+          puts "Failed to get generator #{gen[1]}, the response from the server was:"
+          puts response.body
+        end
+
+      # If a reference to a git repo
+      elsif gen.to_s =~ /\.git$/
+        Origen::RevisionControl.new(remote: gen, local: i.to_s).checkout(version: 'master', force: true)
+
+      # Assume a reference to a folder
+      else
+        if File.exist?(gen)
+          FileUtils.cp_r(gen, i.to_s)
+        else
+          puts "Failed to find generator at #{gen}"
+        end
+
+      end
+    end
+
+    Origen.session.app_generators[generators_dir] = Time.now
+  end
+end
+
+generators.each_with_index do |gen, i|
+  lib = "#{generators_dir}/#{i}/lib"
+  $LOAD_PATH.unshift(lib)
+end
 
 Origen.with_boot_environment do
   require 'origen_app_generators'
+  generators.each_with_index do |gen, i|
+    loader = "#{generators_dir}/#{i}/config/load_generators.rb"
+    require loader if File.exist?(loader)
+  end
   OrigenAppGenerators.invoke(dir)
 end

--- a/origen_site_config.yml
+++ b/origen_site_config.yml
@@ -1,3 +1,17 @@
+# GENERAL SETUP
+
+# Application generator plugins can be used to extend the available new application templates
+# that are offered via the 'origen new' command.
+# This allows you to offer application shells that are unique to your company or to specific
+# domains within your company.
+#app_generators:
+#  # Example of how to reference a plugin from an internal gem server (recommended)
+#  - ["http://gems.mycompany.net:9292", my_app_generators]
+#  # Alternatively a file system path to a central copy of a plugin can be used
+#  - "/path/to/some/central/location/my_app_generators"
+#  # Or a reference to a plugin's Git repository can be used
+#  - "http://bitbucket.mycompany.net/origen/my_app_generators.git"
+
 # GEM SETUP
 
 # If your company has an internal gem server enter it here


### PR DESCRIPTION
This PR adds a new site config parameter to allow a company to add their own application starter templates.

The Origen app generators plugin will in due course be enhanced to provide an option of creating a new plugin that should be used to contain company-specific app templates/generators.

This update provides the Origen core hooks necessary for the 'origen new' command to be able to pick up such generators, either from an internal gem server, a file location, or from a Git repo.

A user's local copy of the generators will be refreshed every 24 hours or anytime they supply a --fetch option to 'origen new'. This ensures that they will always be pointing to the latest and greatest templates.

The ability to specify a previous version of the generators has been removed. It may be re-introduced in future if there is demand for it, but how to specify a particular version gets more complicated now that multiple generator sources are supported.

Documentation on company specific generators will be provided along with the main update to the Origen app generators plugin.

This PR also includes a small update to stop Origen showing the stack dump if the process ends via exit. This will generally make the command line output cleaner and means that we have the following rule for developers:

~~~ruby
# When exiting like this, no debug information will be provided to the user unless you also provide
# it via puts statements
exit 1 

# This type though will continue to show the stack dump in addition to anything else you provide
# via puts
fail "Something is wrong!"
~~~



