### PR TITLE
Fix for #186

### DIFF
--- a/lib/origen/application.rb
+++ b/lib/origen/application.rb
@@ -755,6 +755,7 @@ END
       options = {
         force_debug: false
       }.merge(options)
+      @on_create_called = false
       if options[:reload]
         @target_load_count = 0
       else
@@ -785,6 +786,7 @@ END
         @target_instantiated = true
         Origen.mode = :debug if options[:force_debug]
         listeners_for(:on_create).each(&:on_create)
+        @on_create_called = true
         # Keep this within the load_event to ensure any objects that are further instantiated objects
         # will be associated with (and cleared out upon reload of) the current target
         listeners_for(:on_load_target).each(&:on_load_target)
@@ -792,6 +794,11 @@ END
       listeners_for(:after_load_target).each(&:after_load_target)
       Origen.app.plugins.validate_production_status
       # @target_instantiated = true
+    end
+
+    # Returns true if the on_create callback has already been called during a target load
+    def on_create_called?
+      !!@on_create_called
     end
 
     # Not a clean unload, but allows objects to be re-instantiated for testing

--- a/lib/origen/callbacks.rb
+++ b/lib/origen/callbacks.rb
@@ -9,6 +9,11 @@ module Origen
 
     def register_callback_listener # :nodoc:
       Origen.app.add_callback_listener(self)
+      # If this object has been instantiated after on_create has already been called,
+      # then invoke it now
+      if Origen.app.on_create_called?
+        on_create if respond_to?(:on_create)
+      end
     end
   end
 

--- a/spec/sub_block_spec.rb
+++ b/spec/sub_block_spec.rb
@@ -340,6 +340,31 @@ module SubBlocksSpec
         $dut.sub1.x.should == 5
         $dut.sub1.y.should == 10
       end
+
+      it 'on_create callbacks in sub_block models get called' do
+        class TopLevel
+          include Origen::TopLevel
+
+          def initialize
+            sub_block :sub1, class_name: "Sub1"
+          end
+        end
+
+        class Sub1
+          include Origen::Model
+          attr_reader :on_create_called
+
+          def on_create
+            on_create_called = true
+          end
+        end
+
+        Origen.app.unload_target!
+        Origen.target.temporary = -> { TopLevel.new }
+        Origen.load_target
+
+        dut.sub1.on_create_called.should == true
+      end
     end
   end
 end

--- a/spec/sub_block_spec.rb
+++ b/spec/sub_block_spec.rb
@@ -355,7 +355,7 @@ module SubBlocksSpec
           attr_reader :on_create_called
 
           def on_create
-            on_create_called = true
+            @on_create_called = true
           end
         end
 

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -46,7 +46,7 @@ registered when the application creates a new instance of <code>CallbackHandlers
 If an instance is never created then the callbacks implemented in that class will never be
 called.
 
-This is particularly true of any objects that are defined [as sub-blocks](<%= path "guides/models/defining/#Adding_Sub_Blocks") %>
+This is particularly true of any objects that are defined [as sub-blocks](<%= path "guides/models/defining/#Adding_Sub_Blocks" %>)
 since the sub-block is not actually instantiated until the point where it is first referenced
 by an application.
 

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -46,6 +46,18 @@ registered when the application creates a new instance of <code>CallbackHandlers
 If an instance is never created then the callbacks implemented in that class will never be
 called.
 
+This is particularly true of any objects that are defined [as sub-blocks](<%= path "guides/models/defining/#Adding_Sub_Blocks") %>
+since the sub-block is not actually instantiated until the point where it is first referenced
+by an application.
+
+<div class="alert alert-warning">
+  <strong>Note!</strong> One exception to the above rule is the <code>on_create</code> callback.
+  Since this is commonly used as a delayed version of initialize, Origen will invoke that method
+  at the point when the listener object is instantiated if the <code>on_create</code> callbacks
+  have already been called.
+</div>
+
+
 #### Persistent Listeners
 
 By default the pool of listeners is cleared out before a target load and they will be replaced


### PR DESCRIPTION
The previous implementation of sub_blocks instantiated the objects straight away, which meant that they were always listening for callbacks after the target was loaded.

Since sub_blocks are now lazy-loaded this is no longer the case. 

I think the new approach is vastly preferable, however there is not really any way to have the best of both worlds where they are instantiated only when required but are also actively listening for callbacks before then.
I've added some documentation to make the new behavior clearer and I don't think this should really be a problem for applications to deal with.

I have added one exception case for the `on_create` callback, since this is intended to be used as a replacement for `initialize` which can be used to init a model with the guarantee that the target is fully loaded.
With this update, any callback listener which is instantiated after the target has already loaded (i.e. it has missed the `on_create` callbacks being invoked) will have its `on_create` method invoked immediately.


