### PR TITLE
Fixed power_domain inspect output for some cases

### DIFF
--- a/lib/origen/power_domains/power_domains_collection.rb
+++ b/lib/origen/power_domains/power_domains_collection.rb
@@ -9,11 +9,11 @@ module Origen
         output_power_domain_list = []
         column_widths = {}.tap do |colhash|
           each do |domain_name, domain|
-            output_attr_list = []
+            output_attr_list = {}
             domain.instance_variables.each do |attr|
               attr_getter = attr.to_s[/\@(\S+)/, 1].to_sym
               attr_val = domain.send attr_getter
-              next unless [String, Numeric, Float, Integer, Symbol].include? attr_val.class
+              next unless [String, Numeric, Float, Integer, Symbol, Range].include? attr_val.class
               headers << attr_getter unless headers.include?(attr_getter)
               str = case attr_val
               when Numeric
@@ -29,7 +29,7 @@ module Origen
               if colhash[attr].nil? || (colhash[attr] < curr_longest)
                 colhash[attr] = curr_longest
               end
-              output_attr_list << str
+              output_attr_list[attr_getter] = str
             end
             output_power_domain_list << output_attr_list
           end
@@ -38,13 +38,13 @@ module Origen
           puts '╔' + column_widths.values.each.map { |i| '═' * i }.join('╤') + '╗'
           puts '║' + headers.each_with_index.map { |col_val, i| " #{col_val} ".ljust(column_widths.values[i]) }.join('│') + '║'
           puts '╟' + column_widths.values.each.map { |i| '─' * i }.join('┼') + '╢'
-          puts output_power_domain_list.each.map { |attributes| '║' + attributes.each_with_index.map { |value, attr_idx| " #{value} ".ljust(column_widths.values[attr_idx]) }.join('│') + '║' }
+          puts output_power_domain_list.each.map { |attributes| '║' + headers.each_with_index.map { |value, attr_idx| " #{attributes[value]} ".ljust(column_widths.values[attr_idx]) }.join('│') + '║' }
           puts '╚' + column_widths.values.each.map { |i| '═' * i }.join('╧') + '╝'
         else
           puts '.' + column_widths.values.each.map { |i| '-' * i }.join('-') + '.'
           puts '|' + headers.each_with_index.map { |col_val, i| " #{col_val} ".ljust(column_widths.values[i]) }.join('|') + '|'
           puts '|' + column_widths.values.each.map { |i| '-' * i }.join('+') + '|'
-          puts output_power_domain_list.each.map { |attributes| '|' + attributes.each_with_index.map { |value, attr_idx| " #{value} ".ljust(column_widths.values[attr_idx]) }.join('|') + '|' }
+          puts output_power_domain_list.each.map { |attributes| '|' + headers.each_with_index.map { |value, attr_idx| " #{attributes[value]} ".ljust(column_widths.values[attr_idx]) }.join('|') + '|' }
           puts '`' + column_widths.values.each.map { |i| '-' * i }.join('-') + '\''
         end
       end


### PR DESCRIPTION
The original printer portion of the inspect function assumes that all of the power domains have the same list of attributes to print out.  If any one of the attributes are missing, you could get glitches in the output.  This PR corrects that.  I've also added back in the voltage range attribute which was incorrectly excluded.

Here's an example of the original output were two of the domains are missing the setpoint attribute.
![image](https://user-images.githubusercontent.com/31351815/31446246-8790860a-ae65-11e7-8820-68e9e182852d.png)

Here's the corrected output
![image](https://user-images.githubusercontent.com/31351815/31446096-56abdee0-ae65-11e7-92ab-3498b47b2520.png)
