### PR TITLE
Pipeline from application command extensions to origen core option parser

### DIFF
--- a/lib/origen/commands/compile.rb
+++ b/lib/origen/commands/compile.rb
@@ -43,10 +43,13 @@ Usage: origen compile [space separated files, lists or directories] [options]
   opts.on('-r', '--reference DIR', String, 'Override the default reference directory') { |o| options[:reference] = o }
   opts.on('-z', '--zip', 'Gzip all output files (diff checking will be skipped)') { |o| options[:zip] = o }
   app_options.each do |app_option|
-    ao = app_option.include_hash_with_key?(:option)
-    if ao
-      app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { instance_exec(options, &ao_proc) }
+      else
+        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+      end
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/compile.rb
+++ b/lib/origen/commands/compile.rb
@@ -1,6 +1,8 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
+include CommandHelpers
+
 options = {}
 
 # App options are options that the application can supply to extend this command

--- a/lib/origen/commands/compile.rb
+++ b/lib/origen/commands/compile.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'origen/commands/helpers'
 
 options = {}
 
@@ -42,18 +43,8 @@ Usage: origen compile [space separated files, lists or directories] [options]
   opts.on('-n', '--name NAME', String, 'Override the default output file name') { |o| options[:output_file_name] = o }
   opts.on('-r', '--reference DIR', String, 'Override the default reference directory') { |o| options[:reference] = o }
   opts.on('-z', '--zip', 'Gzip all output files (diff checking will be skipped)') { |o| options[:zip] = o }
-  app_options.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { instance_exec(options, &ao_proc) }
-      else
-        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-      end
-    else
-      opts.on(*app_option) {}
-    end
-  end
+  # Apply any application option extensions to the OptionParser
+  extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit 0 }
 end

--- a/lib/origen/commands/compile.rb
+++ b/lib/origen/commands/compile.rb
@@ -46,7 +46,7 @@ Usage: origen compile [space separated files, lists or directories] [options]
     ao = app_option.include_hash_with_key?(:option)
     if ao
       app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option]] = true }
+      opts.on(*app_option) { options[ao[:option].to_sym] = true }
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/compile.rb
+++ b/lib/origen/commands/compile.rb
@@ -43,7 +43,13 @@ Usage: origen compile [space separated files, lists or directories] [options]
   opts.on('-r', '--reference DIR', String, 'Override the default reference directory') { |o| options[:reference] = o }
   opts.on('-z', '--zip', 'Gzip all output files (diff checking will be skipped)') { |o| options[:zip] = o }
   app_options.each do |app_option|
-    opts.on(*app_option) {}
+    ao = app_option.include_hash_with_key?(:option)
+    if ao
+      app_option.delete(ao)
+      opts.on(*app_option) { options[ao[:option]] = true }
+    else
+      opts.on(*app_option) {}
+    end
   end
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit 0 }

--- a/lib/origen/commands/compile.rb
+++ b/lib/origen/commands/compile.rb
@@ -1,8 +1,6 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
-include CommandHelpers
-
 options = {}
 
 # App options are options that the application can supply to extend this command
@@ -46,7 +44,7 @@ Usage: origen compile [space separated files, lists or directories] [options]
   opts.on('-r', '--reference DIR', String, 'Override the default reference directory') { |o| options[:reference] = o }
   opts.on('-z', '--zip', 'Gzip all output files (diff checking will be skipped)') { |o| options[:zip] = o }
   # Apply any application option extensions to the OptionParser
-  extend_options(opts, app_options, options)
+  Origen::CommandHelpers.extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit 0 }
 end

--- a/lib/origen/commands/generate.rb
+++ b/lib/origen/commands/generate.rb
@@ -23,10 +23,13 @@ opt_parser = OptionParser.new do |opts|
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   app_options.each do |app_option|
-    ao = app_option.include_hash_with_key?(:option)
-    if ao
-      app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { instance_exec(options, &ao_proc) }
+      else
+        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+      end
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/generate.rb
+++ b/lib/origen/commands/generate.rb
@@ -1,6 +1,8 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
+include CommandHelpers
+
 options = {}
 
 # App options are options that the application can supply to extend this command

--- a/lib/origen/commands/generate.rb
+++ b/lib/origen/commands/generate.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'origen/commands/helpers'
 
 options = {}
 
@@ -22,18 +23,8 @@ opt_parser = OptionParser.new do |opts|
   opts.on('--nocom', 'No comments in the generated pattern') { options[:no_comments] = true }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
-  app_options.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { instance_exec(options, &ao_proc) }
-      else
-        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-      end
-    else
-      opts.on(*app_option) {}
-    end
-  end
+  # Apply any application option extensions to the OptionParser
+  extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/generate.rb
+++ b/lib/origen/commands/generate.rb
@@ -23,7 +23,13 @@ opt_parser = OptionParser.new do |opts|
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   app_options.each do |app_option|
-    opts.on(*app_option) {}
+    ao = app_option.include_hash_with_key?(:option)
+    if ao
+      app_option.delete(ao)
+      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    else
+      opts.on(*app_option) {}
+    end
   end
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/generate.rb
+++ b/lib/origen/commands/generate.rb
@@ -1,8 +1,6 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
-include CommandHelpers
-
 options = {}
 
 # App options are options that the application can supply to extend this command
@@ -26,7 +24,7 @@ opt_parser = OptionParser.new do |opts|
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   # Apply any application option extensions to the OptionParser
-  extend_options(opts, app_options, options)
+  Origen::CommandHelpers.extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/helpers.rb
+++ b/lib/origen/commands/helpers.rb
@@ -1,14 +1,16 @@
-def self.extend_options(opts, app_opts, options)
-  app_opts.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { ao_proc.call(options) }
+module CommandHelpers
+  def extend_options(opts, app_opts, options)
+    app_opts.each do |app_option|
+      if app_option.last.is_a?(Proc)
+        ao_proc = app_option.pop
+        if ao_proc.arity == 1
+          opts.on(*app_option) { ao_proc.call(options) }
+        else
+          opts.on(*app_option) { |arg| ao_proc.call(options, arg) }
+        end
       else
-        opts.on(*app_option) { |arg| ao_proc.call(options, arg) }
+        opts.on(*app_option) {}
       end
-    else
-      opts.on(*app_option) {}
     end
   end
 end

--- a/lib/origen/commands/helpers.rb
+++ b/lib/origen/commands/helpers.rb
@@ -1,0 +1,14 @@
+def self.extend_options(opts, app_opts, options)
+  app_opts.each do |app_option|
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { ao_proc.call(options) }
+      else
+        opts.on(*app_option) { |arg| ao_proc.call(options, arg) }
+      end
+    else
+      opts.on(*app_option) {}
+    end
+  end
+end

--- a/lib/origen/commands/helpers.rb
+++ b/lib/origen/commands/helpers.rb
@@ -1,15 +1,17 @@
-module CommandHelpers
-  def extend_options(opts, app_opts, options)
-    app_opts.each do |app_option|
-      if app_option.last.is_a?(Proc)
-        ao_proc = app_option.pop
-        if ao_proc.arity == 1
-          opts.on(*app_option) { ao_proc.call(options) }
+module Origen
+  module CommandHelpers
+    def self.extend_options(opts, app_opts, options)
+      app_opts.each do |app_option|
+        if app_option.last.is_a?(Proc)
+          ao_proc = app_option.pop
+          if ao_proc.arity == 1
+            opts.on(*app_option) { ao_proc.call(options) }
+          else
+            opts.on(*app_option) { |arg| ao_proc.call(options, arg) }
+          end
         else
-          opts.on(*app_option) { |arg| ao_proc.call(options, arg) }
+          opts.on(*app_option) {}
         end
-      else
-        opts.on(*app_option) {}
       end
     end
   end

--- a/lib/origen/commands/interactive.rb
+++ b/lib/origen/commands/interactive.rb
@@ -6,6 +6,7 @@ begin
 rescue LoadError
   # If not installed simply not available
 end
+require 'origen/commands/helpers'
 
 module Origen
   # Methods available to the command line in a console session, split this to a
@@ -39,18 +40,8 @@ Usage: origen i [options]
     opts.on('-p', '--pry', 'Use Pry for the session (instead of IRB)') { options[:pry] = true }
     opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
     opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
-    app_options.each do |app_option|
-      if app_option.last.is_a?(Proc)
-        ao_proc = app_option.pop
-        if ao_proc.arity == 1
-          opts.on(*app_option) { instance_exec(options, &ao_proc) }
-        else
-          opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-        end
-      else
-        opts.on(*app_option) {}
-      end
-    end
+    # Apply any application option extensions to the OptionParser
+    extend_options(opts, app_options, options)
     opts.separator ''
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }
   end

--- a/lib/origen/commands/interactive.rb
+++ b/lib/origen/commands/interactive.rb
@@ -9,6 +9,8 @@ end
 require 'origen/commands/helpers'
 
 module Origen
+  extend CommandHelpers
+
   # Methods available to the command line in a console session, split this to a
   # separate file if it gets large over time
   module ConsoleMethods

--- a/lib/origen/commands/interactive.rb
+++ b/lib/origen/commands/interactive.rb
@@ -9,8 +9,6 @@ end
 require 'origen/commands/helpers'
 
 module Origen
-  extend CommandHelpers
-
   # Methods available to the command line in a console session, split this to a
   # separate file if it gets large over time
   module ConsoleMethods
@@ -43,7 +41,7 @@ Usage: origen i [options]
     opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
     opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
     # Apply any application option extensions to the OptionParser
-    extend_options(opts, app_options, options)
+    Origen::CommandHelpers.extend_options(opts, app_options, options)
     opts.separator ''
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }
   end

--- a/lib/origen/commands/interactive.rb
+++ b/lib/origen/commands/interactive.rb
@@ -40,7 +40,13 @@ Usage: origen i [options]
     opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
     opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
     app_options.each do |app_option|
-      opts.on(*app_option) {}
+      ao = app_option.include_hash_with_key?(:option)
+      if ao
+        app_option.delete(ao)
+        opts.on(*app_option) { options[ao[:option].to_sym] = true }
+      else
+        opts.on(*app_option) {}
+      end
     end
     opts.separator ''
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/interactive.rb
+++ b/lib/origen/commands/interactive.rb
@@ -40,10 +40,13 @@ Usage: origen i [options]
     opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
     opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
     app_options.each do |app_option|
-      ao = app_option.include_hash_with_key?(:option)
-      if ao
-        app_option.delete(ao)
-        opts.on(*app_option) { options[ao[:option].to_sym] = true }
+      if app_option.last.is_a?(Proc)
+        ao_proc = app_option.pop
+        if ao_proc.arity == 1
+          opts.on(*app_option) { instance_exec(options, &ao_proc) }
+        else
+          opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+        end
       else
         opts.on(*app_option) {}
       end

--- a/lib/origen/commands/lint.rb
+++ b/lib/origen/commands/lint.rb
@@ -20,7 +20,13 @@ http://origen.freescale.net/origen/latest/guides/utilities/lint/
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   app_options.each do |app_option|
-    opts.on(*app_option) {}
+    ao = app_option.include_hash_with_key?(:option)
+    if ao
+      app_option.delete(ao)
+      opts.on(*app_option) { options[ao[:option]] = true }
+    else
+      opts.on(*app_option) {}
+    end
   end
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/lint.rb
+++ b/lib/origen/commands/lint.rb
@@ -1,7 +1,5 @@
 require 'origen/commands/helpers'
 
-include CommandHelpers
-
 options = {}
 
 # App options are options that the application can supply to extend this command
@@ -24,7 +22,7 @@ http://origen.freescale.net/origen/latest/guides/utilities/lint/
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   # Apply any application option extensions to the OptionParser
-  extend_options(opts, app_options, options)
+  Origen::CommandHelpers.extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/lint.rb
+++ b/lib/origen/commands/lint.rb
@@ -1,5 +1,7 @@
 require 'origen/commands/helpers'
 
+include CommandHelpers
+
 options = {}
 
 # App options are options that the application can supply to extend this command

--- a/lib/origen/commands/lint.rb
+++ b/lib/origen/commands/lint.rb
@@ -20,10 +20,13 @@ http://origen.freescale.net/origen/latest/guides/utilities/lint/
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   app_options.each do |app_option|
-    ao = app_option.include_hash_with_key?(:option)
-    if ao
-      app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { instance_exec(options, &ao_proc) }
+      else
+        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+      end
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/lint.rb
+++ b/lib/origen/commands/lint.rb
@@ -1,3 +1,5 @@
+require 'origen/commands/helpers'
+
 options = {}
 
 # App options are options that the application can supply to extend this command
@@ -19,18 +21,8 @@ http://origen.freescale.net/origen/latest/guides/utilities/lint/
   opts.on('-e', '--easy', 'Be less strict, most checks run with this flag enabled can be corrected automatically') { options[:easy] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
-  app_options.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { instance_exec(options, &ao_proc) }
-      else
-        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-      end
-    else
-      opts.on(*app_option) {}
-    end
-  end
+  # Apply any application option extensions to the OptionParser
+  extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/lint.rb
+++ b/lib/origen/commands/lint.rb
@@ -23,7 +23,7 @@ http://origen.freescale.net/origen/latest/guides/utilities/lint/
     ao = app_option.include_hash_with_key?(:option)
     if ao
       app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option]] = true }
+      opts.on(*app_option) { options[ao[:option].to_sym] = true }
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/lsf.rb
+++ b/lib/origen/commands/lsf.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'origen/commands/helpers'
 
 options = {}
 
@@ -55,18 +56,8 @@ Usage: origen lsf [options]
   # opts.on("-e", "--execute", "Execute....") { options[:execute] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
-  app_options.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { instance_exec(options, &ao_proc) }
-      else
-        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-      end
-    else
-      opts.on(*app_option) {}
-    end
-  end
+  # Apply any application option extensions to the OptionParser
+  extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/lsf.rb
+++ b/lib/origen/commands/lsf.rb
@@ -56,7 +56,13 @@ Usage: origen lsf [options]
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   app_options.each do |app_option|
-    opts.on(*app_option) {}
+    ao = app_option.include_hash_with_key?(:option)
+    if ao
+      app_option.delete(ao)
+      opts.on(*app_option) { options[ao[:option]] = true }
+    else
+      opts.on(*app_option) {}
+    end
   end
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/lsf.rb
+++ b/lib/origen/commands/lsf.rb
@@ -1,6 +1,8 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
+include CommandHelpers
+
 options = {}
 
 def require_type_or_id(options)

--- a/lib/origen/commands/lsf.rb
+++ b/lib/origen/commands/lsf.rb
@@ -1,8 +1,6 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
-include CommandHelpers
-
 options = {}
 
 def require_type_or_id(options)
@@ -59,7 +57,7 @@ Usage: origen lsf [options]
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   # Apply any application option extensions to the OptionParser
-  extend_options(opts, app_options, options)
+  Origen::CommandHelpers.extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/lsf.rb
+++ b/lib/origen/commands/lsf.rb
@@ -56,10 +56,13 @@ Usage: origen lsf [options]
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   app_options.each do |app_option|
-    ao = app_option.include_hash_with_key?(:option)
-    if ao
-      app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { instance_exec(options, &ao_proc) }
+      else
+        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+      end
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/lsf.rb
+++ b/lib/origen/commands/lsf.rb
@@ -59,7 +59,7 @@ Usage: origen lsf [options]
     ao = app_option.include_hash_with_key?(:option)
     if ao
       app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option]] = true }
+      opts.on(*app_option) { options[ao[:option].to_sym] = true }
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/program.rb
+++ b/lib/origen/commands/program.rb
@@ -23,10 +23,13 @@ opt_parser = OptionParser.new do |opts|
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   app_options.each do |app_option|
-    ao = app_option.include_hash_with_key?(:option)
-    if ao
-      app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { instance_exec(options, &ao_proc) }
+      else
+        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+      end
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/program.rb
+++ b/lib/origen/commands/program.rb
@@ -1,6 +1,8 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
+include CommandHelpers
+
 options = {}
 
 # App options are options that the application can supply to extend this command

--- a/lib/origen/commands/program.rb
+++ b/lib/origen/commands/program.rb
@@ -23,7 +23,13 @@ opt_parser = OptionParser.new do |opts|
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   app_options.each do |app_option|
-    opts.on(*app_option) {}
+    ao = app_option.include_hash_with_key?(:option)
+    if ao
+      app_option.delete(ao)
+      opts.on(*app_option) { options[ao[:option]] = true }
+    else
+      opts.on(*app_option) {}
+    end
   end
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/program.rb
+++ b/lib/origen/commands/program.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'origen/commands/helpers'
 
 options = {}
 
@@ -22,18 +23,8 @@ opt_parser = OptionParser.new do |opts|
   opts.on('-p', '--project NAME', String, 'Specify the LSF project, default is msg.te') { |o| options[:project] = o }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
-  app_options.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { instance_exec(options, &ao_proc) }
-      else
-        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-      end
-    else
-      opts.on(*app_option) {}
-    end
-  end
+  # Apply any application option extensions to the OptionParser
+  extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/program.rb
+++ b/lib/origen/commands/program.rb
@@ -1,8 +1,6 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
-include CommandHelpers
-
 options = {}
 
 # App options are options that the application can supply to extend this command
@@ -26,7 +24,7 @@ opt_parser = OptionParser.new do |opts|
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   # Apply any application option extensions to the OptionParser
-  extend_options(opts, app_options, options)
+  Origen::CommandHelpers.extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/program.rb
+++ b/lib/origen/commands/program.rb
@@ -26,7 +26,7 @@ opt_parser = OptionParser.new do |opts|
     ao = app_option.include_hash_with_key?(:option)
     if ao
       app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option]] = true }
+      opts.on(*app_option) { options[ao[:option].to_sym] = true }
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/rc.rb
+++ b/lib/origen/commands/rc.rb
@@ -2,7 +2,6 @@ require 'optparse'
 require 'origen/commands/helpers'
 
 include Origen::Utility::InputCapture
-include CommandHelpers
 
 def _unmanaged_files
   unmanaged_files = Origen::RevisionControl::IGNORE_FILES
@@ -130,7 +129,7 @@ The following options are available:
   EOT
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }
     # Apply any application option extensions to the OptionParser
-    extend_options(opts, app_options, options)
+    Origen::CommandHelpers.extend_options(opts, app_options, options)
     opts.separator ''
     opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
     opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }

--- a/lib/origen/commands/rc.rb
+++ b/lib/origen/commands/rc.rb
@@ -2,6 +2,7 @@ require 'optparse'
 require 'origen/commands/helpers'
 
 include Origen::Utility::InputCapture
+include CommandHelpers
 
 def _unmanaged_files
   unmanaged_files = Origen::RevisionControl::IGNORE_FILES

--- a/lib/origen/commands/rc.rb
+++ b/lib/origen/commands/rc.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'origen/commands/helpers'
 
 include Origen::Utility::InputCapture
 
@@ -127,9 +128,8 @@ The following commands are available:
 The following options are available:
   EOT
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }
-    app_options.each do |app_option|
-      opts.on(*app_option) {}
-    end
+    # Apply any application option extensions to the OptionParser
+    extend_options(opts, app_options, options)
     opts.separator ''
     opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
     opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }

--- a/lib/origen/commands/save.rb
+++ b/lib/origen/commands/save.rb
@@ -15,10 +15,13 @@ Usage: origen save TYPE [options]
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   app_options.each do |app_option|
-    ao = app_option.include_hash_with_key?(:option)
-    if ao
-      app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { instance_exec(options, &ao_proc) }
+      else
+        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+      end
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/save.rb
+++ b/lib/origen/commands/save.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'origen/commands/helpers'
 
 options = {}
 
@@ -14,18 +15,8 @@ Usage: origen save TYPE [options]
   opts.on('-f', '--file FILE', String, 'Override the default log file') { |o| options[:log_file] = o }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
-  app_options.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { instance_exec(options, &ao_proc) }
-      else
-        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-      end
-    else
-      opts.on(*app_option) {}
-    end
-  end
+  # Apply any application option extensions to the OptionParser
+  extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/save.rb
+++ b/lib/origen/commands/save.rb
@@ -1,8 +1,6 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
-include CommandHelpers
-
 options = {}
 
 # App options are options that the application can supply to extend this command
@@ -18,7 +16,7 @@ Usage: origen save TYPE [options]
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   # Apply any application option extensions to the OptionParser
-  extend_options(opts, app_options, options)
+  Origen::CommandHelpers.extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/save.rb
+++ b/lib/origen/commands/save.rb
@@ -18,7 +18,7 @@ Usage: origen save TYPE [options]
     ao = app_option.include_hash_with_key?(:option)
     if ao
       app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option]] = true }
+      opts.on(*app_option) { options[ao[:option].to_sym] = true }
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/save.rb
+++ b/lib/origen/commands/save.rb
@@ -15,7 +15,13 @@ Usage: origen save TYPE [options]
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   app_options.each do |app_option|
-    opts.on(*app_option) {}
+    ao = app_option.include_hash_with_key?(:option)
+    if ao
+      app_option.delete(ao)
+      opts.on(*app_option) { options[ao[:option]] = true }
+    else
+      opts.on(*app_option) {}
+    end
   end
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/save.rb
+++ b/lib/origen/commands/save.rb
@@ -1,6 +1,8 @@
 require 'optparse'
 require 'origen/commands/helpers'
 
+include CommandHelpers
+
 options = {}
 
 # App options are options that the application can supply to extend this command

--- a/lib/origen/commands/time.rb
+++ b/lib/origen/commands/time.rb
@@ -2,8 +2,6 @@ require 'optparse'
 require 'pathname'
 require 'origen/commands/helpers'
 
-include CommandHelpers
-
 options = {}
 
 ARGV << '-h' if ARGV.empty?
@@ -32,7 +30,7 @@ Usage: origen time CMD [args] [options]
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-f', '--file FILE', String, 'Override the default log file') { |o| options[:log_file] = o }
   # Apply any application option extensions to the OptionParser
-  extend_options(opts, app_options, options)
+  Origen::CommandHelpers.extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/time.rb
+++ b/lib/origen/commands/time.rb
@@ -29,7 +29,13 @@ Usage: origen time CMD [args] [options]
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-f', '--file FILE', String, 'Override the default log file') { |o| options[:log_file] = o }
   app_options.each do |app_option|
-    opts.on(*app_option) {}
+    ao = app_option.include_hash_with_key?(:option)
+    if ao
+      app_option.delete(ao)
+      opts.on(*app_option) { options[ao[:option]] = true }
+    else
+      opts.on(*app_option) {}
+    end
   end
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/time.rb
+++ b/lib/origen/commands/time.rb
@@ -2,6 +2,8 @@ require 'optparse'
 require 'pathname'
 require 'origen/commands/helpers'
 
+include CommandHelpers
+
 options = {}
 
 ARGV << '-h' if ARGV.empty?

--- a/lib/origen/commands/time.rb
+++ b/lib/origen/commands/time.rb
@@ -29,10 +29,13 @@ Usage: origen time CMD [args] [options]
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-f', '--file FILE', String, 'Override the default log file') { |o| options[:log_file] = o }
   app_options.each do |app_option|
-    ao = app_option.include_hash_with_key?(:option)
-    if ao
-      app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option].to_sym] = true }
+    if app_option.last.is_a?(Proc)
+      ao_proc = app_option.pop
+      if ao_proc.arity == 1
+        opts.on(*app_option) { instance_exec(options, &ao_proc) }
+      else
+        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+      end
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/time.rb
+++ b/lib/origen/commands/time.rb
@@ -32,7 +32,7 @@ Usage: origen time CMD [args] [options]
     ao = app_option.include_hash_with_key?(:option)
     if ao
       app_option.delete(ao)
-      opts.on(*app_option) { options[ao[:option]] = true }
+      opts.on(*app_option) { options[ao[:option].to_sym] = true }
     else
       opts.on(*app_option) {}
     end

--- a/lib/origen/commands/time.rb
+++ b/lib/origen/commands/time.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'pathname'
+require 'origen/commands/helpers'
 
 options = {}
 
@@ -28,18 +29,8 @@ Usage: origen time CMD [args] [options]
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
   opts.on('-f', '--file FILE', String, 'Override the default log file') { |o| options[:log_file] = o }
-  app_options.each do |app_option|
-    if app_option.last.is_a?(Proc)
-      ao_proc = app_option.pop
-      if ao_proc.arity == 1
-        opts.on(*app_option) { instance_exec(options, &ao_proc) }
-      else
-        opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-      end
-    else
-      opts.on(*app_option) {}
-    end
-  end
+  # Apply any application option extensions to the OptionParser
+  extend_options(opts, app_options, options)
   opts.separator ''
   opts.on('-h', '--help', 'Show this message') { puts opts; exit }
 end

--- a/lib/origen/commands/web.rb
+++ b/lib/origen/commands/web.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'pathname'
+require 'origen/commands/helpers'
 
 module Origen
   options = {}
@@ -49,18 +50,8 @@ The following options are available:
     opts.on('-m', '--mode MODE', Origen::Mode::MODES, 'Force the Origen operating mode:', '  ' + Origen::Mode::MODES.join(', ')) { |_m| }
     opts.on('--no-serve', "Don't serve the website after compiling without the remote option") { options[:no_serve] = true }
     opts.on('-c', '--comment COMMENT', String, 'Supply a commit comment when deploying to Git') { |o| options[:comment] = o }
-    app_options.each do |app_option|
-      if app_option.last.is_a?(Proc)
-        ao_proc = app_option.pop
-        if ao_proc.arity == 1
-          opts.on(*app_option) { instance_exec(options, &ao_proc) }
-        else
-          opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
-        end
-      else
-        opts.on(*app_option) {}
-      end
-    end
+    # Apply any application option extensions to the OptionParser
+    extend_options(opts, app_options, options)
     opts.separator ''
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }
   end

--- a/lib/origen/commands/web.rb
+++ b/lib/origen/commands/web.rb
@@ -50,7 +50,13 @@ The following options are available:
     opts.on('--no-serve', "Don't serve the website after compiling without the remote option") { options[:no_serve] = true }
     opts.on('-c', '--comment COMMENT', String, 'Supply a commit comment when deploying to Git') { |o| options[:comment] = o }
     app_options.each do |app_option|
-      opts.on(*app_option) {}
+      ao = app_option.include_hash_with_key?(:option)
+      if ao
+        app_option.delete(ao)
+        opts.on(*app_option) { options[ao[:option]] = true }
+      else
+        opts.on(*app_option) {}
+      end
     end
     opts.separator ''
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }

--- a/lib/origen/commands/web.rb
+++ b/lib/origen/commands/web.rb
@@ -53,7 +53,7 @@ The following options are available:
       ao = app_option.include_hash_with_key?(:option)
       if ao
         app_option.delete(ao)
-        opts.on(*app_option) { options[ao[:option]] = true }
+        opts.on(*app_option) { options[ao[:option].to_sym] = true }
       else
         opts.on(*app_option) {}
       end

--- a/lib/origen/commands/web.rb
+++ b/lib/origen/commands/web.rb
@@ -3,6 +3,8 @@ require 'pathname'
 require 'origen/commands/helpers'
 
 module Origen
+  extend CommandHelpers
+
   options = {}
 
   # App options are options that the application can supply to extend this command

--- a/lib/origen/commands/web.rb
+++ b/lib/origen/commands/web.rb
@@ -3,8 +3,6 @@ require 'pathname'
 require 'origen/commands/helpers'
 
 module Origen
-  extend CommandHelpers
-
   options = {}
 
   # App options are options that the application can supply to extend this command
@@ -53,7 +51,7 @@ The following options are available:
     opts.on('--no-serve', "Don't serve the website after compiling without the remote option") { options[:no_serve] = true }
     opts.on('-c', '--comment COMMENT', String, 'Supply a commit comment when deploying to Git') { |o| options[:comment] = o }
     # Apply any application option extensions to the OptionParser
-    extend_options(opts, app_options, options)
+    Origen::CommandHelpers.extend_options(opts, app_options, options)
     opts.separator ''
     opts.on('-h', '--help', 'Show this message') { puts opts; exit }
   end

--- a/lib/origen/commands/web.rb
+++ b/lib/origen/commands/web.rb
@@ -50,10 +50,13 @@ The following options are available:
     opts.on('--no-serve', "Don't serve the website after compiling without the remote option") { options[:no_serve] = true }
     opts.on('-c', '--comment COMMENT', String, 'Supply a commit comment when deploying to Git') { |o| options[:comment] = o }
     app_options.each do |app_option|
-      ao = app_option.include_hash_with_key?(:option)
-      if ao
-        app_option.delete(ao)
-        opts.on(*app_option) { options[ao[:option].to_sym] = true }
+      if app_option.last.is_a?(Proc)
+        ao_proc = app_option.pop
+        if ao_proc.arity == 1
+          opts.on(*app_option) { instance_exec(options, &ao_proc) }
+        else
+          opts.on(*app_option) { |arg| instance_exec(options, arg, &ao_proc) }
+        end
       else
         opts.on(*app_option) {}
       end

--- a/lib/origen/core_ext/array.rb
+++ b/lib/origen/core_ext/array.rb
@@ -20,4 +20,18 @@ class Array
     hash.delete_if { |_k, v| v.size == 1 }
     hash
   end
+
+  def include_hash?
+    each { |e| return true if e.is_a? Hash }
+    false
+  end
+
+  def include_hash_with_key?(key)
+    each do |e|
+      if e.is_a? Hash
+        return e if e.key?(key)
+      end
+    end
+    nil
+  end
 end

--- a/lib/origen/generator/job.rb
+++ b/lib/origen/generator/job.rb
@@ -4,6 +4,7 @@ module Origen
     class Job # :nodoc: all
       attr_accessor :output_file_body, :pattern
       attr_reader :split_counter
+      attr_reader :options
 
       def initialize(pattern, options)
         @testing = options[:testing]

--- a/lib/origen/generator/pattern.rb
+++ b/lib/origen/generator/pattern.rb
@@ -368,7 +368,11 @@ module Origen
 
         if Origen.tester.generate?
           Origen.app.listeners_for(:pattern_generated).each do |listener|
-            listener.pattern_generated(Pathname.new(job.output_pattern))
+            if listener.class.instance_method(:pattern_generated).arity == 1
+              listener.pattern_generated(Pathname.new(job.output_pattern))
+            else
+              listener.pattern_generated(Pathname.new(job.output_pattern), job.options)
+            end
           end
         end
       end

--- a/templates/web/guides/misc/commandsov.md.erb
+++ b/templates/web/guides/misc/commandsov.md.erb
@@ -16,8 +16,10 @@ To document the new option you can pass the details to Origen via the
 <code>@application_options</code> variable and the new option will appear in the help
 as if it was a built-in part of the command.
 
-Additionally, if you want the option to be registered with Origen's option parser, you can supply an 
-'option name' in the details passed by <code>@application_options</code> (see example below).
+Additionally, you can provide a block to Origen that will be executed if the option is given. The block should
+be passed as the last element of the array that is pushed to the <code>@application_options</code> variable and
+can be specified using a lambda sytax <code>lambda { |options| options[:some_option] = true }</code> or 
+alternately <code>->(options) { options[:some_option] = true }</code>.
 
 #### Example
 
@@ -44,9 +46,10 @@ when "generate"
   # Option definitions must be pushed into the @application_options array, don't re-assign it!
   @application_options << ["--no_md5", "Don't apply the MD5 checksum to pattern names"]
 
-  # To regiser the option with Origen's option parser, include a hash { option: <option_name> }
-  # With the example below, the opt_parser.parse! will register 'myapp_compile: true'
-  @application_options << ["--compile", "Compile the pattern", { option: 'myapp_compile' }]
+  # To specify a block to be executed by Origen's option parser (when the option is used), include 
+  # a block as the last element
+  @application_options << ["--compile", "Compile the pattern", ->(options) { options[:myapp_compile] = true }]
+  @application_options << ["--compiler NAME", "Compiler to use", ->(options, compiler) { options[:myapp_compiler] = compiler }]
 
   # Note that it is important not to delete the argument from ARGV, this is necessary to make Origen
   # fully aware of it, so that it can be passed on to any additional jobs invoked from this process

--- a/templates/web/guides/misc/commandsov.md.erb
+++ b/templates/web/guides/misc/commandsov.md.erb
@@ -16,6 +16,9 @@ To document the new option you can pass the details to Origen via the
 <code>@application_options</code> variable and the new option will appear in the help
 as if it was a built-in part of the command.
 
+Additionally, if you want the option to be registered with Origen's option parser, you can supply an 
+'option name' in the details passed by <code>@application_options</code> (see example below).
+
 #### Example
 
 In one application we added an MD5 checksum to the names of all generated patterns
@@ -39,7 +42,12 @@ attr_accessor :no_md5
 # to exit here to allow the standard Origen command to run afterwards
 when "generate"
   # Option definitions must be pushed into the @application_options array, don't re-assign it!
-  @application_options << ["--no_md5", "Don't apply the MD5 checksum to pattern names"],
+  @application_options << ["--no_md5", "Don't apply the MD5 checksum to pattern names"]
+
+  # To regiser the option with Origen's option parser, include a hash { option: <option_name> }
+  # With the example below, the opt_parser.parse! will register 'myapp_compile: true'
+  @application_options << ["--compile", "Compile the pattern", { option: 'myapp_compile' }]
+
   # Note that it is important not to delete the argument from ARGV, this is necessary to make Origen
   # fully aware of it, so that it can be passed on to any additional jobs invoked from this process
   Origen.app.no_md5 = true if ARGV.include?("--no_md5")


### PR DESCRIPTION
Allow applications (or plugins) to specify an 'option name' for command option extensions which, when set, will register in the Origen Core option parser.


Example:

This example shows how origen_testers can extend the 'generate' command with a '--compile' option which, when set, will register in the Origen Core option parser as *testers_compile_pat: true*.  In turn, that can be passed along to various processes associated with the base command (e.g. can be passed to the listener pattern_generated for post-pattern pattern compilation).

origen_testers: config/shared_commands.rb
```ruby

case @command
  when "generate"
    @application_options << ['--compile', 'Compile the current pattern or the list', { option: 'testers_compile_pat' }]

```