### PR TITLE
bug fix

### DIFF
--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -56,7 +56,7 @@ module Origen
         elsif FALSE_VALUES.include?(val)
           return false
         end
-        config
+        val
       else
         config = configs.find { |c| c.key?(val) }
         config ? config[val] : nil

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -34,4 +34,15 @@ describe "Origen.site_config" do
       Origen.site_config.gem_manage_bundler.should == true
     end
   end
+  
+  it "allows user overrides" do
+    with_env_variable("ORIGEN_USER_GEM_DIR", "C:\test\path") do
+      ENV["ORIGEN_USER_GEM_DIR"].should == "C:\test\path"
+      Origen.site_config.gem_install_dir.should == "C:\test\path"
+    end
+    with_env_variable("ORIGEN_USER_INSTALL_DIR", "~/other/path") do
+      ENV["ORIGEN_USER_INSTALL_DIR"].should == "~/other/path"
+      Origen.site_config.user_install_dir.should == "~/other/path"
+    end
+  end
 end


### PR DESCRIPTION
This change causes the environment variable string to be returned by find_val if it exists and is not a true or false value.  Without this update the following line always returns nil forcing the gem_install_dir elsewhere:
https://github.com/Origen-SDK/origen/blob/3c71e2b7a3f137a53f032b205f901d50827a6ce8/lib/origen/site_config.rb#L14