### PR TITLE
Add regex as possible input to regs() method

### DIFF
--- a/lib/c99/nvm.rb
+++ b/lib/c99/nvm.rb
@@ -101,6 +101,10 @@ module C99
         bits 13..8, :upper, description: 'This is dreg3 bit upper'
         bit 7..0,  :lower, writable: false, reset: 0x55, description: "This is dreg3 bit lower\nThis is dreg3 bit lower line 2"
       end
+
+      reg :dreg4, 0x1000, size: 8, description: "** Data Register 4 **\nThis is dreg4" do
+        bit 7..0, :busy, reset: 0x55, description: "**Busy Bits** - These do something super cool\n\n0 | Job0\n1 | Job1\n10 | Job2\n11 | Job3\n100 | Job4\n101 | Job5\n110 | Job6\n111 | Job7\n1000 | Job8\n1001 | Job9\n1010 | Job10\n1011 | Job11\n1100 | Job12\n1101 | Job13\n1110 | Job14\n1111 | Job15\n10000 | Job16\n10001 | Job17\n10010 | Job18"
+      end
     end
   end
 end

--- a/lib/origen/registers/bit_collection.rb
+++ b/lib/origen/registers/bit_collection.rb
@@ -225,10 +225,11 @@ module Origen
       end
 
       def bit_value_descriptions(_bitname = nil)
+        options = _bitname.is_a?(Hash) ? _bitname : {}
         if name == :unknown
           []
         else
-          @reg.bit_value_descriptions(name)
+          @reg.bit_value_descriptions(name, options)
         end
       end
 

--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -21,7 +21,11 @@ module RegTest
       Container.new(endian: :little).big_endian?.should == false
     end
 
-    it "updates it's address based on the address of the contained register(s)" do
+    it "contains bits" do
+      Container.new.contains_bits?.should == true
+    end
+
+     it "updates it's address based on the address of the contained register(s)" do
       c = Container.new
       r1 = Reg.new(self, 0, 8, :r1, {})
       r2 = Reg.new(self, 1, 8, :r2, {})
@@ -62,7 +66,11 @@ module RegTest
       owner = Container.new
       r1 = Reg.new(owner, 0, 16, :r1, {})
       c.owner.should == nil
+      c.owned_by?('owner').should == false
       c.add(r1).owner.should == owner
+      c.owned_by?('owner').should == false
+      c.owned_by = 'cont_owner'
+      c.owned_by?('cont_owner').should == true
     end
 
     it "keeps the registers in address order" do
@@ -158,6 +166,12 @@ module RegTest
       r1.write(0x7E00)
       big.add(r1, address: 4)
       big.data.should == 0x0000_7E00
+      big.big_endian?.should == true
+      big.little_endian?.should == false
+      r1.read
+      r1.is_to_be_read?.should == true
+      big.clear_flags
+      r1.is_to_be_read?.should == false
     end
 
     it "works with another real life data example" do
@@ -166,6 +180,8 @@ module RegTest
       r1.write(0x80)
       little.add(r1, address: 3)
       little.data.should == 0x0000_0080
+      little.little_endian?.should == true
+      little.big_endian?.should == false
     end
 
     it "can be shifted left" do

--- a/spec/features_spec.rb
+++ b/spec/features_spec.rb
@@ -63,6 +63,9 @@ describe "Feature API" do
         bits 15..0, :dataLow
         bits 31..16, :dataHigh, feature: :f3
       end
+      reg :r7, 60, feature: [:f3, :f4] do
+        bits 31..0, :data
+      end
     end
   end
   
@@ -71,10 +74,12 @@ describe "Feature API" do
     dut.has_features?.should == true
     dut.has_feature?(:f1).should == true
     dut.regs.size.should == 5
-    dut.regs(enabled_features: :all).size.should == 6
+    dut.regs(enabled_features: :all).size.should == 7
     dut.regs(enabled_features: :default).size.should == 5
     dut.regs(enabled_features: :f1).size.should == 4
-    dut.regs(enabled_features: [:f1, :f2, :f3]).size.should == 6
+    dut.regs(enabled_features: [:f1, :f2, :f3]).size.should == 7
+    dut.regs(enabled_features: :f3).size.should == 5
+    dut.regs(enabled_features: :f4).size.should == 4
     dut.regs(enabled_features: :none).size.should == 3
   end
   
@@ -120,6 +125,12 @@ describe "Feature API" do
     dut.reg(:r5, enabled_features: :none).should == nil # this should give an error
     dut.reg(:r3).should == nil
     dut.reg(:r5).enabled_by_feature?(:f2).should == true
+    dut.reg(:r7, enabled_feature: :f3).has_feature_constraint?.should == true
+    dut.reg(:r7, enabled_feature: :f3).enabled_by_feature?(:f3).should == true
+    dut.reg(:r7, enabled_feature: :f3).enabled_by_feature?(:f4).should == true
+    dut.reg(:r7, enabled_feature: [:f3, :f4]).enabled_by_feature?(:f3).should == true
+    dut.reg(:r7, enabled_feature: [:f3, :f4]).enabled_by_feature?(:f4).should == true
+    dut.reg(:r7).should == nil
     dut.reg(:r5).enabled?.should == true
 
     dut.reg(:r3, enabled_features: :all).enabled?.should == false

--- a/spec/parameters_spec.rb
+++ b/spec/parameters_spec.rb
@@ -197,6 +197,8 @@ module ParametersSpec
       $dut.params = :probe
       $dut.erase.time.data.should == 3
       $dut.erase.pulses.data.should == 4
+
+      lambda { $dut.erase.pulses.bind $dut.params.erase.pulses }.should raise_error
     end
 
     it "inherited value works" do

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -2,9 +2,36 @@ require 'spec_helper'
 
 describe "Origen.site_config" do
 
+  # Make sure that cached site config values don't affect these or the
+  # next tests
+  before :each do
+    clear_site_config
+  end
+
+  after :all do
+    clear_site_config
+  end
+
+  def clear_site_config
+    Origen.instance_variable_set("@site_config", nil)
+  end
+
+  def with_env_variable(var, value)
+    orig = ENV[var]
+    ENV[var] = value
+    yield
+    ENV[var] = orig
+  end
+
   it "converts true/false values from environment variables to booleans" do
-    ENV["ORIGEN_GEM_MANAGE_BUNDLER"] = "false"
-    ENV["ORIGEN_GEM_MANAGE_BUNDLER"].should == "false"
-    Origen.site_config.gem_manage_bundler.should == false
+    with_env_variable("ORIGEN_GEM_MANAGE_BUNDLER", "false") do
+      ENV["ORIGEN_GEM_MANAGE_BUNDLER"].should == "false"
+      Origen.site_config.gem_manage_bundler.should == false
+    end
+    with_env_variable("ORIGEN_GEM_MANAGE_BUNDLER", "true") do
+      ENV["ORIGEN_GEM_MANAGE_BUNDLER"].should == "true"
+      clear_site_config
+      Origen.site_config.gem_manage_bundler.should == true
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,7 +68,7 @@ RSpec.configure do |config|
     # Enable only the newer, non-monkey-patching expect syntax.
     # For more details, see:
     #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
-    expectations.syntax = :should
+    expectations.syntax = [:should, :expect]
   end
 
   ## rspec-mocks config goes here. You can use an alternate test double

--- a/templates/web/guides/models/registers.md.erb
+++ b/templates/web/guides/models/registers.md.erb
@@ -491,5 +491,48 @@ reg.is_to_be_read?        # => false
 reg.data.to_hex           # => "0x1F"
 ~~~
 
+#### More Examples
+
+Here are some addtional examples showing how to iterate through a model's registers
+
+~~~ruby
+class Top
+  include Origen::TopLevel
+
+  def initialize
+    reg :adc0_cfg, 0x200 do
+      bits 31..0, :data
+    end
+    reg :adc1_cfg, 0x300 do
+      bits 31..0, :data
+    end
+    reg :dac_cfg, 0x400 do
+      bits 31..0, :data
+    end
+    reg :status, 0x100 do
+      bits 31..0, :data
+    end
+  end
+end
+
+$dut = Top.new
+
+# Iterate over ALL registers (:adc0_cfg, :adc1_cfg, :dac_cfg, :status)
+$dut.regs do |r|
+  # do something with register r
+end
+
+# Iterate over all registers matching a regular expression
+# Ex 1: Only ADC cfg registers (:adc0_cfg, :adc1_cfg)
+$dut.regs('/acd\d_cfg/') do |r|
+  # do someting with register r
+end
+
+# Ex 2: Any cfg registers (:adc0_cfg, :adc1_cfg, :dac_cfg)
+$dut.regs('/cfg/') do |r|
+  # do someting with register r
+end
+~~~
+
 
 % end


### PR DESCRIPTION
Convenience of being able to grab all registers of a model that match a given regular expression.

Example: set configuration register for all ADCs (i.e. adc0_cfg, adc1_cfg, etc.) 
dut.regs('/adc\d_cfg/').each do |k,v|
  v.write!(0x000A_5000)
end