### PR TITLE
More fixes for #186

### DIFF
--- a/lib/origen/model_initializer.rb
+++ b/lib/origen/model_initializer.rb
@@ -47,6 +47,11 @@ module Origen
         is_top_level = x.respond_to?(:includes_origen_top_level?)
         if x.respond_to?(:wrap_in_controller)
           x = x.wrap_in_controller
+          # If this object has been instantiated after on_create has already been called,
+          # then invoke it now
+          if Origen.application_loaded? && Origen.app.on_create_called?
+            x.controller.on_create if x.controller.respond_to?(:on_create)
+          end
         end
         if is_top_level
           Origen.app.listeners_for(:on_top_level_instantiated, top_level: false).each do |listener|

--- a/spec/sub_block_spec.rb
+++ b/spec/sub_block_spec.rb
@@ -359,11 +359,26 @@ module SubBlocksSpec
           end
         end
 
+        class Sub1Controller
+          include Origen::Controller
+          attr_reader :controller_on_create_called
+
+          def wrapped?
+            true
+          end
+
+          def on_create
+            @controller_on_create_called = true
+          end
+        end
+
         Origen.app.unload_target!
         Origen.target.temporary = -> { TopLevel.new }
         Origen.load_target
 
         dut.sub1.on_create_called.should == true
+        dut.sub1.wrapped?.should == true
+        dut.sub1.controller_on_create_called.should == true
       end
     end
   end


### PR DESCRIPTION
This is a further patch for #186 

Controllers are not explicitly registered as callback listeners, but they do work like one since their responsible model listens and that will proxy any requests for callback methods that are implemented by the controller.

The previous update for #186 means that any model which implemented on_create will have that called when it is instantiated, but it did not account for the fact that a controller could have one too.

This update adds the same on_create exception for controllers.
