### PR TITLE
Add block write!/read! ability to allow for better coding style for bit manipulations.

### DIFF
--- a/lib/origen/registers.rb
+++ b/lib/origen/registers.rb
@@ -597,6 +597,10 @@ module Origen
     end
     alias_method :regs, :reg
 
+    def wreg(reg)
+      yield reg
+    end
+
     private
 
     def match_registers(regex)

--- a/lib/origen/registers.rb
+++ b/lib/origen/registers.rb
@@ -597,10 +597,6 @@ module Origen
     end
     alias_method :regs, :reg
 
-    def wreg(reg)
-      yield reg
-    end
-
     private
 
     def match_registers(regex)

--- a/lib/origen/registers/bit_collection.rb
+++ b/lib/origen/registers/bit_collection.rb
@@ -523,7 +523,7 @@ module Origen
       def read!(value = nil, options = {})
         yield @reg if block_given?
         value, options = nil, value if value.is_a?(Hash)
-        read(value, options) if !block_given?
+        read(value, options) unless block_given?
         # launch a read reg
         @reg.request(:read_register, options)
         self

--- a/lib/origen/registers/bit_collection.rb
+++ b/lib/origen/registers/bit_collection.rb
@@ -502,14 +502,16 @@ module Origen
         result.to_s
       end
 
-      # Write the bit value on silicon<br>
+      # Write the bit value on silicon.
       # This method will update the data value of the bits and then call $top.write_register
-      # passing the owngin register as the first argument.<br>
+      # passing the owning register as the first argument.
       # This method is expected to handle writing the current state of the register to silicon.
       def write!(value = nil, options = {})
         value, options = nil, value if value.is_a?(Hash)
         write(value, options) if value
-        yield @reg if block_given?
+        if block_given?
+          yield size == @reg.size ? @reg : self
+        end
         @reg.request(:write_register, options)
         self
       end
@@ -521,10 +523,11 @@ module Origen
       #   reg(:data).read!         # Read register :data, expecting whatever value it currently holds
       #   reg(:data).read!(0x5555) # Read register :data, expecting 0x5555
       def read!(value = nil, options = {})
-        yield @reg if block_given?
         value, options = nil, value if value.is_a?(Hash)
         read(value, options) unless block_given?
-        # launch a read reg
+        if block_given?
+          yield size == @reg.size ? @reg : self
+        end
         @reg.request(:read_register, options)
         self
       end

--- a/lib/origen/registers/bit_collection.rb
+++ b/lib/origen/registers/bit_collection.rb
@@ -509,6 +509,7 @@ module Origen
       def write!(value = nil, options = {})
         value, options = nil, value if value.is_a?(Hash)
         write(value, options) if value
+        yield @reg if block_given?
         @reg.request(:write_register, options)
         self
       end
@@ -520,8 +521,9 @@ module Origen
       #   reg(:data).read!         # Read register :data, expecting whatever value it currently holds
       #   reg(:data).read!(0x5555) # Read register :data, expecting 0x5555
       def read!(value = nil, options = {})
+        yield @reg if block_given?
         value, options = nil, value if value.is_a?(Hash)
-        read(value, options)
+        read(value, options) if !block_given?
         # launch a read reg
         @reg.request(:read_register, options)
         self

--- a/spec/reg_spec.rb
+++ b/spec/reg_spec.rb
@@ -1351,17 +1351,17 @@ module RegTest
                                        :w       => { :pos => 3 }
       reg(:blregtest).data.should == 0x0
       reg(:blregtest).write! do |r|
-      	r.bits(:y).write(1)
-      	r.bits(:x).write(0x2)
-      	r.bits(:w).write(1)
+        r.bits(:y).write(1)
+        r.bits(:x).write(0x2)
+        r.bits(:w).write(1)
       end
       reg(:blregtest).data.should == 0xD
-	  reg(:blregtest).read! do |r|
-      	r.bits(:y).read
+      reg(:blregtest).read! do |r|
+        r.bits(:y).read
       end      
       reg(:blregtest).bits(:y).is_to_be_read?.should == true
       reg(:blregtest).bits(:x).is_to_be_read?.should == false
-	  reg(:blregtest).bits(:w).is_to_be_read?.should == false
+      reg(:blregtest).bits(:w).is_to_be_read?.should == false
     end
 
     it "write method can override a read-only register bitfield with :force = true" do

--- a/spec/reg_spec.rb
+++ b/spec/reg_spec.rb
@@ -1356,6 +1356,13 @@ module RegTest
         r.bits(:w).write(1)
       end
       reg(:blregtest).data.should == 0xD
+
+      reg(:blregtest).write(0)
+      reg(:blregtest).x.write! do |b|
+        b[1].write(1)
+      end
+      reg(:blregtest).data.should == 0b0100
+
       reg(:blregtest).read! do |r|
         r.bits(:y).read
       end      

--- a/spec/reg_spec.rb
+++ b/spec/reg_spec.rb
@@ -1345,17 +1345,23 @@ module RegTest
       o.respond_to?(:reg2).should == false
     end
 
-    specify "wreg method can set bits" do
-      add_reg :wregtest,   0x00,  4,  :y       => { :pos => 0},
+    specify "block read/write method can set/read bits" do
+      add_reg :blregtest,   0x00,  4,  :y       => { :pos => 0},
                                        :x       => { :pos => 1, :bits => 2 },
                                        :w       => { :pos => 3 }
-      reg(:wregtest).data.should == 0x0
-      wreg(reg(:wregtest)) do |r|
+      reg(:blregtest).data.should == 0x0
+      reg(:blregtest).write! do |r|
       	r.bits(:y).write(1)
       	r.bits(:x).write(0x2)
       	r.bits(:w).write(1)
       end
-      reg(:wregtest).data.should == 0xD
+      reg(:blregtest).data.should == 0xD
+	  reg(:blregtest).read! do |r|
+      	r.bits(:y).read
+      end      
+      reg(:blregtest).bits(:y).is_to_be_read?.should == true
+      reg(:blregtest).bits(:x).is_to_be_read?.should == false
+	  reg(:blregtest).bits(:w).is_to_be_read?.should == false
     end
 
     it "write method can override a read-only register bitfield with :force = true" do

--- a/spec/reg_spec.rb
+++ b/spec/reg_spec.rb
@@ -1345,6 +1345,18 @@ module RegTest
       o.respond_to?(:reg2).should == false
     end
 
+    specify "wreg method can set bits" do
+      add_reg :wregtest,   0x00,  4,  :y       => { :pos => 0},
+                                       :x       => { :pos => 1, :bits => 2 },
+                                       :w       => { :pos => 3 }
+      wreg(reg(:wregtest)) do |r|
+      	r.bits(:y).write(1)
+      	r.bits(:x).write(0x2)
+      	r.bits(:w).write(1)
+      end
+      reg(:wregtest).data.should == 0xD
+    end
+
     it "write method can override a read-only register bitfield with :force = true" do
         reg :reg, 0x0, 32, description: 'reg' do
             bits 7..0,   :field1, reset: 0x0, access: :rw

--- a/spec/reg_spec.rb
+++ b/spec/reg_spec.rb
@@ -1349,6 +1349,7 @@ module RegTest
       add_reg :wregtest,   0x00,  4,  :y       => { :pos => 0},
                                        :x       => { :pos => 1, :bits => 2 },
                                        :w       => { :pos => 3 }
+      reg(:wregtest).data.should == 0x0
       wreg(reg(:wregtest)) do |r|
       	r.bits(:y).write(1)
       	r.bits(:x).write(0x2)


### PR DESCRIPTION
This pull request intends to add a method to provide for better coding style when dealing with large numbers of bit manipulations within a register.  These manipulations can be hard to read, and error prone when '!' is in play.

Previous code style:
```
  $dut.mtr.mct.reg(:bstart).bits(:bstart).write(0x4) # Program BIST but don't start them
  $dut.mtr.mct.reg(:bstart).bits(:cens).write(1) 
  $dut.mtr.mct.reg(:bstart).bits(:cenac).write(1)
  $dut.mtr.mct.reg(:bstart).bits(:brst).write(1)
  $dut.mtr.mct.reg(:bstart).bits(:cof).write(1)
  $dut.mtr.mct.reg(:bstart).bits(:clken).write(1)
  $dut.mtr.mct.reg(:bstart).write!
```
New coding style:
```
  $dut.wreg($dut.mtr.mct.reg(:bstart)) do |r|
    r.bits(:cens).write(1) 
    r.bits(:cenac).write(1)
    r.bits(:brst).write(1)
    r.bits(:cof).write(1)
    r.bits(:clken).write(1)
  end
  $dut.mtr.mct.reg(:bstart).write!
```
