### PR TITLE
Fix regression manager's use of bundle exec

### DIFF
--- a/lib/origen/regression_manager.rb
+++ b/lib/origen/regression_manager.rb
@@ -73,14 +73,25 @@ module Origen
                     system 'bundle install --gemfile Gemfile --binstubs lbin --path ~/.origen/gems/' # this needs to be executed as 'origen -v' does not seem to handle it on its own.
                     system 'origen -v' # Let origen handle the gems installation and bundler setup.
                   else
-                    system 'bundle exec origen -v'
-                    system 'bundle install' # Make sure bundle updates the necessary config/gems required for Origen.
+                    if Origen.site_config.gem_manage_bundler
+                      system 'origen -v'
+                      system 'bundle install' # Make sure bundle updates the necessary config/gems required for Origen.
+                      system 'origen m debug'
+                    else
+                      system 'bundle install' # Make sure bundle updates the necessary config/gems required for Origen.
+                      system 'bundle exec origen -v'
+                      system 'origen m debug'
+                    end
                   end
                   Origen.log.info '######################################################'
                   Origen.log.info 'running regression command in reference workspace...'
                   Origen.log.info '######################################################'
                   Origen.log.info
-                  system 'bundle exec origen regression'
+                  if Origen.site_config.gem_manage_bundler
+                    system 'origen regression'
+                  else
+                    system 'bundle exec origen regression'
+                  end
                 end
               end
             end


### PR DESCRIPTION
I couldn't get the regression manager to work in one of my apps, I suspect probably related to some relatively recent changes to the Origen boot process.

Anyway, these changes fixed it.

It's basically removing the regression manger's use of `bundle exec` when launching origen commands whenever Origen is in charge of bundler (should be the case in 99-100% of apps).
Not sure why it used `bundle exec` originally, but the way it is now aligns to how you would invoke origen directly from the command line.
