### PR TITLE
Changed PowerDomain.voltage_range to unit_voltage_range because it…

### DIFF
--- a/lib/origen/core_ext/string.rb
+++ b/lib/origen/core_ext/string.rb
@@ -55,8 +55,17 @@ class String
   # Sanitizes the string for conversion to a symbol and returns a lower
   # cased symbol version of the string
   def symbolize
+    orig_had_leading_underscore = match(/^\_/) ? true : false
+    orig_had_trailing_underscore = match(/\_$/) ? true : false
+    new_str = gsub(/(\?|\!|\-|\/|\\|\n|\s|\(|\)|\.|\[|\]|-|{|})/, '_').downcase
+    # Get rid of adjacent underscores
+    new_str.match(/\_\_/) ? new_str = new_str.squeeze('_') : new_str
+    new_str.chomp!('_') unless orig_had_trailing_underscore
+    unless orig_had_leading_underscore
+      new_str = new_str[1..-1] if new_str.match(/^\_/)
+    end
     @@symbolize ||= {}
-    @@symbolize[self] ||= gsub(/(\?|\!|\-|\/|\\|\n|\s|\(|\)|\.|\[|\]|-|{|})/, '_').downcase.to_sym
+    @@symbolize[self] ||= new_str.to_sym
   end
 
   # acronyms

--- a/lib/origen/power_domains/power_domain.rb
+++ b/lib/origen/power_domains/power_domain.rb
@@ -1,7 +1,7 @@
 module Origen
   module PowerDomains
     class PowerDomain
-      attr_accessor :id, :description, :voltage_range, :nominal_voltage, :setpoint
+      attr_accessor :id, :description, :nominal_voltage_range, :nominal_voltage, :setpoint
 
       # Generic Power Domain Name
       # This is the power supply that can be blocked off to multiple power supplies
@@ -112,15 +112,15 @@ module Origen
       alias_method :value, :setpoint
 
       # Acceptable voltage range
-      def voltage_range
-        @voltage_range
+      def nominal_voltage_range
+        @nominal_voltage_range
       end
-      alias_method :range, :voltage_range
+      alias_method :nom_range, :nominal_voltage_range
 
       # Setter for setpoint
       def setpoint=(val)
         unless setpoint_ok?(val)
-          Origen.log.warn("Setpoint (#{setpoint_string(val)}) for power domain '#{name}' is not within the voltage range (#{voltage_range_string})!")
+          Origen.log.warn("Setpoint (#{setpoint_string(val)}) for power domain '#{name}' is not within the voltage range (#{nominal_voltage_range_string})!")
         end
         @setpoint = val
       end
@@ -128,9 +128,9 @@ module Origen
       # Checks if the setpoint is valid
       def setpoint_ok?(val = nil)
         if val.nil?
-          voltage_range.include?(setpoint) ? true : false
+          nominal_voltage_range.include?(setpoint) ? true : false
         else
-          voltage_range.include?(val) ? true : false
+          nominal_voltage_range.include?(val) ? true : false
         end
       end
       alias_method :value_ok?, :setpoint_ok?
@@ -182,20 +182,20 @@ module Origen
       def voltages_ok?
         if nominal_voltage.nil?
           false
-        elsif voltage_range == :fixed
+        elsif nominal_voltage_range == :fixed
           true
-        elsif voltage_range.nil?
+        elsif nominal_voltage_range.nil?
           Origen.log.error("PPEKit: Missing voltage range for power domain '#{name}'!")
           false
-        elsif voltage_range.is_a? Range
-          if voltage_range.include?(nominal_voltage)
+        elsif nominal_voltage_range.is_a? Range
+          if nominal_voltage_range.include?(nominal_voltage)
             true
           else
-            Origen.log.error("PPEKit: Nominal voltage #{nominal_voltage} is not inbetween the voltage range #{voltage_range} for power domain '#{name}'!")
+            Origen.log.error("PPEKit: Nominal voltage #{nominal_voltage} is not inbetween the voltage range #{nominal_voltage_range} for power domain '#{name}'!")
             false
           end
         else
-          Origen.log.error("Power domain attribute 'voltage_range' must be a Range or set to the value of :fixed!")
+          Origen.log.error("Power domain attribute 'nominal_voltage_range' must be a Range or set to the value of :fixed!")
           return_value = false
         end
       end

--- a/spec/power_domains_spec.rb
+++ b/spec/power_domains_spec.rb
@@ -27,19 +27,18 @@ class SoC_With_Domains
     add_power_domain :vdd do |domain|
       domain.description = 'CPU'
       domain.nominal_voltage = 1.0.V
-      domain.nominal_voltage_range = 0.7.V..1.1.V
+      domain.unit_voltage_range = 0.7.V..1.1.V
       domain.display_names(Nokogiri::XML::DocumentFragment.parse 'OV<sub>DD</sub>')
     end
     add_power_domain :vdda do |domain|
       domain.description = 'PLL'
       domain.nominal_voltage = 1.2.V
-      domain.nominal_voltage_range = 1.08.V..1.32.V
+      domain.unit_voltage_range = 1.08.V..1.32.V
       domain.display_names(Nokogiri::XML::DocumentFragment.parse 'AV<sub>DD</sub>')
     end
     add_power_domain :vccsoc do |domain|
       domain.description = 'SoC'
       domain.nominal_voltage = 1.5.V
-      domain.nominal_voltage_range = 1.35.V..1.65.V
       domain.display_names(Nokogiri::XML::DocumentFragment.parse 'VDD')
     end
   end
@@ -63,9 +62,10 @@ describe "Power domains" do
     dut.power_domains.size.should == 3
     dut.power_domains(:vdd).description.should == 'CPU'
     dut.power_domains(:vdd).nom.should == 1.0.V
-    dut.power_domains(:vdd).nom_range.should == (0.7.V..1.1.V)
+    dut.power_domains(:vdd).unit_voltage_range.should == (0.7.V..1.1.V)
     dut.power_domains(:vdd).setpoint.should == nil
     dut.power_domains(:vdda).setpoint.should == nil
+    dut.power_domains(:vccsoc).unit_voltage_range.should == :fixed
     dut.power_domains(:vccsoc).setpoint.should == nil
     dut.power_domains(:vccsoc).nominal_voltage.should == 1.5.V
     dut.power_domains(:vccsoc).setpoint_to_nominal

--- a/spec/power_domains_spec.rb
+++ b/spec/power_domains_spec.rb
@@ -27,19 +27,19 @@ class SoC_With_Domains
     add_power_domain :vdd do |domain|
       domain.description = 'CPU'
       domain.nominal_voltage = 1.0.V
-      domain.voltage_range = 0.7.V..1.1.V
+      domain.nominal_voltage_range = 0.7.V..1.1.V
       domain.display_names(Nokogiri::XML::DocumentFragment.parse 'OV<sub>DD</sub>')
     end
     add_power_domain :vdda do |domain|
       domain.description = 'PLL'
       domain.nominal_voltage = 1.2.V
-      domain.voltage_range = 1.08.V..1.32.V
+      domain.nominal_voltage_range = 1.08.V..1.32.V
       domain.display_names(Nokogiri::XML::DocumentFragment.parse 'AV<sub>DD</sub>')
     end
     add_power_domain :vccsoc do |domain|
       domain.description = 'SoC'
       domain.nominal_voltage = 1.5.V
-      domain.voltage_range = 1.35.V..1.65.V
+      domain.nominal_voltage_range = 1.35.V..1.65.V
       domain.display_names(Nokogiri::XML::DocumentFragment.parse 'VDD')
     end
   end
@@ -63,7 +63,7 @@ describe "Power domains" do
     dut.power_domains.size.should == 3
     dut.power_domains(:vdd).description.should == 'CPU'
     dut.power_domains(:vdd).nom.should == 1.0.V
-    dut.power_domains(:vdd).range.should == (0.7.V..1.1.V)
+    dut.power_domains(:vdd).nom_range.should == (0.7.V..1.1.V)
     dut.power_domains(:vdd).setpoint.should == nil
     dut.power_domains(:vdda).setpoint.should == nil
     dut.power_domains(:vccsoc).setpoint.should == nil

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -76,4 +76,13 @@ describe String do
     "0x1234".is_verilog_number?.should == false
     "12".is_verilog_number?.should == false
   end
+  
+  specify 'it does not add adjacent underscores, trailing underscores, or leading underscores (unless they previously existed) when symbolizing' do
+    "Example String".symbolize.should == :example_string
+    "Example  String".symbolize.should == :example_string
+    "Example  String ".symbolize.should == :example_string
+    "_ Example  String ".symbolize.should == :_example_string
+    " Example  String _".symbolize.should == :example_string_
+    "_ Example  String _".symbolize.should == :_example_string_
+  end
 end


### PR DESCRIPTION
… really refers to the range a unit could be fused to a specific value based on power/performance.  The PowerDomain class still needs to integrate spec limits that would handle the full range.  If anyone else has a better name for this attribute pls join the conversation.