### PR TITLE
Update to windows install docs changing recommended versions of Ruby …

### DIFF
--- a/templates/web/guides/starting/installwin.md.erb
+++ b/templates/web/guides/starting/installwin.md.erb
@@ -82,8 +82,10 @@ choco install consoleZ -y --force
 
 ### 3. Install Ruby
 
+#### 3.1 Install the Ruby Executable
+
 ~~~text
-choco install ruby -y --version=2.2.4 --force
+choco install ruby -y --version=2.3 --force
 choco install ruby2.devkit -y --force
 ~~~
 
@@ -91,15 +93,32 @@ choco install ruby2.devkit -y --force
 
 Execute the following command from the console:
 
+#### 3.2 Install RubyGems
+
 ~~~text
-@powershell (new-object System.Net.WebClient).DownloadFile('https://rubygems.org/downloads/rubygems-update-2.6.7.gem’,'C:\rubygems-update-2.6.7.gem') && gem install --local C:\rubygems-update-2.6.7.gem && update_rubygems --no-ri --no-rdoc && gem uninstall rubygems-update -x
+@powershell (new-object System.Net.WebClient).DownloadFile('https://rubygems.org/downloads/rubygems-update-2.7.3.gem’,'C:\rubygems-update-2.7.3.gem') && gem install --local C:\rubygems-update-2.7.3.gem && update_rubygems --no-ri --no-rdoc && gem uninstall rubygems-update -x
 ~~~
+
+<div class="alert alert-danger">
+  The version of Ruby is just a recommendation from the Origen development team. Origen has proven to
+  work on several versions of Ruby. However, changing the version of Ruby may also require you to reevaluate
+  the version of RubyGems used. For example, we've found that Ruby 2.2.4, is not fully compatible RubyGems 2.6.7,
+  for all gems (we run into issues with Symlinks on Windows that are resolved by updating RubyGems) but
+  it works with RubyGems 2.2.3. Also, the version of RubyGems that ships with your installation of Ruby may be
+  fine. See the <a href="http://guides.rubygems.org/rubygems-basics/">RubyGems website</a> for additional details.
+  <br>
+  <br>
+  The conclusion of this alert box is don't stress too much about the exact versions you're using and if you
+  run into issues installing gems, consider possible incompatabilities between the versions of Ruby, RubyGems,
+  or the gem that you are trying to install. You can also use RubyGems to manually install the gems yourself,
+  to bypass any installation options Origen may try to set.
+</div>
 
 Open <code>C:\tools\DevKit2\config.yml</code> in your favorite editor and write this at the
 bottom:
 
 ~~~text
-- C:/tools/ruby22
+- C:/tools/ruby23
 ~~~
 
 Save it, and then execute the following commands from the console:


### PR DESCRIPTION
This is another update I've hung onto for a while (for no reason in particular) that I addressed for some of our Windows users. The current install guide actually does not work for us. We get issues with some gems (the ones trying to build libraries, like JSON, nokogiri, etc) not installing due to <code>Symlink</code> issues.

We found that we can get around this by using RubyGems 2.2.3 (what the original Windows install guide had) or by manually installing the gems with some options to not build the libraries.

[However, with Ruby 2.2 support ending in March](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) (see the last paragraph on that page), I've been recommending to our users to just install Ruby 2.3 and Ruby Gems 2.7.3, and this has worked well for us. Since the specs that we run on our Linux environment (at least here at NXP) use Ruby 2.3, I think we should update the Windows install guide to these new versions. I've been using them for a while now and haven't seen any issues. I actually prototyped #207 with this install.

I also added a box that says don't stress too much about the versions of Ruby/RubyGems and described a bit of our struggle. I hope it doesn't come off as hating on RubyGems, because I actually love RubyGems, but shows to try different versions and use best judgement if running into gem installation issues.