### PR TITLE
Added in support for evaluating spec formulas that reference a power …

### DIFF
--- a/lib/origen/model.rb
+++ b/lib/origen/model.rb
@@ -175,6 +175,12 @@ module Origen
       if @current_mode
         return _modes[@current_mode] if _modes[@current_mode]
         fail "The mode #{@current_mode} of #{self.class} has not been defined!"
+      else
+        unless top_level?
+          if parent.current_mode
+            _modes[parent.current_mode.id] if _modes.include? parent.current_mode.id
+          end
+        end
       end
     end
     alias_method :mode, :current_mode

--- a/lib/origen/model.rb
+++ b/lib/origen/model.rb
@@ -177,8 +177,10 @@ module Origen
         fail "The mode #{@current_mode} of #{self.class} has not been defined!"
       else
         unless top_level?
-          if parent.current_mode
-            _modes[parent.current_mode.id] if _modes.include? parent.current_mode.id
+          # Need to do this in case a class besides SubBlock includes Origen::Model
+          obj_above_self = parent.nil? ? Origen.top_level : parent
+          if obj_above_self.current_mode
+            _modes[obj_above_self.current_mode.id] if _modes.include? obj_above_self.current_mode.id
           end
         end
       end

--- a/lib/origen/specs/checkers.rb
+++ b/lib/origen/specs/checkers.rb
@@ -72,13 +72,46 @@ module Origen
       end
 
       def evaluate_limit(limit)
-        return limit if [Fixnum, Float, Numeric, Symbol].include? limit.class
+        return limit if [Fixnum, Float, Numeric].include? limit.class
         return nil if limit.nil?
         limit = limit.to_s if [Nokogiri::XML::NodeSet, Nokogiri::XML::Text, Nokogiri::XML::Element].include? limit.class
-        limit.gsub!("\n", ' ')
-        limit.scrub!
+        if limit.is_a? Symbol
+          limit = ':' + limit.to_s
+        else
+          limit.gsub!("\n", ' ')
+          limit.scrub!
+        end
         result = false
-        if !!(limit.match(/^\d+\.\d+$/)) || !!(limit.match(/^-\d+\.\d+$/))
+        if limit.match(/\:\S+/)
+          limit_items = limit.split(/\:|\s+/).reject(&:empty?)
+          references = limit.split(/\:|\s+/).select { |var| var.match(/^[a-zA-Z]\S+$/) }
+          new_limit_items = [].tap do |limit_ary|
+            limit_items.each do |item|
+              if references.include? item
+                # See if the limit is referencing a power domain, this should be extended to clocks
+                # TODO: Expand limit references to check Origen::Clocks
+                if Origen.top_level.respond_to? :power_domains
+                  if Origen.top_level.power_domains.include? item.to_sym
+                    limit_ary << Origen.top_level.power_domains(item.to_sym).nominal_voltage
+                  else
+                    limit_ary << item
+                  end
+                else
+                  limit_ary << item
+                end
+              else
+                limit_ary << item
+              end
+            end
+          end
+          new_limit = new_limit_items.join(' ')
+          new_limit_references = new_limit.split(/\:|\s+/).select { |var| var.match(/^[a-zA-Z]\S+$/) }
+          if new_limit_references.empty?
+            result = eval(new_limit).round(4)
+          else
+            return limit
+          end
+        elsif !!(limit.match(/^\d+\.\d+$/)) || !!(limit.match(/^-\d+\.\d+$/))
           result = Float(limit).round(4) rescue false # Use the same four digits of accuracy as the Spec model
         elsif !!(limit.match(/\d+\.\d+\s+\d+\.\d+/)) # workaround for multiple specs authoring bug
           Origen.log.debug "Found two numbers without an operator in the limit string '#{limit}', choosing the first..."

--- a/lib/origen/specs/checkers.rb
+++ b/lib/origen/specs/checkers.rb
@@ -93,12 +93,16 @@ module Origen
                 if Origen.top_level.respond_to? :power_domains
                   if Origen.top_level.power_domains.include? item.to_sym
                     limit_ary << Origen.top_level.power_domains(item.to_sym).nominal_voltage
-                  else
-                    limit_ary << item
+                    next
                   end
-                else
-                  limit_ary << item
                 end
+                if Origen.top_level.respond_to? :clocks
+                  if Origen.top_level.clocks.include? item.to_sym
+                    limit_ary << Origen.top_level.clocks(item.to_sym).freq_target
+                    next
+                  end
+                end
+                limit_ary << item
               else
                 limit_ary << item
               end

--- a/spec/chipmode_spec.rb
+++ b/spec/chipmode_spec.rb
@@ -26,6 +26,10 @@ module ChipModeSpec
         reg :reg1, 0x100 do
           bits 31..0, :data
         end
+        add_mode :native do |m|
+          m.mem_freq = 0.8.Ghz
+          m.myclk = 133.Mhz
+        end
       end
     end
 
@@ -74,7 +78,7 @@ module ChipModeSpec
 
     it "can manipulate the sub_block modes" do
       t = Top.new
-      t.dcfg_dcsr.modes.count.should == 1
+      t.dcfg_dcsr.modes.count.should == 2
       t.dcfg_dcsr.mode = :rcw12
       t.dcfg_dcsr.mode.name.should == :rcw12
       t.dcfg_dcsr.mode.typ_voltage == 1.2
@@ -95,6 +99,18 @@ module ChipModeSpec
       t.dp_pmu1_dcsr.rst_dcsr.mode.data_rate(absolute_number: false).should == 1200
       t.dcfg_dcsr.mode = :rcw12
       t.dcfg_dcsr.mode.data_rate.should == 1.33e6
+    end
+    
+    it 'can pass the DUT mode to child IP by default (if defined)' do
+      t = Top.new
+      t.mode = :native
+      t.dcfg_dcsr.mode.id.should == :native
+      t.dcfg_dcsr.mode.mem_freq.should == 0.8.Ghz
+      t.dcfg_dcsr.mode.myclk.should == 133.Mhz
+      t.dcfg_dcsr.mode = :rcw12
+      t.mode.id.should == :native
+      t.dcfg_dcsr.mode.id.should == :rcw12
+      t.dcfg_dcsr.mode.typ_voltage == 1.2
     end
   end
 end

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -5,15 +5,29 @@ class SoC_With_Specs
   include Origen::TopLevel
 
   def initialize
+    add_clock :core_clk do |c|
+      c.users =           [:cores]
+      c.freq_target =     1.2.Ghz
+      c.freq_range =      1.0.Ghz..1.4.Ghz
+    end
     add_power_domain :vmemio do |d|
       d.description = 'Memory IO Power Domain'
       d.nominal_voltage = 1.35.V
+    end
+    add_power_domain :voffset do |d|
+      d.description = 'Fake power supply that is used for spec testing'
+      d.nominal_voltage = 0.25.V
     end
     sub_block :ip_with_specs, class_name: "IP_With_Specs", base_address: 0x1000_0000
     sub_block :ip_without_specs, class_name: "IP_WithOut_Specs", base_address: 0xDEAD_BEEF
     add_mode :default, description: "Nominal power/performance binned device"
     add_mode :low_power, description: "Low power binned device"
     add_mode :high_performance, description: "High performance binned device"
+    spec :fmin, :ac do |s|
+      s.symbol "Fmin"
+      s.description = "Frequency Min"
+      s.min = ":core_clk * 0.9"
+    end
     spec :memio_voh, :dc do |s|
       s.symbol "Voh"
       s.description = "Output high voltage"
@@ -23,6 +37,11 @@ class SoC_With_Specs
       s.symbol "DirectRefSpec"
       s.description = "Check for the case where a spec formula references a Symbol"
       s.max = :vmemio
+    end
+    spec :memio_voh_offset, :dc do |s|
+      s.symbol "Voh_offset"
+      s.description = "Output high voltage with offset"
+      s.max = ":vmemio * 0.8 - :voffset"
     end
     modes.each do |mode|
       case mode
@@ -224,7 +243,7 @@ describe "Origen Specs Module" do
   end
 
   it "can see top level specs" do
-    @dut.specs.size.should == 10
+    @dut.specs.size.should == 12
     @dut.modes.should == [:default, :low_power, :high_performance, :no_specs_defined]
     @dut.mode = :no_specs_defined
     @dut.specs(:soc_vdd).should == nil # Returns nil because @dut.mode is set to :no_specs_defined
@@ -473,6 +492,15 @@ describe "Origen Specs Module" do
     @dut.specs(:memio_voh).max.value.should == 1.08
     @dut.specs(:direct_ref_spec).max.exp.should == :vmemio
     @dut.specs(:direct_ref_spec).max.value.should == 1.35
+    @dut.power_domains(:voffset).nominal_voltage.should == 0.25
+    @dut.specs(:memio_voh_offset).max.exp.should == ":vmemio * 0.8 - :voffset"
+    @dut.specs(:memio_voh_offset).max.value.should == 0.83
+  end
+  
+  it 'can evaluate references to clocks' do
+    @dut.clocks(:core_clk).freq_target.should == 1.2.Ghz
+    @dut.specs(:fmin).min.exp.should == ":core_clk * 0.9"
+    @dut.specs(:fmin).min.value.should == 1.08.Ghz
   end
     
 end

--- a/spec/specs_spec.rb
+++ b/spec/specs_spec.rb
@@ -5,11 +5,25 @@ class SoC_With_Specs
   include Origen::TopLevel
 
   def initialize
+    add_power_domain :vmemio do |d|
+      d.description = 'Memory IO Power Domain'
+      d.nominal_voltage = 1.35.V
+    end
     sub_block :ip_with_specs, class_name: "IP_With_Specs", base_address: 0x1000_0000
     sub_block :ip_without_specs, class_name: "IP_WithOut_Specs", base_address: 0xDEAD_BEEF
     add_mode :default, description: "Nominal power/performance binned device"
     add_mode :low_power, description: "Low power binned device"
     add_mode :high_performance, description: "High performance binned device"
+    spec :memio_voh, :dc do |s|
+      s.symbol "Voh"
+      s.description = "Output high voltage"
+      s.max = ":vmemio * 0.8"
+    end
+    spec :direct_ref_spec, :dc do |s|
+      s.symbol "DirectRefSpec"
+      s.description = "Check for the case where a spec formula references a Symbol"
+      s.max = :vmemio
+    end
     modes.each do |mode|
       case mode
       when :default
@@ -210,7 +224,7 @@ describe "Origen Specs Module" do
   end
 
   it "can see top level specs" do
-    @dut.specs.size.should == 8
+    @dut.specs.size.should == 10
     @dut.modes.should == [:default, :low_power, :high_performance, :no_specs_defined]
     @dut.mode = :no_specs_defined
     @dut.specs(:soc_vdd).should == nil # Returns nil because @dut.mode is set to :no_specs_defined
@@ -451,6 +465,14 @@ describe "Origen Specs Module" do
     tmp_vh.external_changes_internal.should == false
     tmp_vh.changes.class.should == Hash
     tmp_vh.changes.should == {internal: 'Change with internal comments', external: 'For external customers'}
+  end
+  
+  it 'can evaluate references to power domains' do
+    @dut.power_domains(:vmemio).nominal_voltage.should == 1.35
+    @dut.specs(:memio_voh).max.exp.should == ":vmemio * 0.8"
+    @dut.specs(:memio_voh).max.value.should == 1.08
+    @dut.specs(:direct_ref_spec).max.exp.should == :vmemio
+    @dut.specs(:direct_ref_spec).max.value.should == 1.35
   end
     
 end


### PR DESCRIPTION
…domain.  only took 4 years to get this working!

~~~ruby
  it 'can evaluate references to power domains' do
    @dut.power_domains(:vmemio).nominal_voltage.should == 1.35
    @dut.specs(:memio_voh).max.exp.should == ":vmemio * 0.8"
    @dut.specs(:memio_voh).max.value.should == 1.08
    @dut.specs(:direct_ref_spec).max.exp.should == :vmemio
    @dut.specs(:direct_ref_spec).max.value.should == 1.35
  end

  it 'can evaluate references to clocks' do
    @dut.clocks(:core_clk).freq_target.should == 1.2.Ghz
    @dut.specs(:fmin).min.exp.should == ":core_clk * 0.9"
    @dut.specs(:fmin).min.value.should == 1.08.Ghz
  end
~~~ #