### PR TITLE
Fix for #192 (Constant bundle install when invoking under user Origen env)

### DIFF
--- a/bin/origen
+++ b/bin/origen
@@ -43,6 +43,7 @@ else
   end
 end
 
+# If running inside an application workspace
 if origen_root
   # Force everyone to have a consistent way of installing gems with bundler
   ENV['BUNDLE_GEMFILE'] = File.join(origen_root, 'Gemfile')
@@ -58,6 +59,8 @@ if origen_root
   end
   
   boot_app = true
+
+# If running outside an application and a user or central tool Origen bundle is to be used
 elsif Origen.site_config.gem_manage_bundler && (Origen.site_config.user_install_enable || Origen.site_config.tool_repo_install_dir)
   # Force everyone to have a consistent way of installing gems with bundler.
   # In this case, we aren't running from an Origen application, so build everything at Origen.home instead
@@ -91,8 +94,17 @@ elsif Origen.site_config.gem_manage_bundler && (Origen.site_config.user_install_
   ENV['BUNDLE_GEMFILE'] = gemfile
   ENV['BUNDLE_PATH'] = File.expand_path(Origen.site_config.gem_install_dir)
   ENV['BUNDLE_BIN'] = File.join(origen_root, 'lbin')
-  
-  boot_app = false
+
+  origen_exec = File.join(ENV['BUNDLE_BIN'], 'origen')
+
+  # If the user/tool bundle already exists but we have not been invoked through that, abort this thread
+  # and re-launch under the required bundler environment
+  if File.exist?(origen_exec) && !ENV['BUNDLE_BIN_PATH'] && File.exist?(ENV['BUNDLE_PATH'])
+    exec Gem.ruby, origen_exec, *ARGV
+    exit 0
+  else
+    boot_app = false
+  end
 end
 
 if origen_root && File.exist?(ENV['BUNDLE_GEMFILE']) && Origen.site_config.gem_manage_bundler && (boot_app || Origen.site_config.user_install_enable || Origen.site_config.tool_repo_install_dir)


### PR DESCRIPTION
When a user install is in play, a Gem bundle gets created in the location pointed to by `site_config.user_install_dir`.

This creates an `origen` executable at `#{site_config.user_install_dir}/lbin/origen` and when Origen is invoked through that it will execute under the context of the gem bundle defined by `#{site_config.user_install_dir}/Gemfile`.

Normally, users of Origen don't need to worry about that too much, since we recommend that they add `./lbin` to their path, so when they type `origen` at the command line it is invoked in the context of their app's gem bundle.
Even if they happen to invoke some other `origen` executable, the bin script contains some logic to automagically re-launch Origen under the correct bundle environment.

Such code does not exist in the bin script branch concerned with booting a user or tool install env, and this could lead to bundler gem version conflict errors which resulted in Origen taking a long way round to correct it by re-bundling each time.

This change adds the same patch to re-direct to the bundled version of `origen` if it happens to be invoked from an origen executable which is outwith the scope of the user/tool env, which will probably be the case most of time under such an environment setup.

