### PR TITLE
Few fixes

### DIFF
--- a/bin/origen
+++ b/bin/origen
@@ -178,7 +178,9 @@ rescue Exception => e
   # case the application code is responsible for printing a helpful error message.
   # This will intercept all other exits, e.g. via 'fail "Something has done wrong"', and split the stack
   # dump to separate all in-application references from Origen core/plugin references.
-  unless e.is_a?(SystemExit)
+  if e.is_a?(SystemExit)
+    exit e.status
+  else
     puts
     if Origen.app_loaded?
       puts 'COMPLETE CALL STACK'

--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -4,6 +4,10 @@ unless defined? RGen::ORIGENTRANSITION
   require 'English'
   require 'pathname'
   require 'pry'
+  # require these here to make required files consistent between global commands invoke globally and global commands
+  # invoked from an application workspace
+  require 'colored'
+  require 'fileutils'
   # Keep a note of the pwd at the time when Origen was first loaded, this is initially used
   # by the site_config lookup.
   $_origen_invocation_pwd ||= Pathname.pwd
@@ -587,12 +591,13 @@ unless defined? RGen::ORIGENTRANSITION
       # Use User.current to retrieve the current user, this is an internal API that will
       # be cleaned up (removed) in future
       # @api private
-      def current_user
+      def current_user(options = {})
+        @current_user = nil if options[:refresh]
         if app_loaded? || in_app_workspace?
           return @switch_user unless @switch_user.nil?
-          application.current_user
+          @current_user ||= application.current_user
         else
-          User.new(User.current_user_id)
+          @current_user ||= User.new(User.current_user_id)
         end
       end
 

--- a/lib/origen/commands/web.rb
+++ b/lib/origen/commands/web.rb
@@ -135,13 +135,14 @@ The following options are available:
     when 'new'
       _build_web_dir
     when 'compile'
-      Origen.app.load_target!
       if options[:remote]
+        Origen.app.load_target!
         _require_web_directory
         _deployer.prepare!(options)
         # If the whole site has been requested that start from a clean slate
         _build_web_dir if ARGV.empty?
       else
+        Origen.app.load_target!(force_debug: true)
         Origen.set_development_mode
       end
       options[:files] = ARGV.dup

--- a/lib/origen/remote_manager.rb
+++ b/lib/origen/remote_manager.rb
@@ -216,9 +216,7 @@ module Origen
       @remotes = {}
       top_level_remotes
       top_level_remotes.each do |remote|
-        traverse_remotes(remote) do |remote|
-          add_remote(remote)
-        end
+        add_remote(remote)
       end
       # Add remotes from imports
       Origen.app.plugins.each do |plugin|
@@ -233,29 +231,8 @@ module Origen
       Origen.app.config.remotes    #+ Origen.app.config.remotes_dev (there are no core remotes at this time)
     end
 
-    # Walks down an import tree recursively yielding all nested imports, if
-    # the imported application has not been populated yet then it will
-    # not return any nested imports.
-    #
-    # This will also update the required origen version if a app
-    # instance is encountered that requires a newer version than the current
-    # version.
-    def traverse_remotes(remote, &block)
-      yield remote
-      if remote_present?(remote)
-        app = Origen.application_instance(origen_root_for(remote), reload: true)
-        app.config.remotes.each do |remote|
-          traverse_remotes(remote, &block)
-        end
-      end
-    end
-
     def remotes
       @remotes ||= resolve_remotes
-    end
-
-    def remote_present?(remote)
-      !!origen_root_for(remote, accept_missing: true)
     end
 
     # Conflicts are resolved by the following rules:

--- a/lib/origen/revision_control/design_sync.rb
+++ b/lib/origen/revision_control/design_sync.rb
@@ -316,6 +316,7 @@ module Origen
               # Screen out common redundant output
               unless line =~ /^Logging/ || line == '' ||
                      line =~ /V(\d+\.\d+-\d+|\d.\d+)/ || # Screen out something like "V5.1-1205" or "V6R2010"
+                     line =~ /^3DEXPERIENCER\d+x$/ || # Screen out something like '3DEXPERIENCER2016x'
                      line.strip.empty?
                 output << line.strip
               end

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -2,9 +2,27 @@ require 'spec_helper'
 
 describe "Origen.site_config" do
 
+  # Make sure that cached site config values don't affect these or the
+  # next tests
+  before :each do
+    Origen.instance_variable_set("@site_config", nil)
+  end
+
+  after :all do
+    Origen.instance_variable_set("@site_config", nil)
+  end
+
+  def with_env_variable(var, value)
+    orig = ENV[var]
+    ENV[var] = value
+    yield
+    ENV[var] = orig
+  end
+
   it "converts true/false values from environment variables to booleans" do
-    ENV["ORIGEN_GEM_MANAGE_BUNDLER"] = "false"
-    ENV["ORIGEN_GEM_MANAGE_BUNDLER"].should == "false"
-    Origen.site_config.gem_manage_bundler.should == false
+    with_env_variable("ORIGEN_GEM_MANAGE_BUNDLER", "false") do
+      ENV["ORIGEN_GEM_MANAGE_BUNDLER"].should == "false"
+      Origen.site_config.gem_manage_bundler.should == false
+    end
   end
 end

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -5,10 +5,14 @@ describe "Origen.site_config" do
   # Make sure that cached site config values don't affect these or the
   # next tests
   before :each do
-    Origen.instance_variable_set("@site_config", nil)
+    clear_site_config
   end
 
   after :all do
+    clear_site_config
+  end
+
+  def clear_site_config
     Origen.instance_variable_set("@site_config", nil)
   end
 
@@ -23,6 +27,11 @@ describe "Origen.site_config" do
     with_env_variable("ORIGEN_GEM_MANAGE_BUNDLER", "false") do
       ENV["ORIGEN_GEM_MANAGE_BUNDLER"].should == "false"
       Origen.site_config.gem_manage_bundler.should == false
+    end
+    with_env_variable("ORIGEN_GEM_MANAGE_BUNDLER", "true") do
+      ENV["ORIGEN_GEM_MANAGE_BUNDLER"].should == "true"
+      clear_site_config
+      Origen.site_config.gem_manage_bundler.should == true
     end
   end
 end


### PR DESCRIPTION
PR just fixing some things that I've noticed:

1. Origen.current_user will create a new instance every time, meaning that our instance variables are lost. For example:

~~~
u = Origen.current_user
u.instance_variable_set(:@test, 'test')

u.instance_variable_get(@:test) #=> 'test'
Origen.current_user.instance_variable_get(@:test) #=> nil
~~~

I think that it’s a bit confusing the Origen.current_user creates a new user every time. I changed it to store the user in @current_user instance variable on Origen and return that if it exists. I added a 'refresh' option that can passed in to force current_user to be reevaluated if an Origen program SSH's as another user or something to that effect.

2. origen web compile, even though starting a development server, requires setting the mode to debug first.

I think this is just a bug since there's a line that says Origen.set_development_mode if remote is not selected, but this is called after the target is already checked, resulting in the load_target! method failing with modified files in the workspace. Instead, I added loading the target with :force_debug set to true if remote is not used. If remote is specified though, the target will still be checked for production worthiness.

It's simple enough to just use 'origen mode debug' to set the mode to debug but this was also a simple fix and I think is the actually desired behavior.

3.  require colored at origen top level.

This is an inconsistency from global vs. application commands. When running in an application, application/release.rb is autoloaded and thus colored is brought in. So, if running a global command from an application (as in during development of the global command), you don't need to have require colored in the app. But, when running globally, you'll get a ruby stack trace since colored isn't loaded. Also, if another gem that requires colored is loaded first, you won't see this error even when running globally, adding to the confusion.

This just adds colored at the Origen module to make global commands more consistent. 'fileutils' is also a culprit, so added that as well.

4. Updated design sync interface to handle newer-styled headers.

DesignSync 2016 header is of the form: '3DEXPERIENCER2016x', which isn't currently screened out. Added a case to handle this.