### PR TITLE
Express global commands

### DIFF
--- a/lib/origen/commands_global.rb
+++ b/lib/origen/commands_global.rb
@@ -23,6 +23,19 @@ if ENV['BUNDLE_GEMFILE']
   Bundler.require(:development)
   Bundler.require(:runtime)
   Bundler.require(:default)
+else
+  # If we're not running from a Bundler build, which we aren't here,
+  # get a list of installed system gems. Go through this list finding and get any that has a dependency
+  # on Origen. If so, assume that gem is a plugin.
+  # For all plugins, require it to register as a plugin.
+  # The global handler below will take it from there.
+  Gem::Specification.each do |gem|
+    gem.dependencies.each do |d|
+      if d.name == 'origen'
+        require gem.name
+      end
+    end
+  end
 end
 
 # Load the global app and an empty target, this helps to ensure that all of Origen's functionality

--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -16,16 +16,16 @@ module Origen
       else
         path = eval_path(find_val('user_gem_dir') || find_val('gem_install_dir') || home_dir)
       end
-      
+
       append = find_val('append_gems')
-      append = 'gems' if (append == true || append.nil?)
-      
+      append = 'gems' if append == true || append.nil?
+
       if append
-        if !path.end_with?(append)
+        unless path.end_with?(append)
           path = File.join(path, append)
         end
       end
-      path      
+      path
     end
     alias_method :user_gem_dir, :gem_install_dir
 
@@ -37,31 +37,31 @@ module Origen
     def home_dir
       eval_path(find_val('home_dir') || '~/')
     end
-    
+
     def eval_path(path, options = {})
       # Expand the first path. This will take care of replacing any leading ~/ with the home directory.
-      if path.start_with?("\\")
+      if path.start_with?('\\')
         path[0] = ''
       else
         path = File.expand_path(path)
       end
-      
+
       # Gsub the remaining ~ that aren't escaped.
       # If it was escaped, eat the escape character
       path.gsub!(/(?<!\\|\A)~/, "#{Etc.getlogin}")
       path.gsub!(/\\(?=~)/, '')
-      
+
       append = find_val('append_dot_origen')
-      append = '.origen' if (append == true || append.nil?)
-      
+      append = '.origen' if append == true || append.nil?
+
       if append
-        if !path.end_with?(append)
+        unless path.end_with?(append)
           path = File.join(path, append)
         end
       end
       path
     end
-    
+
     # Dynamically remove the highest instance of :var
     def remove_highest(var)
       @configs.each do |c|
@@ -69,18 +69,18 @@ module Origen
           return c.delete(var)
         end
       end
-      
+
       # return nil if we haven't returned a value yet
       nil
     end
-    
+
     # Dynamically remove all the instances of :var
     def remove_all_instances(var)
       # Iterate though all the site configs, removing every instance of :var
       # Return an array containing the value of :var at each config,
       # from lowest priority to highest.
       # If [] is returned, it implies that there was no instancs of :var to be removed.
-      ret = Array.new
+      ret = []
       @configs.each do |c|
         if c.key?(var)
           ret << c.delete(var)
@@ -89,28 +89,28 @@ module Origen
       ret
     end
     alias_method :purge, :remove_all_instances
-    
+
     # Dynamically add a new site variable at the highest priority.
     def add_as_highest(var, value)
       # Don't want to override anything, so just shift in a dummy site config instance at the highest level and
       # set the value there.
-      configs.prepend({var.to_s => value})
+      configs.prepend(var.to_s => value)
     end
     alias_method :[]=, :add_as_highest
-    
+
     # Dynamically add a new site variable at the lowest priority.
     # Essentially, this sets a new default value.
     def add_as_lowest(var, value)
       # Don't want to override anything, so just shift in a dummy site config at the lowest level and
       # set the value there.
-      configs.append({var.to_s => value})
+      configs.append(var.to_s => value)
     end
 
     # Adds a new site config file as the highest priority
     def add_site_config_as_highest(site_config_file)
       configs.prepend YAML.load_file(File.expand_path('../../../origen_site_config.yml', __FILE__))
     end
-    
+
     # Adds a new site config file as the highest priority
     def add_site_config_as_lowest(site_config_file)
       configs.append YAML.load_file(File.expand_path('../../../origen_site_config.yml', __FILE__))
@@ -138,9 +138,9 @@ module Origen
       find_val(val)
     end
     alias_method :[], :get
-    
+
     def get_all(val)
-      ret = Array.new
+      ret = []
       @configs.each do |c|
         if c.key?(val)
           ret << c[val]
@@ -156,7 +156,7 @@ module Origen
     def rebuild!
       configs!
     end
-    
+
     private
 
     def find_val(val, options = {})
@@ -168,7 +168,7 @@ module Origen
         config = configs.find { |c| c.key?(val) }
         value = config ? config[val] : nil
       end
-      
+
       if TRUE_VALUES.include?(value)
         return true
       elsif FALSE_VALUES.include?(value)
@@ -180,7 +180,7 @@ module Origen
     def configs
       @configs ||= configs!
     end
-    
+
     # Forces a reparse of the site configs.
     def configs!
       @configs = begin
@@ -223,7 +223,6 @@ module Origen
         configs
       end
     end
-    
   end
 
   def self.site_config

--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -2,6 +2,7 @@ module Origen
   class SiteConfig
     require 'pathname'
     require 'yaml'
+    require 'etc'
 
     TRUE_VALUES = ['true', 'TRUE', '1', 1]
     FALSE_VALUES = ['false', 'FALSE', '0', 0]
@@ -10,13 +11,109 @@ module Origen
 
     # Gets the gem_intall_dir. This is either site_config.home_dir/gems or the site configs gem_install_dir
     def gem_install_dir
-      return "#{tool_repo_install_dir}/gems" if gems_use_tool_repo && tool_repo_install_dir && !user_install_enable
-      find_val('user_gem_dir') || find_val('gem_install_dir') || "#{find_val('home_dir')}/gems"
+      if gems_use_tool_repo && tool_repo_install_dir && !user_install_enable
+        path = eval_path(tool_repo_install_dir)
+      else
+        path = eval_path(find_val('user_gem_dir') || find_val('gem_install_dir') || home_dir)
+      end
+      
+      append = find_val('append_gems')
+      append = 'gems' if (append == true || append.nil?)
+      
+      if append
+        if !path.end_with?(append)
+          path = File.join(path, append)
+        end
+      end
+      path      
     end
+    alias_method :user_gem_dir, :gem_install_dir
 
     # Gets the user_install_dir. Like gem_install_dir, this default to somewhere home_dir, unless overridden
     def user_install_dir
-      find_val('user_install_dir') || find_val('home_dir')
+      eval_path(find_val('user_install_dir') || home_dir)
+    end
+
+    def home_dir
+      eval_path(find_val('home_dir') || '~/')
+    end
+    
+    def eval_path(path, options = {})
+      # Expand the first path. This will take care of replacing any leading ~/ with the home directory.
+      if path.start_with?("\\")
+        path[0] = ''
+      else
+        path = File.expand_path(path)
+      end
+      
+      # Gsub the remaining ~ that aren't escaped.
+      # If it was escaped, eat the escape character
+      path.gsub!(/(?<!\\|\A)~/, "#{Etc.getlogin}")
+      path.gsub!(/\\(?=~)/, '')
+      
+      append = find_val('append_dot_origen')
+      append = '.origen' if (append == true || append.nil?)
+      
+      if append
+        if !path.end_with?(append)
+          path = File.join(path, append)
+        end
+      end
+      path
+    end
+    
+    # Dynamically remove the highest instance of :var
+    def remove_highest(var)
+      @configs.each do |c|
+        if c.key?(var)
+          return c.delete(var)
+        end
+      end
+      
+      # return nil if we haven't returned a value yet
+      nil
+    end
+    
+    # Dynamically remove all the instances of :var
+    def remove_all_instances(var)
+      # Iterate though all the site configs, removing every instance of :var
+      # Return an array containing the value of :var at each config,
+      # from lowest priority to highest.
+      # If [] is returned, it implies that there was no instancs of :var to be removed.
+      ret = Array.new
+      @configs.each do |c|
+        if c.key?(var)
+          ret << c.delete(var)
+        end
+      end
+      ret
+    end
+    alias_method :purge, :remove_all_instances
+    
+    # Dynamically add a new site variable at the highest priority.
+    def add_as_highest(var, value)
+      # Don't want to override anything, so just shift in a dummy site config instance at the highest level and
+      # set the value there.
+      configs.prepend({var.to_s => value})
+    end
+    alias_method :[]=, :add_as_highest
+    
+    # Dynamically add a new site variable at the lowest priority.
+    # Essentially, this sets a new default value.
+    def add_as_lowest(var, value)
+      # Don't want to override anything, so just shift in a dummy site config at the lowest level and
+      # set the value there.
+      configs.append({var.to_s => value})
+    end
+
+    # Adds a new site config file as the highest priority
+    def add_site_config_as_highest(site_config_file)
+      configs.prepend YAML.load_file(File.expand_path('../../../origen_site_config.yml', __FILE__))
+    end
+    
+    # Adds a new site config file as the highest priority
+    def add_site_config_as_lowest(site_config_file)
+      configs.append YAML.load_file(File.expand_path('../../../origen_site_config.yml', __FILE__))
     end
 
     def method_missing(method, *args, &block)
@@ -32,31 +129,61 @@ module Origen
         fail 'Missing site_config value!'
       end
       define_singleton_method(method) do
-        val
+        find_val(method)
       end
       val
     end
 
+    def get(val)
+      find_val(val)
+    end
+    alias_method :[], :get
+    
+    def get_all(val)
+      ret = Array.new
+      @configs.each do |c|
+        if c.key?(val)
+          ret << c[val]
+        end
+      end
+      ret
+    end
+
+    def clear
+      @configs.clear
+    end
+
+    def rebuild!
+      configs!
+    end
+    
     private
 
     def find_val(val, options = {})
       env = "ORIGEN_#{val.upcase}"
       if ENV.key?(env)
-        val = ENV[env]
-        if TRUE_VALUES.include?(val)
-          return true
-        elsif FALSE_VALUES.include?(val)
-          return false
-        end
-        val
+        value = ENV[env]
+        value
       else
         config = configs.find { |c| c.key?(val) }
-        config ? config[val] : nil
+        value = config ? config[val] : nil
       end
+      
+      if TRUE_VALUES.include?(value)
+        return true
+      elsif FALSE_VALUES.include?(value)
+        return false
+      end
+      value
     end
 
     def configs
-      @configs ||= begin
+      @configs ||= configs!
+    end
+    
+    # Forces a reparse of the site configs.
+    def configs!
+      @configs = begin
         # This global is set when Origen is first required, it generally means that what is considered
         # to be the pwd for the purposes of looking for a site_config file is the place from where the
         # user invoked Origen. Otherwise if the running app switches the PWD it can lead to confusing
@@ -96,6 +223,7 @@ module Origen
         configs
       end
     end
+    
   end
 
   def self.site_config

--- a/origen_site_config.yml
+++ b/origen_site_config.yml
@@ -21,12 +21,22 @@
 # user (recommended)
 gem_manage_bundler: true
 
-# Define where a typical user's home directory will be, with a hidden directory for Origen.
-home_dir: ~/.origen
+# WORKSPACE DIRECTORY SETUP
 
-# Define where the gems should be installed
-# By default, this will be at <home_dir>/gems but can be overridden here.
-#gem_install_dir: ~/.origen/gems
+# Defines where the home directory is
+#home_dir: ~/
+
+# Defines where the user customization directory is
+#user_install_dir:
+
+# Defines the gems are to be installed
+#user_gem_dir:
+
+# Indicates whether '.origen' should be appended to home_dir
+append_dot_origen: true
+
+# Indicates whether 'gems' should be appended to the user_gem_dir
+append_gems: true
 
 # ORIGEN STARTUP OPTIONS
 # These options define how and where Origen should boot.
@@ -35,9 +45,6 @@ home_dir: ~/.origen
 # By default, don't allow user install. This is more for power users to utilize for debug or those who want absolute 
 # control over their environment.
 user_install_enable: false
-
-# Default to the user's install dir being the .origen in their home directory but allow it to be overridden
-#user_install_dir: ~/.origen
 
 # Default 'tool_repo_install_dir' to nil, meaning no 'tool_repo_install_dir' is present. If neither this nor 
 # 'user_install_enable' is present, the universal install will be used.

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -1,19 +1,24 @@
 require 'spec_helper'
+require 'etc'
 
-describe "Origen.site_config" do
+fdescribe "Origen.site_config" do
 
   # Make sure that cached site config values don't affect these or the
   # next tests
-  before :each do
-    clear_site_config
-  end
-
-  after :all do
+  before :all do
     clear_site_config
   end
 
   def clear_site_config
-    Origen.instance_variable_set("@site_config", nil)
+    Origen.site_config.instance_variable_set('@configs', Array.new)
+  end
+
+  def username
+    Etc.getlogin
+  end
+  
+  def home
+    File.expand_path '~/'
   end
 
   def with_env_variable(var, value)
@@ -21,6 +26,14 @@ describe "Origen.site_config" do
     ENV[var] = value
     yield
     ENV[var] = orig
+  end
+
+  def add_config_variable(var, value)
+    Origen.site_config.instance_variable_get('@configs').prepend({var => value})
+  end
+  
+  def remove_config_variable(var)
+    Origen.site_config.remove_config_variable(var)
   end
 
   it "converts true/false values from environment variables to booleans" do
@@ -36,13 +49,430 @@ describe "Origen.site_config" do
   end
   
   it "allows user overrides" do
-    with_env_variable("ORIGEN_GEM_INSTALL_DIR", "C:\test\path") do
-      ENV["ORIGEN_GEM_INSTALL_DIR"].should == "C:\test\path"
-      Origen.site_config.gem_install_dir.should == "C:\test\path"
-    end
-    with_env_variable("ORIGEN_USER_INSTALL_DIR", "~/other/path") do
-      ENV["ORIGEN_USER_INSTALL_DIR"].should == "~/other/path"
-      Origen.site_config.user_install_dir.should == "~/other/path"
+    add_config_variable('test', 'test value')
+    Origen.site_config.test.should == 'test value'
+    
+    with_env_variable("ORIGEN_TEST", "Origen Test Value") do
+      ENV["ORIGEN_TEST"].should == "Origen Test Value"
+      Origen.site_config.test.should == "Origen Test Value"
     end
   end
+  
+  describe 'Site config as it relates to install directories' do
+    it 'has method :gem_install_dir (for legacy) aliased to method :user_gem_dir' do
+      expect(Origen.site_config.method(:gem_install_dir)).to eql(Origen.site_config.method(:user_gem_dir))
+    end
+    
+    context 'with default site config' do
+      before :context do
+        clear_site_config
+        
+        # Create a blank site config
+        Origen.site_config.home_dir
+        
+        # Remove the instances of home_dir, user_install_dir, user_gem_dir, and gem_install_dir
+        # that may be present in the user's site configs by default.
+        Origen.site_config.remove_all_instances('home_dir')
+        Origen.site_config.remove_all_instances('user_install_dir')
+        Origen.site_config.remove_all_instances('user_gem_dir')
+        Origen.site_config.remove_all_instances('gem_install_dir')
+      end
+      
+      after :context do
+        clear_site_config
+      end
+      
+      it 'sets home_dir to ~/ by default' do
+        expect(Origen.site_config.home_dir).to eql("#{home}/.origen")
+        expect(Origen.home).to eql("#{home}/.origen")
+      end
+      
+      it 'sets user_install_dir to /home/<username>/.origen by default' do
+        expect(Origen.site_config.user_install_dir).to eql("#{home}/.origen")
+      end
+      
+      it 'sets user_gem_dir to /home/<username>/.origen/gems by default' do
+        expect(Origen.site_config.user_gem_dir).to eql("#{home}/.origen/gems")
+      end
+    end
+    
+    context 'with overriden gem_install_dir' do
+      before :context do
+        add_config_variable('gem_install_dir', '/gem_location/')
+      end
+      
+      after :context do
+        clear_site_config
+      end
+      
+      it 'leaves home_dir as the default' do
+        expect(Origen.site_config.home_dir).to eql("#{home}/.origen")
+        expect(Origen.home).to eql("#{home}/.origen")
+      end
+      
+      it 'leaves the user_install_dir as the default' do
+        expect(Origen.site_config.user_install_dir).to eql("#{home}/.origen")
+      end
+      
+      it 'changes the user_gem_dir' do
+        expect(Origen.site_config.user_gem_dir).to eql("/gem_location/.origen/gems")
+      end
+    end
+    
+    context 'with overriden gem_install_dir AND overriden user_gem_dir' do
+      before :context do
+        add_config_variable('gem_install_dir', '/gem_location/')
+        add_config_variable('user_gem_dir', '/user_location')
+      end
+      
+      after :context do
+        clear_site_config
+      end
+    
+      it 'leaves home_dir as the default' do
+        expect(Origen.site_config.home_dir).to eql("#{home}/.origen")
+        expect(Origen.home).to eql("#{home}/.origen")
+      end
+      
+      it 'leaves the user_install_dir as the default' do
+        expect(Origen.site_config.user_install_dir).to eql("#{home}/.origen")
+      end
+      
+      it 'uses :user_gem_dir over :gem_install_dir' do
+        expect(Origen.site_config.user_gem_dir).to eql("/user_location/.origen/gems")
+      end
+    end
+    
+    context 'with overriden :user_gem_dir AND ENV variable ORIGEN_USER_GEM_DIR set' do
+      before :context do
+        add_config_variable('gem_install_dir', '/gem_location/')
+        add_config_variable('user_gem_dir', '/user_location')
+      end
+      
+      after :context do
+        clear_site_config
+      end
+      
+      it 'uses ORIGEN_USER_GEM_DIR over :user_gem_dir' do
+        with_env_variable 'ORIGEN_USER_GEM_DIR', '/user_env_location' do
+          expect(Origen.site_config.user_gem_dir).to eql("/user_env_location/.origen/gems")
+        end
+      end
+    end
+    
+    context 'with overriden :user_install_dir overrriden' do
+      before :context do
+        clear_site_config
+        
+        add_config_variable('user_install_dir', '/user/install/dir')
+      end
+      
+      it 'moves the :user_install_dir' do
+        expect(Origen.site_config.home_dir).to eql("#{home}/.origen")
+        expect(Origen.home).to eql("#{home}/.origen")
+      end
+      
+      it 'moves the home_dir as well' do
+        expect(Origen.site_config.user_install_dir).to eql('/user/install/dir/.origen')
+      end
+      
+      it 'leaves the :user_gem_install alone' do
+        expect(Origen.site_config.user_gem_dir).to eql("#{home}/.origen/gems")
+      end
+    end
+    
+    context 'with home_dir overriden' do
+      before :context do
+        clear_site_config
+        
+        add_config_variable('home_dir', '/home/dir/')
+      end
+      
+      it 'moves the home_dir' do
+        expect(Origen.site_config.home_dir).to eql("/home/dir/.origen")
+        expect(Origen.home).to eql("/home/dir/.origen")
+      end
+      
+      it 'moves the :user_install_dir as well' do
+        expect(Origen.site_config.user_install_dir).to eql('/home/dir/.origen')
+      end
+      
+      it 'also moves the :user_gem_install' do
+        expect(Origen.site_config.user_gem_dir).to eql('/home/dir/.origen/gems')
+      end
+    end
+    
+    context 'with home_dir, user_gem_dir, and user_install_dir all overriden' do
+      before :context do
+        clear_site_config
+        
+        add_config_variable('home_dir', '/home/location/')
+        add_config_variable('user_install_dir', '/user/install')
+        add_config_variable('gem_install_dir', '/gem/location/')
+        add_config_variable('user_gem_dir', '/user/location')
+      end
+      
+      it 'moves the home_dir' do
+        expect(Origen.site_config.home_dir).to eql("/home/location/.origen")
+        expect(Origen.home).to eql("/home/location/.origen")
+      end
+      
+      it 'moves the :user_install_dir as well' do
+        expect(Origen.site_config.user_install_dir).to eql('/user/install/.origen')
+      end
+      
+      it 'also moves :user_gem_dir' do
+        expect(Origen.site_config.user_gem_dir).to eql('/user/location/.origen/gems')
+      end
+    end
+  end
+  
+  describe 'Site config install directories with ENV variables set' do
+    # Make sure the ENV variables correctly overwrite the site config variables.
+    # These use methods instead, so this moreso making sure the top method works rather than the
+    # underlying find_val.
+    context 'with ORIGEN_GEM_INSTALL_DIR set' do
+      before :context do
+        # Need to clear in the event that :user_gem_dir is actually set
+        clear_site_config
+        
+        ENV['ORIGEN_GEM_INSTALL_DIR'] = '/env/gem/'
+      end
+      
+      it 'uses the value in ORIGEN_GEM_INSTALL_DIR instead of :gem_install_dir' do
+        expect(Origen.site_config.user_gem_dir).to eql("/env/gem/.origen/gems")
+      end
+      
+      it 'uses the value in :user_gem_dir instead of ORIGEN_GEM_INSTALL_DIR since :user_gem_dir takes precedenece' do
+        ENV['ORIGEN_USER_GEM_DIR'] = '/env/user/gem/'
+        expect(Origen.site_config.user_gem_dir).to eql("/env/user/gem/.origen/gems")
+      end
+      
+      after :context do
+        ENV['ORIGEN_GEM_INSTALL_DIR'] = nil
+        ENV['ORIGEN_USER_GEM_DIR'] = nil
+      end
+    end
+    
+    context 'with ORIGEN_HOME_DIR set' do
+      before :context do
+        clear_site_config
+      end
+      
+      it 'uses the value in ORIGEN_HOME_DIR instead of :home_dir' do
+        with_env_variable('ORIGEN_HOME_DIR', '/proj/env/~') do
+          expect(Origen.site_config.home_dir).to eql("/proj/env/#{username}/.origen")
+          expect(Origen.home).to eql("/proj/env/#{username}/.origen")
+          expect(Origen.site_config.user_install_dir).to eql("/proj/env/#{username}/.origen")
+          expect(Origen.site_config.user_gem_dir).to eql("/proj/env/#{username}/.origen/gems")
+        end
+      end
+    end
+    
+    context 'with ORIGEN_HOME_DIR, ORIGEN_USER_INSTALL_DIR, and ORIGEN_USER_GEM_DIR all set' do
+      before :context do
+        clear_site_config
+        
+        ENV['ORIGEN_HOME_DIR'] = '/env/home/~'
+        ENV['ORIGEN_USER_INSTALL_DIR'] = '/env/install/~'
+        ENV['ORIGEN_USER_GEM_DIR'] = '/env/gem/~'
+      end
+      
+      it 'uses the home_dir in ORIGEN_HOME_DIR' do
+        expect(Origen.site_config.home_dir).to eql("/env/home/#{username}/.origen")
+        expect(Origen.home).to eql("/env/home/#{username}/.origen")
+      end
+      
+      it 'uses the user_install_dir in ORIGEN_USER_INSTALL_DIR' do
+        expect(Origen.site_config.user_install_dir).to eql("/env/install/#{username}/.origen")
+      end
+      
+      it 'uses the user_gem_dir in ORIGEN_USER_GEM_DIR' do
+        expect(Origen.site_config.user_gem_dir).to eql("/env/gem/#{username}/.origen/gems")
+      end
+            
+      after :context do
+        ENV['ORIGEN_HOME_DIR'] = nil
+        ENV['ORIGEN_USER_INSTALL_DIR'] = nil
+        ENV['ORIGEN_USER_GEM_DIR'] = nil
+      end
+    end
+  end
+  
+  describe 'Evaluating paths for directories' do
+    context 'with basic values' do
+      it 'uses the path given as is, and appends .origen to it' do
+        expect(Origen.site_config.eval_path('/my/path')).to eql('/my/path/.origen')
+      end
+      
+      it 'does not append .origen if .origen is already provided in the path' do
+        expect(Origen.site_config.eval_path('/my/path/.origen')).to eql('/my/path/.origen')
+      end
+      
+      it 'evaluates the path ~/ (default) to the home directory (or C: for Windows)' do
+        expect(Origen.site_config.eval_path('~/')).to eql("#{home}/.origen")
+      end
+    end
+    
+    context 'using ~ in paths' do
+      it 'replaces ~ with <username> and appending .origen' do
+        expect(Origen.site_config.eval_path('/proj/origen/~')).to eql("/proj/origen/#{username}/.origen")
+      end
+      
+      it 'replace all ~ with <username> and appending .origen' do
+        expect(Origen.site_config.eval_path('/proj/~/origens/~')).to eql("/proj/#{username}/origens/#{username}/.origen")
+      end
+      
+      it 'replaces all but leading ~ with <username> and appending .origen' do
+        expect(Origen.site_config.eval_path('~/origens/~')).to eql("/home/#{username}/origens/#{username}/.origen")
+      end
+      
+      it 'allows ~ to be esacped' do
+        expect(Origen.site_config.eval_path('~/\~/~')).to eql("/home/#{username}/~/#{username}/.origen")
+        #expect(Origen.site_config.eval_path("~/\\~/~")).to eql("/home/#{username}/~/#{username}/.origen")
+      end
+      
+      it 'allows leading ~ to be escaped' do
+        expect(Origen.site_config.eval_path('\~/~')).to eql("~/#{username}/.origen")
+      end
+    end
+    
+    context 'with :append_dot_origen set to values' do
+      before :context do
+        clear_site_config
+        
+        # Only bring in the default site config at the root of Origen.
+        Origen.site_config.add_site_config_as_highest("#{Origen.app.root}/origen_site_config.yml")
+      end
+      
+      it 'is set to true by default' do
+        expect(Origen.site_config.append_dot_origen).to be true
+      end
+      
+      it 'does not append .origen when set to false' do
+        add_config_variable('append_dot_origen', 'false')
+        
+        expect(Origen.site_config.append_dot_origen).to be false
+        expect(Origen.site_config.home_dir).to eql("/home/#{username}")
+      end
+      
+      it 'appends whatever append_dot_origen is when it does not equal true or false (TRUE/FALSE/0/1)' do
+        add_config_variable('append_dot_origen', '.test')
+
+        expect(Origen.site_config.append_dot_origen).to eql('.test')
+        expect(Origen.site_config.home_dir).to eql("/home/#{username}/.test")
+      end
+      
+      it 'still appends /gems to :user_gem_dir' do
+        expect(Origen.site_config.user_gem_dir).to eql("/home/#{username}/.test/gems")
+      end
+    end
+      
+    context 'with :append_gems set to values' do
+      before :context do
+        clear_site_config
+        
+        # Only bring in the default site config at the root of Origen.
+        Origen.site_config.add_site_config_as_highest("#{Origen.app.root}/origen_site_config.yml")
+      end
+      
+      it 'is set to true by default' do
+        expect(Origen.site_config.append_gems).to be true
+      end
+      
+      it 'does not append \'gems\' when set to false' do
+        add_config_variable('append_gems', 'false')
+        
+        expect(Origen.site_config.append_gems).to be false
+        expect(Origen.site_config.user_gem_dir).to eql("/home/#{username}/.origen")
+      end
+      
+      it 'appends whatever append_gems is when it does not equal true or false (TRUE/FALSE/0/1)' do
+        add_config_variable('append_gems', 'user_gems')
+        
+        expect(Origen.site_config.user_gem_dir).to eql("/home/#{username}/.origen/user_gems")
+      end
+    end
+  end
+  
+  describe 'Site Config Dynamic Methods' do
+    context 'with dynamically built site config' do
+      it 'can dynamically add a new site config value as the highest priority' do
+        # Add a new variable
+        Origen.site_config.add_as_highest('new_highest', 'new value')
+        expect(Origen.site_config.new_highest).to eql('new value')
+        
+        # Add it again, making sure that it is the new highest value
+        Origen.site_config.add_as_highest('new_highest', 'newer value')
+        expect(Origen.site_config.new_highest).to eql('newer value')
+      end
+      
+      it 'can dynamically add a new site config value as the lowest priority' do
+        Origen.site_config.add_as_lowest('new_lowest', 'new value')
+        expect(Origen.site_config.new_lowest).to eql('new value')
+        
+        Origen.site_config.add_as_lowest('new_lowest', 'newer value')
+        expect(Origen.site_config.new_lowest).to eql('new value')
+      end
+      
+      it 'can dynamically add a new site config value using index notation' do
+        Origen.site_config['new_index'] = 'new index value'
+        expect(Origen.site_config.new_index).to eql('new index value')
+      end
+      
+      it 'can dynamically add a new highest priority value using index notation' do
+        Origen.site_config['new_index'] = 'newer index value'
+        expect(Origen.site_config.new_index).to eql('newer index value')
+      end
+      
+      it 'can retrieve a site config variable\'s current value' do
+        expect(Origen.site_config.get('new_lowest')).to eql('new value')
+      end
+      
+      it 'can retrieve a site config variable\'s current value, and list of values in order of priority' do
+        expect(Origen.site_config.get_all('new_lowest')).to eql(['new value', 'newer value'])
+      end
+      
+      it 'can retreive a site config variable\'s current value using index notation []' do
+        expect(Origen.site_config['new_index']).to eql('newer index value')
+      end
+      
+      it 'gets nil if the requested variable is not in the site config' do
+        expect(Origen.site_config['unknown_value']).to be_nil
+      end
+      
+      it 'gets an empty array if the requested variable is not in the site config' do
+        expect(Origen.site_config.get_all('unknown_value')).to be_empty
+      end
+      
+      it 'can dynamically remove the highest priority of a config variable' do
+        val = Origen.site_config.remove_highest('new_lowest')
+        expect(Origen.site_config.new_lowest).to eql('newer value')
+        expect(val).to eql('new value')
+      end
+      
+      it 'returns nil if the requested variable is not in the site config' do
+        expect(Origen.site_config.remove_highest('unknown_value')).to be_nil
+      end
+      
+      it 'can dynamically purge a config variable from the site config' do
+        vals = Origen.site_config.purge('new_highest')
+        expect(Origen.site_config.new_highest).to be(nil)
+        expect(vals).to eql(['newer value', 'new value'])
+      end
+      
+      it 'returns an empty array if the requested variable is not in the site config' do
+        expect(Origen.site_config.purge('unknown_value')).to be_empty
+      end
+      
+      it 'has method :purge aliased to :remove_all_instances' do
+        expect(Origen.site_config.method(:purge)).to eql(Origen.site_config.method(:remove_all_instances))
+      end
+      
+      it 'can clear the existing site config' do
+        Origen.site_config.clear
+        expect(Origen.site_config.instance_variable_get('@configs')).to be_empty
+      end
+    end
+  end  
 end

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'etc'
 
-fdescribe "Origen.site_config" do
+describe "Origen.site_config" do
 
   # Make sure that cached site config values don't affect these or the
   # next tests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  #config.filter_run :focus
+  config.filter_run :focus
   #config.run_all_when_everything_filtered = true
 
   # Many RSpec users commonly either run the entire suite or an individual

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
+  #config.filter_run :focus
   #config.run_all_when_everything_filtered = true
 
   # Many RSpec users commonly either run the entire suite or an individual

--- a/templates/web/guides/advanced/invocations.md.erb
+++ b/templates/web/guides/advanced/invocations.md.erb
@@ -16,7 +16,7 @@ When you install the <code>origen</code> gem, the origen executable will be regi
 the origen repository can be downloaded directly to your system, then the executable sourced from the <code>bin/origen</code>
 directory. It is also possible to create your own script to source Origen any way you want. However you choose to do so,
 that Origen executable becomes your <code>Universal Origen Install</code>. Origen invocations stemming from this location are
-invoked <code>universally</code>.
+invoked <code>universally</code>. This generally uses the <code>System Install</code> and the <code>System Gems</code>.
 
 Universal invocations provide a common, site-wide means to start up Origen or allow for an experienced user or IT department 
 to setup an Origen install in a project or tools workspace. However, normal users lose the ability to customize their 
@@ -26,6 +26,34 @@ For example, in order to add global commands to Origen, you must add additional 
 However, if Origen is living in some tool directory, changing the <code>Gemfile</code> will affect everyone's installation
 (for better or worse) and individual users lose control over their global installation. The 
 [Site Config](<%= path "guides/starting/company/" %>) can help us with this.
+
+#### Dependencies Using The System Gems
+
+The simplest and quickest way to add dependencies to Origen is to just use <code>gem install</code> and install any gems
+you want. Dependencies brought in this way will be able to register <code>global commands</code> to Origen, even
+when brought in as seperate gems.
+
+Under the hood, all this doing is going through the system installed gems and seeing which have a dependency
+on <code>Origen</code>. If the gem does, it is loaded as if it were a plugin, registering all global
+commands it may have.
+
+Some drawbacks of this are:
+
+* You (or someone) must be able to install gems on the system. For most Windows users who control their own
+PCs, this is not an issue. But for more locked-down PCs, or the most likely scenerio of using a centralized Linux server,
+you will need advanced permissions to add system gems.
+* You are stuck with whatever version of the gem you pull. Newer ones will need to be updated as above.
+* Developing these are clumsier than using Bundler.
+
+But, to this last note, using <code>User Installations</code> (the next section) boots global commands the
+same way. So, you can develop the plugin using <code>User Installations</code> and still install it
+as a system gem and get the same affect.
+
+This methodology is better suited for managing a global installation (obvisouly). All users using
+this installation will be able to see these plugins when running <code>universally</code>.
+
+Note that if a <code>user install</code>, <code>tool repo install</code>, or if running from
+within an application, these plugins will be bypassed, and must be added to the <code>Gemfile</code>.
 
 #### Site Config For User Installations
 

--- a/templates/web/guides/plugins/creating.md.erb
+++ b/templates/web/guides/plugins/creating.md.erb
@@ -233,9 +233,30 @@ end
 
 ~~~
 
-<b>Please note though that this requires the plugin to be added as a dependency to non-application Origen 
-invocations. Please see the</b> [Invocation Considerations](<%= path "guides/starting/invoking" %>) <b>page 
-for an explanation or refresher on what this means.</b>
+<div class="alert alert-danger">
+  <strong>Danger!</strong> Global commands are a bit more involved and require some extra setup outside of the
+  plugin itself. When inside an application, these commands will behave as <code>Shared</code> commands,
+  but outside of an application, the plugin must be brought in as a dependency either through <code>User Installs</code>
+  or <code>Tool Repo Installs</code>, or must be added to the system gems. For a refresher on what this means,
+  please see the <a href="<%= path 'guides/starting/invoking' %>">Invocation Considerations Guide</a>. For even more
+  details please see the <a href="<%= path 'guides/advanced/invocations' %>">Advanced Topic On Invocations</a>.
+</div>
+
+<div class="alert alert-danger">
+  <strong>Danger!</strong> <code>Global</code> commands behave slightly differently when run from an application
+  versus running without one. Origen does provide a 'standalone' application which gives all the functionality,
+  but this application cannot be customized. If you find yourself requiring application-specific behavior, your command
+  is better suited to be a <code>Shared</code> command.
+</div>
+
+<div class="alert alert-danger">
+  <strong>Danger!</strong> Although <code>Global</code> and <code>Shared</code> commands may have differences
+  in the application behavior, they do not have any differences, from an Origen perspective, when invoked
+  either by a <code>Tool Repo Install</code> or <code>User Install</code> setup versus a <code>System Level</code>
+  setup. Bundler makes it easier to develop Global commands than using Gem natively, so it is recommended
+  that you use a <code>User Install</code> when developing Global commands. You can read up on this is and
+  how to set it up in the <a href="<%= path 'guides/advanced/invocations' %>">Advanced Topic On Invocations</a>.
+</div>
 
 #### Command Sharing Considerations
 

--- a/templates/web/guides/starting/company.md.erb
+++ b/templates/web/guides/starting/company.md.erb
@@ -62,4 +62,90 @@ Origen.site_config.gem_server          # => nil
 Origen.site_config.gem_manage_bundler  # => true
 ~~~
 
+#### Dynamic Configurations
+
+The Origen site config has some basic methods to dynamically get, set, and remove values.
+
+##### Getting Values
+
+~~~ruby
+Origen.site_config.get(var) 
+  #=> gets the current value of a site config variable 'name'
+  #=> if var doesn't exist, nil is returned
+
+Origen.site_config.get_all(var) 
+  #=> gets all values of a site config variable 'name'
+  #=> returns an array of values, where the higher priority values are earlier in the array
+  #=> i.e., get_all(var).first is the current value and highest priority
+  #=> get_all(var).last is the lowest priority value
+  #=> same as Origen.site_config.add_as_highest(var, value)
+  
+Origen.site_config[var]
+  #=> same as Origen.site_config.get(var)
+~~~
+
+<div class="alert alert-info">
+  <strong>Info!</strong> You can also get a value using the method name corresponding to the site config variable, 
+  as described in the aforementioned section.
+</div>
+
+##### Setting Values
+
+~~~ruby
+Origen.site_config.add_as_highest(var, value)
+  #=> add a new site variable at the highest priority
+
+Origen.site_config.add_as_lowest(var, value)
+  #=> add a new site variable at the lowest priority
+  #=> essentially, this sets a new default value
+
+Origen.site_config[var] = value
+  #=> same as Origen.site_config.add_as_highest(var, value)
+~~~
+
+##### Removing Values
+
+~~~ruby
+remove_highest(var)
+  #=> remove the highest instance of var
+  #=> returns the value of the variable removed
+  #=> if var doesn't exist, nil is returned
+
+remove_all_instances(var)
+  #=> remove all the instances of var
+  #=> returns an array of the values, from highest priority to lowest
+  #=> if var doesn't exist, the an empty array is returned
+
+purge(var)
+  #=> aliase to remove_all_instances
+
+clear
+  #=> clears the site config completely
+~~~
+
+##### Adding New Configuration Files
+
+You can also add a new configuration file that is not in the default paths using the methods below:
+
+~~~ruby
+# Adds a new site config file as the highest priority
+add_site_config_as_highest(site_config_file)
+
+# Adds a new site config file as the lowest priority
+add_site_config_as_lowest(site_config_file)
+~~~
+
+<div class="alert alert-warning">
+  <strong>Warning</strong> Using the site config is this way requires that Origen has already booted. So, using these
+  methods to dynamically change site config variables like <code>user_gem_dir</code>, or 
+  <code>user_install_dir</code> won't have the desired
+  effect.
+</div>
+
+<div class="alert alert-warning">
+  <strong>Warning</strong> For <code>append_dot_origen</code> and <code>append_gems</code>, <code>nil</code> and
+  <code>false</code> are not the same. If either of those are undefined (<code>nil</code>) they will resolve to true. To
+  disable, they must be explicity set to <code>false</code>.
+</div>
+
 % end

--- a/templates/web/guides/starting/gems.md.erb
+++ b/templates/web/guides/starting/gems.md.erb
@@ -205,4 +205,15 @@ update the system Ruby installation in order to achieve the required runtime env
 They simply checkout the version of the given application that they want, and then Origen/Bundler
 takes care of guaranteeing that the runtime environment is the correct one.
 
+<div class="alert alert-warning">
+  <strong>Warning!</strong> Although the above note is true for most cases, there are two corner cases. The first is
+  any changes to the boot process will that version of Origen. For example, some of the following guides will discuss moving
+  around install directories, but this requires later versions of Origen to accomplish. You can check the release notes
+  for when features were added.
+  
+  The second case is for running plugins from system gems. However, the <code>gem install</code> process will update
+  the Origen version for you, so this is more of an FYI in case you see your Origen version change after installing
+  a plugin in the system Ruby.
+</div>
+
 % end

--- a/templates/web/guides/starting/invoking.md.erb
+++ b/templates/web/guides/starting/invoking.md.erb
@@ -1,22 +1,107 @@
 % render "layouts/guides.html" do
 
 As you may have noticed, running <code>origen</code> or <code>origen -h</code> gives you a different set of commands
-depending on where you run. When you run Origen from outside of an application, you are getting the Origen
-<code>global</code> commands. When you run Origen inside of an application's workspace, you are getting
-the <code>application & shared</code> commands. This division of the commands gives only what is relevant for wherever
-Origen was invoked. For example, it does not make sense to create a new application when you are in one. Nor does make
-sense to try and generate a pattern or compile a website if the application doesn't exist.
+depending on where you run. When you <code>invoke</code> Origen, one of the first things it will do is figure out what
+type of <code>invocation</code> you've issued. The type of invocation isn't something you need to control neccessarily, 
+but its important to understand why Origen's behavior seems to arbitrarily change.
 
-Plugins can add [Shared Commands](<%= path "guides/plugins/creating/#Sharing_Application_Commands" %>) and 
-[Global Commands](<%= path "guides/plugins/creating/#Sharing_Global_Commands" %>). In order to use these commands 
-though, the plugin must be added as a [dependency](<%= path "guides/starting/gems" %>). Inside an application, this is 
-easy, just add it to the Gemfile. To add commands to your global commands is a bit more involved and is out of scope 
-for a beginner's guide.
+### Application Invocations
 
-Normally, advanced users will handle setting up 
-[Tool Repo Installs](<%= path "guides/advanced/invocations/#Site_Config_For_Toolset_Installations" %>) for others
-to use. Please see the topic on this for setting this up. You can also 
-[Enable Your User-Directory Install](<%= path "guides/advanced/invocations/#Site_Config_For_User_Installations" %>) 
-if you wish to add global dependencies yourself.
+When you invoke Origen from within an application (or a plugin), you're using Origen's <code>application invocation</code>.
+This will most likely be the invocation used for any test or product engineer that is not creating a new application. 
+You'll notice that when you first run
+Origen from an application, you'll see Bundler start to do some stuff... but what's it doing? Bundler is building
+up a custom <code>bin</code> folder (<code>lbin</code>, to be exact) which it will channel future invocation within the
+application through. This ties this particular application to the gems specified in the <code>Gemfile</code> and gives
+you the <code>application invocation</code>.
+
+So, what does that mean? Application invocations begin by booting up the application and all needed plugins. The
+best way to see that will be to just run <code>origen -h</code> from inside and outside an appication. When running
+from within an application, you'll get the <code>core application</code> commands, 
+any [Shared Commands](<%= path "guides/plugins/creating/#Sharing_Application_Commands" %>) from plugins, and any 
+[Global Commands](<%= path "guides/plugins/creating/#Sharing_Global_Commands" %>) from plugins.
+
+### Global Invocations
+
+<code>Global Invocations</code> are the opposite of the aforermentioned <code>Application Invocations</code>. These
+invocations are obviously for when origen is run without any application.
+
+The default core global commands are just <code>new</code> and <code>interactive</code>. This makes sense, since its not
+appropriate to create a new application if you're already running from one, and when there is no application you'll
+most likely want to create a new one. You can see 
+[here for creating a new application](<%= path "guides/starting/app" %>).
+
+However, global invocations can also run other <code>global commands</code>. This allows Origen to become a platform
+for tool distribution, allowing for developers who use Origen to use all that Origen offers to build and distribute
+other tools or scripts.
+
+Using <code>global commands</code> may require a bit of additional setup. The commands that are available depend on
+how exactly the <code>global invocation</code> was induced. There are multiple ways to do this, as described in
+the next section.
+
+Note that this section only covers invocations. For a guide on how to actually create global commands, please see the
+[section on global commands](<%= path "guides/plugins/creating/#Sharing_Global_Commands" %>).
+
+#### System Invocations
+
+For new Origen users, this will be the most likely way of globally invoking Origen. This runs Origen straight from
+the system installed gem (i.e., what was installed when you ran <code>gem install origen</code>).
+Origen invocations stemming from the this are known as <code>system invocations</code>.
+
+When these occur, Origen will search through all of the dependencies of each gem that is currently installed on the
+system. If any of these gems have <code>origen</code> as a dependency, then Origen will assume that it is a plugin and
+boot that gem during Origen's own booting process. Thus, it is possible to install plugins that have 
+<code>global commands</code> and also have them active by just running <code>gem install</code>.
+
+Since these are available at the system level, if this is done on a shared system or on a server, all users will
+see those commands become available.
+
+#### User Invocations
+
+<code>System invocations</code> have the potential problem of requiring administrative access rights. When running on your own
+system, this is not an issue, but when run on corporate accounts, most users won't have these permissions.
+
+User installations are more involved. These require using the 
+[site config](<%= path "guides/starting/company/#How_The_Configuration_System_Works" %>)
+to indicate to Origen that you have a global <code>Gemfile</code> setup somewhere. The full details are beyond a
+startup guide, so this is marked as an 
+[advanced topic and can be found here](<%= path "guides/advanced/invocations/#Site_Config_For_User_Installations" %>)
+
+Please don't let that scare you away. However, a tool distribution platform is not Origen's primary purpose,
+so unless you know you'll need it, you can skip the advanced topic until you have more familiarity with Origen.
+
+The basic procedure is:
+
+1. Create a custom site config in your Origen home directory.
+2. Enable users installs.
+3. Add dependencies to your user <code>Gemfile</code>.
+
+Not that bad, right? If this seems like something you'd like to tackle now, go ahead and check out the
+[topic here](<%= path "guides/advanced/invocations/#Site_Config_For_User_Installations" %>).
+
+Once this is setup, invoking Origen through this <code>Gemfile</code> is known as <code>User Invocation</code>.
+
+#### Tool-Repo Invocations
+
+<code>Tool Repo</code> invocations look very similar to user invocations. However, the usage for these is different.
+These installations are built and maintained by an experience user and has the purpose of giving a set of users, or
+users running from a particular directory, access to a pre-built dependency set.
+
+At this point, you will most likely be a user of such an invocation. If so, you would have received some instructions
+from the installation manager on how to use it.
+
+Setting these up is an involved process. An advanced topic on this is also
+available [in the advanced topics](<%= path "guides/advanced/invocations/#Site_Config_For_Toolset_Installations" %>). 
+For now, that is all that will be said on <code>Tool Repo</code> invocations.
+
+<div class="alert alert-info">
+  <strong>Info!</strong> Each one of these cases above, and the <code>application invocations</code>, are handled independently.
+  That is, installing a gem in the system ruby, or installing it in your <code>user install</code> will NOT enable
+  that gem to be used in all your applications. Likewise, installing a gem in the system ruby will not make it
+  attainable automatically in all tool repo installs or in your user install. This is so the <code>Gemfile</code>
+  remains the master dependency list, with the only exception being the system install which has no
+  <code>Gemfile</code>. So, if you want to use a specific gem for all your applications, tool repo installs, and
+  your own user install, you will have to add it to the <code>Gemfile</code> of each.
+</div>
 
 % end

--- a/templates/web/guides/starting/workspace.md.erb
+++ b/templates/web/guides/starting/workspace.md.erb
@@ -105,14 +105,14 @@ ways to deal with this.
 
 Bundler comes with its own clean-up command. Running <code>bundle clean</code> when inside
 of an application will remove all of the 'unused' gems currently taking up space, where 'unused' gems are defined
-as gems not currently being used by the application. This can be a quick solution if you know that you have
+as gems not currently being used by the <u>current</u> application. This can be a quick solution if you know that you have
 several old, outdated gems that will likely never be used again. The only down side being other applications
 will require you to reinstall gems that running <code>bundle clean</code> deleted.
 
 You can see bundler's own documentation on this feature by running <code>bundler clean -h</code> at your
 console, or be visiting the [bundler docs](https://bundler.io/v1.16/man/bundle-clean.1.html).
 
-##### Moving Your Gems Somewhere Else
+##### Relocating Your Gems
 
 <img src="<%= path "img/memes/push_it_somewhere_else_patrick_gems.png" %>" style="display: block; margin: auto; width: 250px; height: 500px;">
 
@@ -147,13 +147,6 @@ site config variables.
   purpose as <code>user_gem_dir</code>, with <code>user_gem_dir</code> taking precedence.
 </div>
 
-<!--
-I'll discuss this topic when I release some fixes for home_dir. I'll open an issue on what I want to do
-after PR #181 is released and we have some stability for one of our key users.
-  - Corey (coreyeng)
-##### Configuring the Home Directory Location
--->
-
 ##### Tool Repo (TR) Directories
 
 Origen supports setting up <code>Tool Repository</code> gem builds. This is considered an advance topic, and can
@@ -161,5 +154,213 @@ be difficult to implement unless you are familiar with Origen's boot process and
 here as being an effective means for advanced users or project managers to oversee a group of user's gem
 install directories. For additional details, please see the 
 [advanced topic on invoking Origen](<%= path "guides/advanced/invocations/#Site_Config_For_Toolset_Installations" %>).
+
+#### Configuring the Home Directory Location
+
+The previous section is an example of using the site config to manage your <code>gems</code> workspace. However,
+there's more to the workspace than just the <code>gems</code> directory.
+
+The workspace is divided into three sections:
+
+1. The Origen Home Directory: Essentially Origen's scratch space.
+2. The User's Installation Directory: Location where user installation customizations can be found.
+3. The User Gem Directory: Location to install the gems.
+
+The above list is a top-down listing of the sections, but we'll actually discuss in detail from the bottom-up view.
+Each of the sections can be customized using the [site config](<%= path "guides/starting/company/" %>).
+
+##### Evaluating Paths
+
+Before we get started, the variables <code>user_gem_dir</code>, <code>user_install_dir</code>, and <code>home_dir</code>
+will be evaluated as <code>paths</code>, meaning that there's some magic that happens between what you type into the
+site config, and what actually gets used. This involves:
+
+* The <code>~</code> means <code>username</code>. For example, if I'm logged in as <code>coreyeng</code>, the path
+<code>/proj/~/my_origen</code> becomes <code>/proj/coreyeng/my_origen</code>.
+* The path is evaluated per Ruby's <a href='https://ruby-doc.org/core-2.3.1/File.html#method-c-expand_path'>File.expand_path</a>.
+Meaning that a leading <code>~/</code> becomes
+<code>/home/coreyeng</code> or <code>C:/users/coreyeng</code> (or whatever your OS evaluates <code>~/</code> to).
+* Not starting the path with either <code>~/</code> or <code>/</code> is a relative path, where the current path is
+prepended. For example, running from <code>/proj/my_project</code> and using <code>origen/~</code> becomes
+<code>/proj/my_project/origen/coreyeng</code>.
+* You can escape the <code>~</code> using the <code>\</code> symbol.
+* If the path provided already ends with the <code>append_dot_origen</code> or <code>append_gems</code>, then those
+will not be reapplied (<code>append_dot_origen</code> and <code>append_gems</code> will be covered in the next section).
+
+##### User Gem Directory
+
+The <code>user gem directory</code> indicates where the gems should be installed. Moving this directory around will
+change where <code>Bundler</code> places all of your gems.
+
+There are three site config variables to consider. Below are those variables as well as some examples of how to use them.
+
+<strong>Default:</strong> If no <code>user_gem_dir</code> is specified, the gem directory falls back to <code>home_dir</code>.
+
+~~~ruby
+# By default, user_gem_dir defaults to wherever the home directory is.
+# origen_site_config.yml
+append_dot_origen: true # Appends .origen to the path
+append_gems: true       # Appends gems to the path
+
+# In interactive session
+Origen.site_config.user_gem_dir #=> '/home/<username>/.origen/gems'
+~~~
+
+~~~ruby
+# Move the user_gem_dir
+# origen_site_config.yml
+user_gem_dir: /proj/my_gems/
+append_dot_origen: true
+append_gems: true
+
+# In interactive session
+Origen.site_config.user_gem_dir #=> '/proj/my_gems/.origen/gems'
+~~~
+
+~~~ruby
+# Set append_dot_origen and append_gems to false to have them removed.
+# origen_site_config.yml
+user_gem_dir: /proj/my_gems/~
+append_dot_origen: false
+append_gems: false
+
+# In interactive session
+Origen.site_config.user_gem_dir #=> '/proj/my_gems/<username>'
+~~~
+
+~~~ruby
+# Set append_dot_origen and append_gems to custom values to have the moved.
+# origen_site_config.yml
+user_gem_dir: /proj/my_gems/
+append_dot_origen: my_workspace
+append_gems: .my_gems
+
+# In interactive session
+Origen.site_config.user_gem_dir #=> '/proj/my_gems/my_workspace/.my_gems'
+~~~
+
+To review quickly, you can move the install directory for the gems by moving </code>user_gem_dir</code>. By default,
+this will automatically append <code>.origen/gems</code> to the directory path, unless <code>append_dot_origen</code>
+and <code>append_gems</code> specify otherwise.
+
+<div class="alert alert-warning">
+  <strong>Deprecation Warning!</strong> This warning from the previous section is repeated here:
+  To support older applications, the site variable <code>gem_install_dir</code>
+  and its <code>environment variable</code> counterpart <code>ORIGEN_GEM_INSTALL_DIR</code> are still valid. However, these fulfill the same
+  purpose as <code>user_gem_dir</code>, with <code>user_gem_dir</code> taking precedence.
+</div>
+
+##### User Installation Directory
+
+The <code>user_install_dir</code> indicates where the user's customization settings are located. Right now, this
+only includes where the global <code>Gemfile</code> can be located, but <code>site configs</code> can also be
+located there. Future user customization settings will also use this directory location.
+
+<strong>Default:</strong> If no <code>user_install_dir</code> is specified, the <code>home_dir</code> is used instead.
+
+~~~ruby
+# Default
+# origen_site_config.yml
+append_dot_origen: true # Appends .origen to the path.
+
+# In interactive session
+Origen.site_config.user_install_dir #=> '/home/<username>/.origen'
+~~~
+
+~~~ruby
+# Move the user_install_dir
+append_dot_origen: true
+user_install_dir: /proj/~/install
+
+# In interactive session
+Origen.site_config.user_install_dir #=> '/proj/<username>/install/.origen'
+~~~
+
+~~~ruby
+# Disable appending .origen
+# Note this also affects the user_gem_dir
+append_dot_origen: false
+user_install_dir: /proj/~/install
+
+# In interactive session
+Origen.site_config.user_install_dir #=> '/proj/<username>/install'
+Origen.site_config.user_gem_dir #=> '/proj/<username>/install/gems'
+~~~
+
+~~~ruby
+# Customize the appended directory
+# Note this also affects the user_gem_dir
+append_dot_origen: my_origen
+user_install_dir: /proj/~/install
+
+# In interactive session
+Origen.site_config.user_install_dir #=> '/proj/<username>/install/my_origen'
+Origen.site_config.user_gem_dir #=> '/proj/<username>/install/my_origen/gems'
+~~~
+
+##### Home Directory
+
+The <code>home_dir</code> takes care of everything else. In general, this acts as Origen's scratch space. For example,
+the <code>LSF logs</code> and the <code>global session</code> are stored in this location.
+
+<strong>Default</code>: if no <code>home_dir</code> is specified, it defaults to <code>~/<code>, which will be expand
+to your home directory (for example, <code>/home/coreyeng</code> on Linux, or <code>C:\users\coreyeng</code> on
+Windows).
+
+<code>home_dir</code> is also the topmost path. So, if <code>user_install_dir</code> and/or <code>user_gem_dir</code>
+are not defined, they default back to <code>home_dir</code>.
+
+~~~ruby
+# If no home_dir is specified, ~/ is used.
+# Default
+
+# In interactive session
+Origen.site_config.home_dir #=> '/home/<username>/.origen'
+Origen.site_config.user_install_dir #=> '/home/<username>/.origen'
+Origen.site_config.user_gem_dir #=> '/home/<username>/.origen/gems'
+~~~
+
+~~~ruby
+# Move the home_dir
+# origen_site_config.yml
+home_dir: /proj/origens/~
+
+# In interactive session
+Origen.site_config.home_dir #=> '/proj/origens/<username>/.origen'
+Origen.site_config.user_install_dir #=> '/proj/origens/<username>/.origen'
+Origen.site_config.user_gem_dir #=> '/proj/origens/<username>/.origen/gems'
+~~~
+
+~~~ruby
+# Move the home_dir and disable append_dot_origen
+# origen_site_config.yml
+home_dir: /proj/origens/~
+append_dot_origen: false
+
+# In interactive session
+Origen.site_config.home_dir #=> '/proj/origens/<username>'
+Origen.site_config.user_install_dir #=> '/proj/origens/<username>'
+Origen.site_config.user_gem_dir #=> '/proj/origens/<username>/gems'
+~~~
+
+~~~ruby
+# Move the home_dir and change append_dot_origen
+# origen_site_config.yml
+home_dir: /proj/origens/~
+append_dot_origen: .my_origen
+
+# In interactive session
+Origen.site_config.home_dir #=> '/proj/origens/<username>/.my_origen'
+Origen.site_config.user_install_dir #=> '/proj/origens/<username>/.my_origen'
+Origen.site_config.user_gem_dir #=> '/proj/origens/<username>/.my_origen/gems'
+~~~
+
+##### Closing Thoughts
+
+The purpose of having all these site configs variables is to allow full customization when desired, but be able to simplify
+common usages. For example, if you want to move your entire <code>.origen</code> from your home directory to some
+project directory, you only need to move <code>home_dir</code>. Everything else will go with it. But, if you want to
+leave your custom user setup and be able to get all the logs and global session in your home directory but just move
+where all your gems are stored, you can do that too.
 
 % end

--- a/templates/web/guides/starting/workspace.md.erb
+++ b/templates/web/guides/starting/workspace.md.erb
@@ -92,7 +92,7 @@ in most cases:
 > bundle update
 ~~~
 
-#### Workspace Size Considerations
+### Workspace Size Considerations
 
 By default, all downloaded dependencies are placed in the <code>home_dir</code>, which is likely pointing to
 <code>~/.origen/gems</code>. However, gems can be large,
@@ -101,7 +101,7 @@ quickly swell in size. This can be problematic particularly on corporate Linux s
 have sufficient home directories to handle the size and quantity of gems we are dealing with. There are a few
 ways to deal with this.
 
-##### Bundle Clean
+#### Bundle Clean
 
 Bundler comes with its own clean-up command. Running <code>bundle clean</code> when inside
 of an application will remove all of the 'unused' gems currently taking up space, where 'unused' gems are defined
@@ -147,7 +147,7 @@ site config variables.
   purpose as <code>user_gem_dir</code>, with <code>user_gem_dir</code> taking precedence.
 </div>
 
-##### Tool Repo (TR) Directories
+#### Tool Repo (TR) Directories
 
 Origen supports setting up <code>Tool Repository</code> gem builds. This is considered an advance topic, and can
 be difficult to implement unless you are familiar with Origen's boot process and site configs, but it mentioned
@@ -155,7 +155,7 @@ here as being an effective means for advanced users or project managers to overs
 install directories. For additional details, please see the 
 [advanced topic on invoking Origen](<%= path "guides/advanced/invocations/#Site_Config_For_Toolset_Installations" %>).
 
-#### Configuring the Home Directory Location
+### Configuring the Home Directory Location
 
 The previous section is an example of using the site config to manage your <code>gems</code> workspace. However,
 there's more to the workspace than just the <code>gems</code> directory.
@@ -169,7 +169,7 @@ The workspace is divided into three sections:
 The above list is a top-down listing of the sections, but we'll actually discuss in detail from the bottom-up view.
 Each of the sections can be customized using the [site config](<%= path "guides/starting/company/" %>).
 
-##### Evaluating Paths
+#### Evaluating Paths
 
 Before we get started, the variables <code>user_gem_dir</code>, <code>user_install_dir</code>, and <code>home_dir</code>
 will be evaluated as <code>paths</code>, meaning that there's some magic that happens between what you type into the
@@ -187,7 +187,7 @@ prepended. For example, running from <code>/proj/my_project</code> and using <co
 * If the path provided already ends with the <code>append_dot_origen</code> or <code>append_gems</code>, then those
 will not be reapplied (<code>append_dot_origen</code> and <code>append_gems</code> will be covered in the next section).
 
-##### User Gem Directory
+#### User Gem Directory
 
 The <code>user gem directory</code> indicates where the gems should be installed. Moving this directory around will
 change where <code>Bundler</code> places all of your gems.
@@ -196,45 +196,56 @@ There are three site config variables to consider. Below are those variables as 
 
 <strong>Default:</strong> If no <code>user_gem_dir</code> is specified, the gem directory falls back to <code>home_dir</code>.
 
-~~~ruby
+~~~yaml
 # By default, user_gem_dir defaults to wherever the home directory is.
 # origen_site_config.yml
 append_dot_origen: true # Appends .origen to the path
 append_gems: true       # Appends gems to the path
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_gem_dir #=> '/home/<username>/.origen/gems'
 ~~~
 
-~~~ruby
-# Move the user_gem_dir
+##### Move the user_gem_dir
+
+~~~yaml
 # origen_site_config.yml
 user_gem_dir: /proj/my_gems/
 append_dot_origen: true
 append_gems: true
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_gem_dir #=> '/proj/my_gems/.origen/gems'
 ~~~
 
-~~~ruby
-# Set append_dot_origen and append_gems to false to have them removed.
+##### Set append_dot_origen and append_gems to false to have them removed
+
+~~~yaml
 # origen_site_config.yml
 user_gem_dir: /proj/my_gems/~
 append_dot_origen: false
 append_gems: false
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_gem_dir #=> '/proj/my_gems/<username>'
 ~~~
 
-~~~ruby
-# Set append_dot_origen and append_gems to custom values to have the moved.
+##### Set append_dot_origen and append_gems to custom values to have the moved
+
+~~~yaml
 # origen_site_config.yml
 user_gem_dir: /proj/my_gems/
 append_dot_origen: my_workspace
 append_gems: .my_gems
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_gem_dir #=> '/proj/my_gems/my_workspace/.my_gems'
 ~~~
@@ -250,7 +261,7 @@ and <code>append_gems</code> specify otherwise.
   purpose as <code>user_gem_dir</code>, with <code>user_gem_dir</code> taking precedence.
 </div>
 
-##### User Installation Directory
+#### User Installation Directory
 
 The <code>user_install_dir</code> indicates where the user's customization settings are located. Right now, this
 only includes where the global <code>Gemfile</code> can be located, but <code>site configs</code> can also be
@@ -258,60 +269,72 @@ located there. Future user customization settings will also use this directory l
 
 <strong>Default:</strong> If no <code>user_install_dir</code> is specified, the <code>home_dir</code> is used instead.
 
-~~~ruby
+~~~yaml
 # Default
 # origen_site_config.yml
 append_dot_origen: true # Appends .origen to the path.
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_install_dir #=> '/home/<username>/.origen'
 ~~~
 
-~~~ruby
-# Move the user_install_dir
+##### Move the user_install_dir
+
+~~~yaml
 append_dot_origen: true
 user_install_dir: /proj/~/install
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_install_dir #=> '/proj/<username>/install/.origen'
 ~~~
 
-~~~ruby
-# Disable appending .origen
+##### Disable appending .origen
+
+~~~yaml
 # Note this also affects the user_gem_dir
 append_dot_origen: false
 user_install_dir: /proj/~/install
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_install_dir #=> '/proj/<username>/install'
 Origen.site_config.user_gem_dir #=> '/proj/<username>/install/gems'
 ~~~
 
-~~~ruby
-# Customize the appended directory
+##### Customize the appended directory
+
+~~~yaml
 # Note this also affects the user_gem_dir
 append_dot_origen: my_origen
 user_install_dir: /proj/~/install
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.user_install_dir #=> '/proj/<username>/install/my_origen'
 Origen.site_config.user_gem_dir #=> '/proj/<username>/install/my_origen/gems'
 ~~~
 
-##### Home Directory
+#### Home Directory
 
 The <code>home_dir</code> takes care of everything else. In general, this acts as Origen's scratch space. For example,
 the <code>LSF logs</code> and the <code>global session</code> are stored in this location.
 
-<strong>Default</code>: if no <code>home_dir</code> is specified, it defaults to <code>~/<code>, which will be expand
+<strong>Default</strong>: if no <code>home_dir</code> is specified, it defaults to <code>~/<code>, which will be expand
 to your home directory (for example, <code>/home/coreyeng</code> on Linux, or <code>C:\users\coreyeng</code> on
 Windows).
 
 <code>home_dir</code> is also the topmost path. So, if <code>user_install_dir</code> and/or <code>user_gem_dir</code>
 are not defined, they default back to <code>home_dir</code>.
 
+##### If no home_dir is specified, ~/ is used
+
 ~~~ruby
-# If no home_dir is specified, ~/ is used.
 # Default
 
 # In interactive session
@@ -320,42 +343,51 @@ Origen.site_config.user_install_dir #=> '/home/<username>/.origen'
 Origen.site_config.user_gem_dir #=> '/home/<username>/.origen/gems'
 ~~~
 
-~~~ruby
-# Move the home_dir
+##### Move the home_dir
+
+~~~yaml
 # origen_site_config.yml
 home_dir: /proj/origens/~
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.home_dir #=> '/proj/origens/<username>/.origen'
 Origen.site_config.user_install_dir #=> '/proj/origens/<username>/.origen'
 Origen.site_config.user_gem_dir #=> '/proj/origens/<username>/.origen/gems'
 ~~~
 
-~~~ruby
-# Move the home_dir and disable append_dot_origen
+##### Move the home_dir and disable append_dot_origen
+
+~~~yaml
 # origen_site_config.yml
 home_dir: /proj/origens/~
 append_dot_origen: false
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.home_dir #=> '/proj/origens/<username>'
 Origen.site_config.user_install_dir #=> '/proj/origens/<username>'
 Origen.site_config.user_gem_dir #=> '/proj/origens/<username>/gems'
 ~~~
 
-~~~ruby
-# Move the home_dir and change append_dot_origen
+##### Move the home_dir and change append_dot_origen
+
+~~~yaml
 # origen_site_config.yml
 home_dir: /proj/origens/~
 append_dot_origen: .my_origen
+~~~
 
+~~~ruby
 # In interactive session
 Origen.site_config.home_dir #=> '/proj/origens/<username>/.my_origen'
 Origen.site_config.user_install_dir #=> '/proj/origens/<username>/.my_origen'
 Origen.site_config.user_gem_dir #=> '/proj/origens/<username>/.my_origen/gems'
 ~~~
 
-##### Closing Thoughts
+#### Closing Thoughts
 
 The purpose of having all these site configs variables is to allow full customization when desired, but be able to simplify
 common usages. For example, if you want to move your entire <code>.origen</code> from your home directory to some


### PR DESCRIPTION
The TL;DR of this: Origen can now register plugins installed at the system level and can run global commands defined there. Also, this includes the enhancements for issue #183 and some methods to dynamically mess with the site config.

Hi,

This is a PR to add a requested feature which allows for global commands to be run when gems are installed at the system level.

Previously, in order to run global commands, you had to setup a TR or user install. TR users could reference a TR install, but that still required some sort of setup (usually a shell script to setup environment variables). With this PR, gems installed at the system level (using gem install), will be registered as Origen plugins, and are capable of adding global commands.

For example, to run a global command in the gem <code>te_utils</code>, the Origen system install manager can simply do: <code>gem install te_utils</code> and run any global commands provided by <code>te_utils</code>. This will go through the same process as the standard boot up routine, so everything required by the global commands will still be available.

Bundler is bypassed in this case. Under the hood, this is just a very simple check to see if Bundler is being used (if it is, then this is an application/tr/user invocation, otherwise it’s a system level invocation), and if not then it will loop through all the registered gems in the system, looking for gems with a dependency on Origen, and load those applications, registering them as plugins.

This opens up two caveats that I see:

- Development and debug is a bit more involved. As far as I can see, everything Bundler does Gem can do as well (which makes sense) just is a bit more involved, and potentially a bit more error prone. For example, developing a gem locally and installing it at the system level is a bit more involved instead of just using the <code>:path</code> option in Bundler. However, all of this should work out to where there is a 1-to-1 correlation between using the system install and the user install so that running from a system install resolves the same as running the user install.
- In normal circumstance, using <code>gem install</code> will resolve and install all dependencies. So, we can safely <code>require</code> origen plugins installed using gem in the same way as using Bundler. However, I think that hacking at the gems install is more dangerous than hacking at Bundler's install (less checks, but maybe I'm wrong), so trying to cut corners during development could cause issues. So, I recommend developing global commands using 1).

This is not so much a caveat, but a design decision: if Bundler is used (we're running from an application/user/TR invocation) then this feature is skipped. This is to remove Origen automagically loading gems that may not be included in the Gemfile. This can be problematic for applications being used across company systems, across companies, or across Windows users. So, to take out the possibility of random 'gem not defined' type issues, the same gem must be required by the Gemfiles and the system, if it is to be used by both invocations.

Docs were updated, but I'm not sure how specs tests could be added for this. I'm not familiar with how the specs are actually run on Git's server or if specs for this would even be possible.

Additionally, this includes fixes/enhancements for issues #183. Docs and specs tests also updated accordingly. I think I hit on all the bullets Ginty had. The only one that I purposely didn't do was having <code>user_gem_dir</code> in the advanced section. But I covered this pretty well I think in the <code>workspace</code> section and Ginty had mentioned that if we just want to move the <code>user_gem_dir</code> the advanced pages shouldn't be needed. The advanced pages are more about setting up user and TR installs anyway and putting the same content that is covered in the <code>workspace</code> section seemed repetitive and out of place to me.

<strong>I changed up the site config stuff quite a bit. So please do review. I don't think it will substantially change anything though but is worth mentioning.</strong>

Lastly, when prototyping for #183, I added some dynamic stuff to get/add/remove values to/from the site config. Seemed like a waste to just throw those away so I added some specs for those too and updated the site config docs. I have a warning though that basically says its use is limited to after Origen has already booted.
