### PR TITLE
Added global app instance when running outside an app

### DIFF
--- a/lib/origen/application/runner.rb
+++ b/lib/origen/application/runner.rb
@@ -228,14 +228,16 @@ module Origen
         # submitted the job.
         Origen.file_handler.set_output_directory(options.merge(create: Origen.running_locally?))
         Origen.file_handler.set_reference_directory(options.merge(create: Origen.running_locally?))
-        tmp = "#{Origen.root}/tmp"
-        FileUtils.mkdir(tmp) unless File.exist?(tmp)
-        if Origen.running_locally?
-          mkdir Origen::Log.log_file_directory
-          mkdir "#{Origen.root}/.lsf"
-        end
-        if options[:lsf]
-          mkdir Origen.app.lsf_manager.log_file_directory
+        unless Origen.running_globally?
+          tmp = "#{Origen.root}/tmp"
+          FileUtils.mkdir(tmp) unless File.exist?(tmp)
+          if Origen.running_locally?
+            mkdir Origen::Log.log_file_directory
+            mkdir "#{Origen.root}/.lsf"
+          end
+          if options[:lsf]
+            mkdir Origen.app.lsf_manager.log_file_directory
+          end
         end
       end
 

--- a/lib/origen/commands/version.rb
+++ b/lib/origen/commands/version.rb
@@ -1,2 +1,2 @@
-puts "Application: #{Origen.app.version}" if Origen.app_loaded?
+puts "Application: #{Origen.app.version}" if Origen.app_loaded? && !Origen.running_globally?
 puts "     Origen: #{Origen.version}"

--- a/lib/origen/commands_global.rb
+++ b/lib/origen/commands_global.rb
@@ -25,6 +25,12 @@ if ENV['BUNDLE_GEMFILE']
   Bundler.require(:default)
 end
 
+# Load the global app and an empty target, this helps to ensure that all of Origen's functionality
+# is available to global commands, since many features implicitly assume the presence of an app
+Origen.app
+Origen.target.temporary = -> {}
+Origen.load_target
+
 # Get a list of registered plugins and get the global launcher
 @global_launcher = Origen._applications_lookup[:name].map do |plugin_name, plugin|
   shared = plugin.config.shared || {}

--- a/lib/origen/global_app.rb
+++ b/lib/origen/global_app.rb
@@ -1,0 +1,9 @@
+class OrigenGlobalApplication < Origen::Application
+  config.output_directory do
+    "#{Origen.root}/origen"
+  end
+
+  config.reference_directory do
+    "#{Origen.root}/origen/.ref"
+  end
+end

--- a/lib/origen/log.rb
+++ b/lib/origen/log.rb
@@ -35,7 +35,7 @@ module Origen
     end
 
     def console_only?
-      self.class.console_only? || !Origen.app
+      self.class.console_only? || !Origen.app || Origen.running_globally?
     end
 
     # Anything executed within the given block will log to the console only


### PR DESCRIPTION
Historically, Origen has been in a very feature limited mode when running outside of an application workspace, where it has only really provided the ability to create a new application.

With the addition of [global plugin commands](http://origen-sdk.org/origen/guides/plugins/creating/#Sharing_Global_Commands), and the concept of [centrally maintained Origen plugin bundles](http://origen-sdk.org/origen/guides/advanced/invocations/#Site_Config_For_Toolset_Installations), it is going to be more common to see plugins provide functionality that can be invoked anywhere and which might not depend on the concept of a current application.

However, many of Origen's core functionality expects an application to be present, whether it is really needed or not, and many things don't work when they are invoked from a global command.

This update adds the following changes to how Origen boots when outside of an application workspace, and it should mean that all Origen functionality now becomes available to global command creators:

* `Origen.app` will return an application instance, called the global app
* `Origen.root` will return the directory from where the `origen` command was invoked
* `Origen.config.output_directory` is set to `"#{Origen.root}/origen"`, so by convention any global commands which create output will place it in a sub-directory named `origen` relative to where it has been launched from (unless the specific command provides alternative arrangements).
* An empty target will be loaded


