### PR TITLE
Windows doesn't all directory names with ':'

### DIFF
--- a/lib/origen/application/deployer.rb
+++ b/lib/origen/application/deployer.rb
@@ -63,8 +63,7 @@ module Origen
         @git_repo ||= begin
           local_path = "#{Origen.config.web_directory.gsub('/', '-').symbolize}"
           local_path.gsub!(':', '-') if Origen.os.windows?
-          local_path = "#{Origen.app.workspace_manager.imports_directory}/git/#{local_path}"
-          local = Pathname.new(local_path)
+          local = Pathname.new("#{Origen.app.workspace_manager.imports_directory}/git/#{local_path}")
           if git_sub_dir
             remote = Origen.config.web_directory.sub("\/#{git_sub_dir}", '')
           else

--- a/lib/origen/application/deployer.rb
+++ b/lib/origen/application/deployer.rb
@@ -61,7 +61,7 @@ module Origen
       # which is will build and checkout as required
       def git_repo
         @git_repo ||= begin
-          local = Pathname.new("#{Origen.app.workspace_manager.imports_directory}/git/#{Origen.config.web_directory.gsub('/', '-').symbolize}")
+          local = Pathname.new("#{Origen.app.workspace_manager.imports_directory}/git/#{Origen.config.web_directory.gsub('/', '-').gsub(':', '-').symbolize}")
           if git_sub_dir
             remote = Origen.config.web_directory.sub("\/#{git_sub_dir}", '')
           else

--- a/lib/origen/application/deployer.rb
+++ b/lib/origen/application/deployer.rb
@@ -61,7 +61,10 @@ module Origen
       # which is will build and checkout as required
       def git_repo
         @git_repo ||= begin
-          local = Pathname.new("#{Origen.app.workspace_manager.imports_directory}/git/#{Origen.config.web_directory.gsub('/', '-').gsub(':', '-').symbolize}")
+          local_path = "#{Origen.config.web_directory.gsub('/', '-').symbolize}"
+          local_path.gsub!(':', '-') if Origen.os.windows?
+          local_path = "#{Origen.app.workspace_manager.imports_directory}/git/#{local_path}"
+          local = Pathname.new(local_path)
           if git_sub_dir
             remote = Origen.config.web_directory.sub("\/#{git_sub_dir}", '')
           else


### PR DESCRIPTION
This fixes a run time error when running 'origen web compile -r'.  The 'DO NOT HAND MODIFY' directory that gets created previously had a ':' in the name which fails to get created on Windows.