### PR TITLE
Private remotes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,7 @@ class OrigenCoreApplication < Origen::Application
       dir: "origen_app_generators",
       rc_url: "https://github.com/Origen-SDK/origen_app_generators.git",
       version: "1006fe8",
+      development: true
     }
   ]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,10 +27,11 @@ class OrigenCoreApplication < Origen::Application
   }
 
   config.remotes = [
+    # To include the OrigenAppGenerators documentation in the main guides
     {
       dir: "origen_app_generators",
       rc_url: "https://github.com/Origen-SDK/origen_app_generators.git",
-      version: "1006fe8",
+      version: "v1.1.0",
       development: true
     }
   ]

--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -75,7 +75,7 @@ unless defined? RGen::ORIGENTRANSITION
 
     class GitError < OrigenError; status_code(11); end
     class DesignSyncError < OrigenError; status_code(12); end
-    class RevisionControlUninitialized < OrigenError; status_code(13); end
+    class RevisionControlUninitializedError < OrigenError; status_code(13); end
 
     class << self
       include Origen::Utility::TimeAndDate

--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -75,6 +75,7 @@ unless defined? RGen::ORIGENTRANSITION
 
     class GitError < OrigenError; status_code(11); end
     class DesignSyncError < OrigenError; status_code(12); end
+    class RevisionControlUninitialized < OrigenError; status_code(13); end
 
     class << self
       include Origen::Utility::TimeAndDate

--- a/lib/origen/application.rb
+++ b/lib/origen/application.rb
@@ -136,7 +136,7 @@ module Origen
 
             end
           # The rc_url has been defined, but the initial app checkin has not been done yet
-          rescue RevisionControlUninitialized
+          rescue RevisionControlUninitializedError
             @revision_controller = nil
           end
         elsif config.vault

--- a/lib/origen/application.rb
+++ b/lib/origen/application.rb
@@ -119,20 +119,25 @@ module Origen
     def revision_controller(options = {})
       if current?
         if config.rc_url
-          if config.rc_url =~ /^sync:/
-            @revision_controller ||= RevisionControl::DesignSync.new(
-              local:  root,
-              remote: config.rc_url
-            )
-          elsif config.rc_url =~ /git/
-            @revision_controller ||= RevisionControl::Git.new(
-              local:                  root,
-              # If a workspace is based on a fork of the master repo, config.rc_url may not
-              # be correct
-              remote:                 (options[:uninitialized] ? config.rc_url : (RevisionControl::Git.origin || config.rc_url)),
-              allow_local_adjustment: true
-            )
+          begin
+            if config.rc_url =~ /^sync:/
+              @revision_controller ||= RevisionControl::DesignSync.new(
+                local:  root,
+                remote: config.rc_url
+              )
+            elsif config.rc_url =~ /git/
+              @revision_controller ||= RevisionControl::Git.new(
+                local:                  root,
+                # If a workspace is based on a fork of the master repo, config.rc_url may not
+                # be correct
+                remote:                 (options[:uninitialized] ? config.rc_url : (RevisionControl::Git.origin || config.rc_url)),
+                allow_local_adjustment: true
+              )
 
+            end
+          # The rc_url has been defined, but the initial app checkin has not been done yet
+          rescue RevisionControlUninitialized
+            @revision_controller = nil
           end
         elsif config.vault
           @revision_controller ||= RevisionControl::DesignSync.new(

--- a/lib/origen/remote_manager.rb
+++ b/lib/origen/remote_manager.rb
@@ -221,7 +221,7 @@ module Origen
       # Add remotes from imports
       Origen.app.plugins.each do |plugin|
         plugin.config.remotes.each do |import_remote|
-          add_remote(import_remote)
+          add_remote(import_remote) unless import_remote[:development]
         end
       end
       @remotes

--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -363,7 +363,7 @@ module Origen
             unless exit_status.success?
               if options[:check_errors]
                 if output.any? { |l| l =~ /Not a git repository/ }
-                  fail RevisionControlUninitialized
+                  fail RevisionControlUninitializedError
                 else
                   fail GitError, "This command failed: 'git #{command}'"
                 end

--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -362,7 +362,11 @@ module Origen
             exit_status = wait_thr.value
             unless exit_status.success?
               if options[:check_errors]
-                fail GitError, "This command failed: 'git #{command}'"
+                if output.any? { |l| l =~ /Not a git repository/ }
+                  fail RevisionControlUninitialized
+                else
+                  fail GitError, "This command failed: 'git #{command}'"
+                end
               end
             end
           end

--- a/templates/web/guides/misc/remotes.md.erb
+++ b/templates/web/guides/misc/remotes.md.erb
@@ -35,9 +35,18 @@ config.remotes = [
     dir: "artwork",
     rc_url: "git@github.com:Origen-SDK/artwork.git",
     version: "master",
+    development: true
   }
 ]
 ~~~
+
+Origen will populate all remotes defined by a top-level application. It will also populate all
+remotes defined by an application's plugins, except for those which have been marked with
+'development: true` as in the 2nd example above.
+
+Setting `development: true`, indicates to Origen that the remote is only required when developing
+the plugin within a standalone workspace, and that it is not required when the plugin is being
+used by a top-level application.
 
 #### Location
 


### PR DESCRIPTION
This PR adds the ability to mark remotes for development use only, so that they will only be populated when developing a plugin and not when that plugin is used by a top-level app.

It also adds a patch to make `Origen.app.rc` return nil instead of crashing in the corner case where config.rc_url has been defined but the application has not been initially checked in yet.