### PR TITLE
Added in 'to_flat_hash' method for Parameter::Set class

### DIFF
--- a/lib/origen/parameters/set.rb
+++ b/lib/origen/parameters/set.rb
@@ -153,6 +153,34 @@ module Origen
         owner._request_live_parameter
         self
       end
+
+      def to_flat_hash(options = {})
+        options = {
+          delimiter: '.'
+        }.update(options)
+        flatten_params(self, options[:delimiter]).first
+      end
+
+      private
+
+      def flatten_params(param_hash, delimiter, name = nil, results_hash = {})
+        param_hash.each do |k, v|
+          if v.is_a? Origen::Parameters::Set
+            name.nil? ? name = k.to_s : name << "#{delimiter}#{k}"
+            (results_hash, name) = flatten_params(v, delimiter, name, results_hash)
+          else
+            if name.nil?
+              results_hash[k] = v
+            else
+              results_hash["#{name}#{delimiter}#{k}"] = v
+              if k == param_hash.keys.last
+                name = nil
+              end
+            end
+          end
+        end
+        [results_hash, name]
+      end
     end
   end
 end

--- a/spec/parameters_spec.rb
+++ b/spec/parameters_spec.rb
@@ -265,5 +265,12 @@ module ParametersSpec
       ip.params.context.should == :ate
       ip.params.a.should == 30
     end
+    
+    it "parameter sets can be converted to a flat hash" do
+      $dut.params.to_flat_hash.include?('erase.time').should == true
+      $dut.params.to_flat_hash['test.ac.period'].should == 1e-08
+      $dut.params.to_flat_hash(delimiter: '_').include?('erase_time').should == true
+      $dut.params.to_flat_hash(delimiter: '_')['test_ac_period'].should == 1e-08
+    end
   end
 end


### PR DESCRIPTION
~~~ruby
[1] pry(#<RSpec::ExampleGroups::Parameters>)> $dut.params
=> {:tprog=>20,
 :erase=>{:time=>4, :pulses=>5},
 :test=>{:ac=>{:period=>1.0e-08}, :func=>#<Proc:0x002b0475292940@/users/bcaqueli/origen/origen/spec/parameters_spec.rb:16 (lambda)>},
 :vdd=>{:nom=>1, :min=>0.8, :max=>1.2}}
[2] pry(#<RSpec::ExampleGroups::Parameters>)> $dut.params.to_flat_hash.include?('erase.time')
=> true
[3] pry(#<RSpec::ExampleGroups::Parameters>)> $dut.params.to_flat_hash['test.ac.period']
=> 1.0e-08
[4] pry(#<RSpec::ExampleGroups::Parameters>)> $dut.params.to_flat_hash(delimiter: '_').include?('erase_time')
=> true
[5] pry(#<RSpec::ExampleGroups::Parameters>)> $dut.params.to_flat_hash(delimiter: '_')['test_ac_period']
=> 1.0e-08
~~~