### PR TITLE
Added in Origen::PowerSupplies model

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -63,6 +63,7 @@ unless defined? RGen::ORIGENTRANSITION
     autoload :LSFManager,    'origen/application/lsf_manager'
     autoload :Fuses,     'origen/fuses'
     autoload :Tests,     'origen/tests'
+    autoload :PowerSupplies, 'origen/power_supplies'
 
     attr_reader :switch_user
 

--- a/lib/origen/model.rb
+++ b/lib/origen/model.rb
@@ -27,6 +27,7 @@ module Origen
       include Origen::Errata
       include Origen::Fuses
       include Origen::Tests
+      include Origen::PowerSupplies
     end
 
     module ClassMethods

--- a/lib/origen/power_supplies.rb
+++ b/lib/origen/power_supplies.rb
@@ -1,0 +1,33 @@
+require_relative './power_supplies/power_supply'
+module Origen
+  module PowerSupplies
+    def power_supplies(expr = nil)
+      if expr.nil?
+        if @_power_supplies.nil?
+          @_power_supplies = {}
+        elsif @_power_supplies.is_a? Hash
+          if @_power_supplies.empty?
+            @_power_supplies
+          else
+            @_power_supplies.ids
+          end
+        else
+          @_power_supplies = {}
+        end
+      else
+        @_power_supplies.recursive_find_by_key(expr)
+      end
+    end
+    alias_method :supplies, :power_supplies
+
+    def add_power_supply(id, options = {}, &block)
+      @_power_supplies ||= {}
+      if @_power_supplies.include?(id)
+        Origen.log.error("Cannot create power supply '#{id}', it already exists!")
+        fail
+      end
+      @_power_supplies[id] = PowerSupply.new(id, options, &block)
+    end
+    alias_method :add_supply, :add_power_supply
+  end
+end

--- a/lib/origen/power_supplies/power_supply.rb
+++ b/lib/origen/power_supplies/power_supply.rb
@@ -5,28 +5,6 @@ module Origen
       include Origen::Specs
       attr_accessor :id, :owner, :description, :type
       
-      # Generic power supply number ... Usually will be the main power supply
-      # with different power supplies coming from them.
-      # Example:  GVDD will cover G1VDD, G2VDD, and G3VDD.
-      attr_accessor :generic
-      
-      # More specific name, e.g. G1VDD
-      attr_accessor :actual
-      
-      # Typical voltages for the actual power supply.  Could be multiple voltages
-      # Expected type is Array
-      attr_accessor :typ_voltages
-
-      # Display Names
-      # Should be Hash
-      #  display_names = {
-      #     input:  G1V<sub>IN</sub>
-      #     output: G1V<sub>OUT</sub>
-      #     nil:    G1V<sub>DD</sub>
-      #}
-      attr_accessor :display_names
-      
-     
       LIMITS = {
         min: 'Minimum',
         nom: 'Nominal',
@@ -48,14 +26,6 @@ module Origen
         @id
       end
 
-      def display_names(name)
-        @display_names = {}
-        @display_names[:nil] = name
-        @display_names[:input] = change_subscript('IN')
-        @display_names[:output] = change_subscript('OUT')
-        @display_names
-      end
-      
       def method_missing(m, *args, &block)
         ivar = "@#{m.to_s.gsub('=', '')}"
         ivar_sym = ":#{ivar}"
@@ -83,13 +53,6 @@ module Origen
         end
       end
 
-      def change_subscript(new_subscript)
-        tmp_display_name = @display_name[:nil].dup
-        sub_input = tmp_display_name.at_css 'sub'
-        sub_input.content = new_subscript unless sub_input.nil?
-        tmp_display_name
-      end
-      
       def attrs_ok?
         return_value = true
         unless @description.is_a? String

--- a/lib/origen/power_supplies/power_supply.rb
+++ b/lib/origen/power_supplies/power_supply.rb
@@ -4,7 +4,29 @@ module Origen
     class PowerSupply
       include Origen::Specs
       attr_accessor :id, :owner, :description, :type
+      
+      # Generic power supply number ... Usually will be the main power supply
+      # with different power supplies coming from them.
+      # Example:  GVDD will cover G1VDD, G2VDD, and G3VDD.
+      attr_accessor :generic
+      
+      # More specific name, e.g. G1VDD
+      attr_accessor :actual
+      
+      # Typical voltages for the actual power supply.  Could be multiple voltages
+      # Expected type is Array
+      attr_accessor :typ_voltages
 
+      # Display Names
+      # Should be Hash
+      #  display_names = {
+      #     input:  G1V<sub>IN</sub>
+      #     output: G1V<sub>OUT</sub>
+      #     nil:    G1V<sub>DD</sub>
+      #}
+      attr_accessor :display_names
+      
+     
       LIMITS = {
         min: 'Minimum',
         nom: 'Nominal',
@@ -26,6 +48,14 @@ module Origen
         @id
       end
 
+      def display_names(name)
+        @display_names = {}
+        @display_names[:nil] = name
+        @display_names[:input] = change_subscript('IN')
+        @display_names[:output] = change_subscript('OUT')
+        @display_names
+      end
+      
       def method_missing(m, *args, &block)
         ivar = "@#{m.to_s.gsub('=', '')}"
         ivar_sym = ":#{ivar}"
@@ -53,6 +83,13 @@ module Origen
         end
       end
 
+      def change_subscript(new_subscript)
+        tmp_display_name = @display_name[:nil].dup
+        sub_input = tmp_display_name.at_css 'sub'
+        sub_input.content = new_subscript unless sub_input.nil?
+        tmp_display_name
+      end
+      
       def attrs_ok?
         return_value = true
         unless @description.is_a? String

--- a/lib/origen/power_supplies/power_supply.rb
+++ b/lib/origen/power_supplies/power_supply.rb
@@ -1,0 +1,66 @@
+require 'origen/specs'
+module Origen
+  module PowerSupplies
+    class PowerSupply
+      include Origen::Specs
+      attr_accessor :id, :owner, :description, :type
+
+      LIMITS = {
+        min: 'Minimum',
+        nom: 'Nominal',
+        max: 'Maximum'
+      }
+
+      def initialize(id, options = {}, &block)
+        @id = id
+        @description = ''
+        @conditions, @platforms = [], []
+        @id = @id.symbolize unless @id.is_a? Symbol
+        add_specs
+        options.each { |k, v| instance_variable_set("@#{k}", v) }
+        (block.arity < 1 ? (instance_eval(&block)) : block.call(self)) if block_given?
+        fail unless attrs_ok?
+      end
+
+      def name
+        @id
+      end
+
+      def method_missing(m, *args, &block)
+        ivar = "@#{m.to_s.gsub('=', '')}"
+        ivar_sym = ":#{ivar}"
+        if m.to_s =~ /=$/
+          define_singleton_method(m) do |val|
+            instance_variable_set(ivar, val)
+          end
+        elsif instance_variables.include? ivar_sym
+          instance_variable_get(ivar)
+        else
+          define_singleton_method(m) do
+            instance_variable_get(ivar)
+          end
+        end
+        send(m, *args, &block)
+      end
+
+      private
+
+      def add_specs
+        LIMITS.each do |id, desc|
+          spec id, :dc do
+            description = desc
+          end
+        end
+      end
+
+      def attrs_ok?
+        return_value = true
+        unless @description.is_a? String
+          Origen.log.error("Test attribute 'description' must be a String!")
+          return_value = false
+        end
+        return_value
+      end
+    end
+  end
+end

--- a/spec/power_supplies_spec.rb
+++ b/spec/power_supplies_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+# Some dummy classes to test out the PowerSupplies module
+class SoC_With_Supplies
+  include Origen::TopLevel
+
+  def initialize
+    add_power_supply :vdd do |supply|
+      supply.description = 'CPU'
+    end
+    add_power_supply :vdda do |supply|
+      supply.description = 'PLL'
+    end
+    add_power_supply :vddsoc do |supply|
+      supply.description = 'SoC'
+    end
+  end
+  
+end
+
+describe "Power Supplies" do
+
+  before :each do
+    Origen.app.unload_target!
+    Origen.target.temporary = -> { SoC_With_Supplies.new }
+    Origen.load_target
+  end
+  
+  after :all do
+    Origen.app.unload_target!
+  end
+
+  it "can create and interact with power supplies" do
+    dut.power_supplies.should == [:vdd, :vdda, :vddsoc]
+    dut.power_supplies.size.should == 3
+    dut.supplies.size.should == 3
+    dut.supplies(:vdd).description.should == 'CPU'
+    dut.supplies(:vdd).specs.size.should == 3
+  end
+
+end


### PR DESCRIPTION
This should prove useful if and when an ATE levels API gets added to origen_testers.  When pins are added to the DUT, each can be assigned a :supply attribute.  I expect the PowerSupplies module will grow over time ti support things such as:

~~~ruby
dut.supplies(:vdd).pins # => [:pinA, :pinB]
dut.supplies(:vdd).has_pin? :pinA # => true
~~~

The PowerSupply initialization automatically creates 3 spec limits that are :min, :nom, :max (all are empty).  I am not really sure if I want to use a spec limit to store the actual power supply limits or not so feedback is welcome (they could just be straight accessors instead).