### PR TITLE
Updated gems to include greater than 1.7.2 for nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       log4r (~> 1.1.10, ~> 1.1)
       nanoc (~> 3.7)
       net-ldap (~> 0.13)
-      nokogiri (= 1.7.2)
+      nokogiri (>= 1.7.2)
       pry (~> 0.10)
       rake (~> 10)
       rspec (~> 3)
@@ -176,4 +176,4 @@ DEPENDENCIES
   ripper-tags
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-ldap", "~>0.13"
   spec.add_runtime_dependency "httparty", "~>0.13"
   spec.add_runtime_dependency "bundler", "~>1.7"
-  spec.add_runtime_dependency "nokogiri", "1.7.2"
+  spec.add_runtime_dependency "nokogiri", ">= 1.7.2"
   spec.add_runtime_dependency "rspec", "~>3"
   spec.add_runtime_dependency "rspec-legacy_formatters", "~>1"
   spec.add_runtime_dependency "thor", "~>0.19"

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -32,6 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-ldap", "~>0.13"
   spec.add_runtime_dependency "httparty", "~>0.13"
   spec.add_runtime_dependency "bundler", "~>1.7"
+  # @welguisz ... If your application depends on 1.7.2 and doesn't work with 
+  # anything later than 1.7.2, add the following line into your Gemfile
+  # gem 'nokogiri', '1.7.2'
   spec.add_runtime_dependency "nokogiri", ">= 1.7.2"
   spec.add_runtime_dependency "rspec", "~>3"
   spec.add_runtime_dependency "rspec-legacy_formatters", "~>1"


### PR DESCRIPTION
When I upgraded to 2.4, nokogiri would not install.  I made a small change to get my app to install.