### PR TITLE
Relief for your OCD

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -86,7 +86,7 @@ unless defined? RGen::ORIGENTRANSITION
       # Uniformly justifies the given help command line for display in a command line help output
       def clean_help_line(str)
         if str =~ /^\s\s\s\s\s\s\s*(.*)/
-          puts((' ' * 20) + Regexp.last_match(1))
+          (' ' * 20) + Regexp.last_match(1)
         # http://rubular.com/r/MKmU4xZgO2
         elsif str =~ /^\s*([^\s]+)\s+*(.*)/
           ' ' + Regexp.last_match(1).ljust(19) + Regexp.last_match(2)

--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -83,6 +83,18 @@ unless defined? RGen::ORIGENTRANSITION
     class << self
       include Origen::Utility::TimeAndDate
 
+      # Uniformly justifies the given help command line for display in a command line help output
+      def clean_help_line(str)
+        if str =~ /^\s\s\s\s\s\s\s*(.*)/
+          puts((' ' * 20) + Regexp.last_match(1))
+        # http://rubular.com/r/MKmU4xZgO2
+        elsif str =~ /^\s*([^\s]+)\s+*(.*)/
+          ' ' + Regexp.last_match(1).ljust(19) + Regexp.last_match(2)
+        else
+          str
+        end
+      end
+
       def enable_profiling
         @profiling = true
       end

--- a/lib/origen/commands.rb
+++ b/lib/origen/commands.rb
@@ -275,11 +275,9 @@ The core origen commands are:
   cmds.split(/\n/).each do |line|
     puts Origen.clean_help_line(line)
   end
+  puts
   if @application_commands && !@application_commands.empty?
-    puts <<-EOT
-
-In addition to these the application has added:
-EOT
+    puts 'In addition to these the application has added:'
     @application_commands.split(/\n/).each do |line|
       puts Origen.clean_help_line(line)
     end
@@ -295,15 +293,14 @@ EOT
   end
 
   if @global_launcher && !@global_launcher.empty?
-    puts ''
     puts 'The following global commands are provided by plugins:'
     @global_commands.each do |str|
       puts Origen.clean_help_line(str)
     end
+    puts
   end
 
   puts <<-EOT
-
 All commands can be run with -d (or --debugger) to enable the debugger.
 All commands can be run with --coverage to enable code coverage.
 Many commands can be run with -h (or --help) for more information.

--- a/lib/origen/commands.rb
+++ b/lib/origen/commands.rb
@@ -253,6 +253,8 @@ else
 Usage: origen COMMAND [ARGS]
 
 The core origen commands are:
+  EOT
+  cmds = <<-EOT
  environment  Display or set the environment (short-cut alias: "e")
  target       Display or set the target (short-cut alias: "t")
  mode         Display or set the mode (short-cut alias: "m")
@@ -269,27 +271,34 @@ The core origen commands are:
  web          Web page tools, see -h for details
  time         Tools for test time analysis and forecasting
  lint         Lint and style check (and correct) your application code
-
   EOT
+  cmds.split(/\n/).each do |line|
+    puts Origen.clean_help_line(line)
+  end
   if @application_commands && !@application_commands.empty?
     puts <<-EOT
+
 In addition to these the application has added:
-#{@application_commands}
 EOT
+    @application_commands.split(/\n/).each do |line|
+      puts Origen.clean_help_line(line)
+    end
+    puts
   end
 
   if @plugin_commands && !@plugin_commands.empty?
     puts 'The following commands are provided by plugins:'
     @plugin_commands.each do |str|
-      puts str
+      puts Origen.clean_help_line(str)
     end
+    puts
   end
 
   if @global_launcher && !@global_launcher.empty?
     puts ''
     puts 'The following global commands are provided by plugins:'
     @global_commands.each do |str|
-      puts str
+      puts Origen.clean_help_line(str)
     end
   end
 

--- a/lib/origen/commands.rb
+++ b/lib/origen/commands.rb
@@ -278,24 +278,30 @@ The core origen commands are:
   puts
   if @application_commands && !@application_commands.empty?
     puts 'In addition to these the application has added:'
-    @application_commands.split(/\n/).each do |line|
-      puts Origen.clean_help_line(line)
+    @application_commands.split(/\n/).each do |cmds|
+      cmds.split(/\n/).each do |line|
+        puts Origen.clean_help_line(line)
+      end
     end
     puts
   end
 
   if @plugin_commands && !@plugin_commands.empty?
     puts 'The following commands are provided by plugins:'
-    @plugin_commands.each do |str|
-      puts Origen.clean_help_line(str)
+    @plugin_commands.each do |cmds|
+      cmds.split(/\n/).each do |line|
+        puts Origen.clean_help_line(line)
+      end
     end
     puts
   end
 
   if @global_launcher && !@global_launcher.empty?
     puts 'The following global commands are provided by plugins:'
-    @global_commands.each do |str|
-      puts Origen.clean_help_line(str)
+    @global_commands.each do |cmds|
+      cmds.split(/\n/).each do |line|
+        puts Origen.clean_help_line(line)
+      end
     end
     puts
   end

--- a/lib/origen/commands_global.rb
+++ b/lib/origen/commands_global.rb
@@ -96,17 +96,22 @@ else
 Usage: origen COMMAND [ARGS]
 
 The following commands are available:
+  EOT
+  cmds = <<-EOT
  new          Create a new Origen application or plugin. "origen new my_app" creates a
               new origen application workspace in "./my_app"
  interactive  Start an interactive Origen console (short-cut alias: "i"), this is just
               IRB with the 'origen' lib loaded automatically
   EOT
+  cmds.split(/\n/).each do |line|
+    puts Origen.clean_help_line(line)
+  end
 
   if @global_launcher && !@global_launcher.empty?
     puts ''
     puts 'The following global commands are provided by plugins:'
     @global_commands.each do |str|
-      puts str
+      puts Origen.clean_help_line(str)
     end
   end
 

--- a/lib/origen/commands_global.rb
+++ b/lib/origen/commands_global.rb
@@ -106,20 +106,18 @@ The following commands are available:
   cmds.split(/\n/).each do |line|
     puts Origen.clean_help_line(line)
   end
-
+  puts
   if @global_launcher && !@global_launcher.empty?
-    puts ''
     puts 'The following global commands are provided by plugins:'
     @global_commands.each do |str|
       puts Origen.clean_help_line(str)
     end
+    puts
   end
 
   puts <<-EOT
-
 Many commands can be run with -h (or --help) for more information.
+
   EOT
-  # fetch        Automatically creates the workspace for the requested plugin and
-  #              populates the latest version of the plugin (short-cut alias: "f")
   exit 0
 end

--- a/lib/origen/commands_global.rb
+++ b/lib/origen/commands_global.rb
@@ -109,8 +109,10 @@ The following commands are available:
   puts
   if @global_launcher && !@global_launcher.empty?
     puts 'The following global commands are provided by plugins:'
-    @global_commands.each do |str|
-      puts Origen.clean_help_line(str)
+    @global_commands.each do |cmds|
+      cmds.split(/\n/).each do |line|
+        puts Origen.clean_help_line(line)
+      end
     end
     puts
   end


### PR DESCRIPTION
No longer grimace at mis-aligned command summaries:

~~~
[nxa21353@acv0145 origen]$ origen
Usage: origen COMMAND [ARGS]

The core origen commands are:
 environment        Display or set the environment (short-cut alias: "e")
 target             Display or set the target (short-cut alias: "t")
 mode               Display or set the mode (short-cut alias: "m")
 plugin             Display or set the plugin (short-cut alias: "pl")
 generate           Generate a test pattern (short-cut alias: "g")
 program            Generate a test program (short-cut alias: "p")
 interactive        Start an interactive Origen console (short-cut alias: "i")
 compile            Compile a template file or directory (short-cut alias: "c")
 exec               Execute any Ruby file with access to your app environment

 rc                 Revision control commands, see -h for details
 save               Save the new or changed files from the last run or a given log file
 lsf                Monitor and manage LSF jobs (short-cut alias: "l")
 web                Web page tools, see -h for details
 time               Tools for test time analysis and forecasting
 lint               Lint and style check (and correct) your application code

In addition to these the application has added:
 specs              Run the specs (unit tests), -c will enable coverage
 examples           Run the examples (acceptance tests), -c will enable coverage
 test               Run both specs and examples, -c will enable coverage
 regression         Test the regression manager (runs a subset of examples)
 tags               Generate ctags for this app

The following commands are provided by plugins:
 core_support:test  Test command from plugin core_support plugin
 testers:build      Build a test program from a collection of sub-programs
 testers:run        Run the last test program generated for the current target


All commands can be run with -d (or --debugger) to enable the debugger.
All commands can be run with --coverage to enable code coverage.
Many commands can be run with -h (or --help) for more information.
~~~