### PR TITLE
Added in package scoped DIB metadata to Origen::Pins::Pin

### DIFF
--- a/lib/origen/pins/pin.rb
+++ b/lib/origen/pins/pin.rb
@@ -9,7 +9,7 @@ module Origen
 
       # Any attributes listed here will be looked up for the current package context
       # before falling back to a default
-      PACKAGE_SCOPED_ATTRIBUTES = [:location, :dib_assignment]
+      PACKAGE_SCOPED_ATTRIBUTES = [:location, :dib_assignment, :dib_meta]
 
       # Pin Types
       TYPES = [:analog, :digital]
@@ -74,6 +74,7 @@ module Origen
         @value = 0
         @clock = nil
         @meta = options[:meta] || {}
+        @dib_meta = options[:dib_meta] || {}
         on_init(owner, options)
         # Assign the initial state from the method so that any inversion is picked up...
         send(@reset)
@@ -420,6 +421,18 @@ module Origen
       end
       alias_method :add_dib_info, :add_dib_assignment
       alias_method :add_channel, :add_dib_assignment
+
+      def add_dib_meta(pkg, options)
+        unless Origen.top_level.packages.include? pkg
+          Origen.log.error("Cannot add DIB metadata for package '#{pkg}', that package has not been added yet!")
+          fail
+        end
+        options.each do |attr, attr_value|
+          packages[pkg][:dib_meta] ||= {}
+          packages[pkg][:dib_meta][attr] = attr_value
+          add_alias attr_value.to_s.symbolize, package: pkg, mode: :all, configuration: :all
+        end
+      end
 
       # Returns the number of test sites enabled for the pin
       def sites

--- a/lib/origen/power_domains/power_domain.rb
+++ b/lib/origen/power_domains/power_domain.rb
@@ -195,6 +195,7 @@ module Origen
           s.min = min
           s.typ = nominal_voltage
           s.max = max
+          s.unit = 'V'
         end
       end
 

--- a/spec/pins_v3_spec.rb
+++ b/spec/pins_v3_spec.rb
@@ -1012,6 +1012,20 @@ describe "Origen Pin API v3" do
     $dut.pins(:pinx).respond_to?(:a).should == true
   end
   
+  it 'add DIB metadata based on package scope' do
+    $dut.add_package :pcs
+    $dut.add_package :bga
+    $dut.add_pin :tdo, packages: { bga: { location: 'BF32', dib_assignment: [10104] }, pcs: { location: 'BF30', dib_assignment: [31808] } }
+    $dut.pins(:tdo).add_dib_meta :pcs, { :x=>2000, :y=>-15600, :net_name=>"R92/DUT_TDO_TC", :connection=>"PE118.16", :slot=>"PE118", :spring_pin=>"16" }
+    $dut.pins(:tdo).add_dib_meta :bga, { :x=>2000.0, :y=>-15600.0, :net_name=>"TDO", :connection=>"PE117.08", :slot=>"PE117", :spring_pin=>"08" }
+    $dut.package = nil
+    $dut.pins(:tdo).dib_meta.should == {}
+    $dut.package = :bga
+    $dut.pins(:tdo).dib_meta.should == { :x=>2000.0, :y=>-15600.0, :net_name=>"TDO", :connection=>"PE117.08", :slot=>"PE117", :spring_pin=>"08" }
+    $dut.package = :pcs
+    $dut.pins(:tdo).dib_meta.should == { :x=>2000, :y=>-15600, :net_name=>"R92/DUT_TDO_TC", :connection=>"PE118.16", :slot=>"PE118", :spring_pin=>"16" }
+  end
+  
   it 'does not allow user to set the current DUT package unless it is to a known package' do
     Origen.app.unload_target!
     @dut = IncorrectPackageDut.new

--- a/templates/web/guides/models/pins.md.erb
+++ b/templates/web/guides/models/pins.md.erb
@@ -440,6 +440,18 @@ has_pin?(:a2)              # => false
 has_pin?(:a3)              # => true
 ~~~
 
+Certain types of metadata only become available at distinct times in a product lifecycle, for example Device Interface Board (DIB) information.
+Depending on when the pin model is constructed the user can specify the DIB metadata in two ways:
+
+~~~ruby
+# All at once
+$dut.add_pin :tdi, packages: { bga: { location: 'BF2', dib_meta: { channel: 100106, connection: "PE117.08", slot: "PE117", spring_pin: "08" } } }
+
+# Over time
+$dut.add_pin :tdi, packages: { bga: { location: 'BF2' } }
+$dut.pins(:tdi).add_dib_meta :bga, { channel: 100106, connection: "PE117.08", slot: "PE117", spring_pin: "08" }
+~~~
+
 #### Pin Functions
 
 Pin aliases are an example of modelling different pin functions that can be mux'd onto the same pin, in this case


### PR DESCRIPTION
~~~ruby
  it 'add DIB metadata based on package scope' do
    $dut.add_package :pcs
    $dut.add_package :bga
    $dut.add_pin :tdo, packages: { bga: { location: 'BF32', dib_assignment: [10104] }, pcs: { location: 'BF30', dib_assignment: [31808] } }
    $dut.pins(:tdo).add_dib_meta :pcs, { :net_name=>"/DUT_TDO_TC", :connection=>"PE118.16", :slot=>"PE118", :spring_pin=>"16" }
    $dut.pins(:tdo).add_dib_meta :bga, { :x=>2000.0, :y=>-15600.0, :net_name=>"TDO", :connection=>"PE117.08", :slot=>"PE117", :spring_pin=>"08" }
    $dut.package = nil
    $dut.pins(:tdo).dib_meta.should == {}
    $dut.package = :bga
    $dut.pins(:tdo).dib_meta.should == {:net_name=>"TDO", :connection=>"PE117.08", :slot=>"PE117", :spring_pin=>"08" }
    $dut.package = :pcs
    $dut.pins(:tdo).dib_meta.should == { :net_name=>"R92/DUT_TDO_TC", :connection=>"PE118.16", :slot=>"PE118", :spring_pin=>"16" }
  end
~~~