### PR TITLE
Org file infrastructure

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -66,6 +66,7 @@ unless defined? RGen::ORIGENTRANSITION
     autoload :PowerDomains,      'origen/power_domains'
     autoload :Clocks,            'origen/clocks'
     autoload :Value,             'origen/value'
+    autoload :OrgFile,           'origen/org_file'
 
     attr_reader :switch_user
 

--- a/lib/origen/org_file.rb
+++ b/lib/origen/org_file.rb
@@ -28,7 +28,7 @@ module Origen
 
       def close(id, options = {})
         fail "An org_file with this ID has not been opened id: #{id}" unless open_files[id]
-        open_files[id].close
+        open_files[id].close unless options[:_internal_org_file_call_]
         open_files[id] = nil
       end
 
@@ -82,6 +82,8 @@ module Origen
         file.puts "#{@buffer}#{@buffer_cycles}" if @buffer
         file.close
       end
+      self.class.close(id, _internal_org_file_call_: true)
+      nil
     end
 
     def read_line
@@ -89,7 +91,11 @@ module Origen
       operations = file.readline.strip.split(';')
       cycles = operations.pop.to_i
       operations = operations.map { |op| op.split(',') }.map { |op| op[0] = eval(op[0]); op }
-      yield operations, cycles
+      if block_given?
+        yield operations, cycles
+      else
+        [operations, cycles]
+      end
     end
 
     def record(path_to_object, method, *args)

--- a/lib/origen/org_file.rb
+++ b/lib/origen/org_file.rb
@@ -1,0 +1,119 @@
+module Origen
+  class OrgFile
+    autoload :Interceptor,   'origen/org_file/interceptor'
+    autoload :Interceptable, 'origen/org_file/interceptable'
+
+    class << self
+      def new(*args, &block)
+        if @internal_new
+          super
+        else
+          open(*args, &block)
+        end
+      end
+
+      def open(id, options = {})
+        fail "An org_file is already open with id: #{id}" if open_files[id]
+        @internal_new = true
+        f = OrgFile.new(id, options)
+        @internal_new = nil
+        open_files[id] = f
+        if block_given?
+          yield f
+          close(id, options)
+        else
+          f
+        end
+      end
+
+      def close(id, options = {})
+        fail "An org_file with this ID has not been opened id: #{id}" unless open_files[id]
+        open_files[id].close
+        open_files[id] = nil
+      end
+
+      def org_file(id = nil)
+        id ? open_files[id] : open_files.to_a.last[1]
+      end
+
+      def cycle(number = 1)
+        open_files.each { |id, f| f.cycle(number) }
+      end
+
+      private
+
+      def open_files
+        @open_files ||= {}.with_indifferent_access
+      end
+    end
+
+    attr_accessor :path, :filename
+    attr_reader :id, :operation
+
+    def initialize(id, options = {})
+      @id = id
+      @path = options[:path] || default_filepath
+      @filename = options[:filename] || "#{id}.org"
+      FileUtils.mkdir_p(path)
+      @path_to_file = File.join(path, filename)
+    end
+
+    def default_filepath
+      "#{Origen.root}/pattern/org/#{Origen.target.name}"
+    end
+
+    def file
+      @file ||= begin
+        if operation == 'r'
+          fail "No org file found at: #{@path_to_file}" unless exist?
+        end
+        File.open(@path_to_file, operation)
+      end
+    end
+
+    def exist?
+      File.exist?(@path_to_file)
+    end
+
+    def close
+      # Corner case, if no call to read_line or record was made then no file was created and there
+      # is no file to close
+      if @file
+        file.puts "#{@buffer}#{@buffer_cycles}" if @buffer
+        file.close
+      end
+    end
+
+    def read_line
+      @operation ||= 'r'
+      operations = file.readline.strip.split(';')
+      cycles = operations.pop.to_i
+      operations = operations.map { |op| op.split(',') }.map { |op| op[0] = eval(op[0]); op }
+      yield operations, cycles
+    end
+
+    def record(path_to_object, method, *args)
+      @operation ||= 'w'
+      @line ||= ''
+      @line += "#{path_to_object},#{method}"
+      @line += ",#{args.join(',')}" unless args.empty?
+      @line += ';'
+    end
+
+    def cycle(number)
+      if @buffer
+        if @line == @buffer
+          @buffer_cycles += 1
+        else
+          file.puts "#{@buffer}#{@buffer_cycles}"
+          @buffer = @line
+          @buffer_cycles = 1
+        end
+      else
+        @buffer = @line
+        @buffer_cycles = 1
+      end
+      @line = nil
+    end
+  end
+end

--- a/lib/origen/org_file/interceptable.rb
+++ b/lib/origen/org_file/interceptable.rb
@@ -1,0 +1,26 @@
+module Origen
+  class OrgFile
+    module Interceptable
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def new(*args, &block)
+          o = allocate
+          i = OrgFile::Interceptor.new(o)
+          o.__interceptor__ = i
+          i.send(:initialize, *args, &block)
+          i
+        end
+      end
+
+      def myself
+        @__interceptor__
+      end
+
+      # @api private
+      def __interceptor__=(obj)
+        @__interceptor__ = obj
+      end
+    end
+  end
+end

--- a/lib/origen/org_file/interceptable.rb
+++ b/lib/origen/org_file/interceptable.rb
@@ -1,7 +1,23 @@
 module Origen
   class OrgFile
     module Interceptable
-      extend ActiveSupport::Concern
+      def self.included(base)
+        base.extend ClassMethods
+
+        # Defers this executing until the whole class has loaded
+        Origen.after_app_loaded do
+          unless (base.instance_methods - Object.methods).include?(:global_path_to)
+            puts 'When adding the OrgFile::Interceptable module to a class, the class must define an instance method called "global_path_to", like this:'
+            puts
+            puts '  # Must return a string that contains a global path to access the given object,'
+            puts '  # here for example if the object was a pin'
+            puts '  def global_path_to'
+            puts '    "dut.pins(:#{id})"'
+            puts '  end'
+            fail "Incomplete integration of OrgFile::Interceptable in #{base}"
+          end
+        end
+      end
 
       module ClassMethods
         def new(*args, &block)
@@ -13,6 +29,8 @@ module Origen
         end
       end
 
+      # Class which include OrgFile::Interceptor should use 'myself' anytime then want to reference 'self',
+      # this ensures that there are never any references to the unwrapped object
       def myself
         @__interceptor__
       end

--- a/lib/origen/org_file/interceptor.rb
+++ b/lib/origen/org_file/interceptor.rb
@@ -1,0 +1,90 @@
+require 'set'
+module Origen
+  class OrgFile
+    # @api private
+    # Helper for the Interceptor where block_given? doesn't work internally
+    def self._block_given_?(&block)
+      block_given?
+    end
+
+    class Interceptor < ::BasicObject
+      def initialize(object, options = {})
+        @object = object
+      end
+
+      def inspect(*args)
+        @object.inspect(*args)
+      end
+
+      def ==(obj)
+        if obj.respond_to?(:__org_file_interceptor__)
+          @object == obj.__object__
+        else
+          @object == obj
+        end
+      end
+      alias_method :equal?, :==
+
+      def record_to_org_file(id = nil, options = {})
+        id, options = nil, id if id.is_a?(::Hash)
+        if options[:only]
+          @org_file_methods_to_intercept = Array(options[:only]).to_set
+        else
+          @org_file_methods_to_intercept = default_org_file_captures
+          if options[:also]
+            @org_file_methods_to_intercept += Array(options[:also]).to_set
+          end
+        end
+        @org_file ||= @old_org_file || OrgFile.org_file(id)
+      end
+
+      # Temporarily stop recording operations within the given block, or stop recording
+      # completely if no block given
+      def stop_recording_to_org_file(&block)
+        @old_org_file = @org_file
+        if OrgFile._block_given_?(&block)
+          @org_file = nil
+          yield
+          @org_file = @old_org_file
+        else
+          @org_file = nil
+        end
+      end
+
+      def method_missing(method, *args, &block)
+        if @org_file && @org_file_methods_to_intercept.include?(method)
+          @org_file.record(@object.global_path_to, method, *args)
+        end
+        @object.send(method, *args, &block)
+      end
+
+      def respond_to?(method, include_private = false)
+        method == :__org_file_interceptor__ ||
+          @object.respond_to?(method, include_private)
+      end
+
+      def __org_file_interceptor__
+        true
+      end
+
+      # @api private
+      #
+      # Don't ever use this! An un-wrapped reference to an object must never make it into
+      # application code or else any operations called on the un-wrapped reference will not
+      # be captured.
+      def __object__
+        @object
+      end
+
+      private
+
+      def debugger
+        ::Kernel.debugger
+      end
+
+      def default_org_file_captures
+        @default_captures ||= Array(@object.try(:org_file_methods)).to_set
+      end
+    end
+  end
+end

--- a/lib/origen/pins/function_proxy.rb
+++ b/lib/origen/pins/function_proxy.rb
@@ -16,6 +16,14 @@ module Origen
         @pin
       end
 
+      # @api private
+      #
+      # To play nicely with == when a function proxy is wrapping a pin that is already
+      # wrapped by an OrgFile interceptor
+      def __object__
+        @pin.__object__
+      end
+
       # Intercept all calls to function-scoped attributes of the pin so
       # that we can inject the function that we want the attribute value for
       Pin::FUNCTION_SCOPED_ATTRIBUTES.each do |attribute|

--- a/lib/origen/pins/pin_collection.rb
+++ b/lib/origen/pins/pin_collection.rb
@@ -494,6 +494,7 @@ pins(:some_group).map(&:id).sort
       private
 
       def clean_value(val)
+        return val if val.respond_to?(:contains_bits?)
         val = val.data if val.respond_to?('data')
         if val.is_a?(String) || val.is_a?(Symbol)
           Origen::Value.new(val)

--- a/lib/origen/value/bin_str_val.rb
+++ b/lib/origen/value/bin_str_val.rb
@@ -29,7 +29,7 @@ module Origen
       end
 
       def to_s
-        val
+        "b#{val}"
       end
 
       # Returns the value of the given bit.

--- a/lib/origen/value/hex_str_val.rb
+++ b/lib/origen/value/hex_str_val.rb
@@ -36,7 +36,7 @@ module Origen
       end
 
       def to_s
-        val
+        "h#{val}"
       end
 
       # Returns the value of the given bit.

--- a/spec/value_spec.rb
+++ b/spec/value_spec.rb
@@ -24,17 +24,17 @@ describe Origen::Value do
     it "converts to an integer and a string" do
       Origen::Value.new(:hA2_34).numeric?.should == true
       Origen::Value.new(:hA2_34).to_i.should == 0xA234
-      Origen::Value.new(:hA2_34).to_s.should == "a234"
+      Origen::Value.new(:hA2_34).to_s.should == "ha234"
 
       Origen::Value.new(:hA2_x4).numeric?.should == false
       Origen::Value.new(:hA2_x4).to_i.should == nil
-      Origen::Value.new(:hA2_x4).to_s.should == "a2x4"
-      Origen::Value.new(:hA2_X4).to_s.should == "a2X4"
+      Origen::Value.new(:hA2_x4).to_s.should == "ha2x4"
+      Origen::Value.new(:hA2_X4).to_s.should == "ha2X4"
     end
 
     it "discards bits that are out of range" do
       Origen::Value.new(:hA2_34, size: 8).to_i.should == 0x34
-      Origen::Value.new(:hA2_FF, size: 6).to_s.should == 'ff'
+      Origen::Value.new(:hA2_FF, size: 6).to_s.should == 'hff'
       Origen::Value.new(:hA2_FF, size: 6).to_i.should == 0x3F
     end
 
@@ -74,17 +74,17 @@ describe Origen::Value do
     it "converts to an integer and a string" do
       Origen::Value.new(:b10_11).numeric?.should == true
       Origen::Value.new(:b10_11).to_i.should == 0b1011
-      Origen::Value.new(:b10_11).to_s.should == "1011"
+      Origen::Value.new(:b10_11).to_s.should == "b1011"
 
       Origen::Value.new(:b10_x1).numeric?.should == false
       Origen::Value.new(:b10_x1).to_i.should == nil
-      Origen::Value.new(:b10_x1).to_s.should == "10x1"
-      Origen::Value.new(:b10_X1).to_s.should == "10x1"
+      Origen::Value.new(:b10_x1).to_s.should == "b10x1"
+      Origen::Value.new(:b10_X1).to_s.should == "b10x1"
     end
 
     it "discards bits that are out of range" do
       Origen::Value.new(:b10_11, size: 2).to_i.should == 0b11
-      Origen::Value.new(:b10_11, size: 3).to_s.should == '011'
+      Origen::Value.new(:b10_11, size: 3).to_s.should == 'b011'
     end
 
     it "can extract bit values" do


### PR DESCRIPTION
This adds the ability to generate org files (Origen vector file format) as described in this RFC: https://github.com/Origen-SDK/rfcs/pull/7

This is not intended to be a user-facing feature, but is internal architecture for use within Origen and its plugins to generate org files or to otherwise capture and process sequences of operations.

#### To open an Org File for read or write

~~~ruby
Origen::OrgFile.open("some_id") do |org_file|
 
end

# Or without the block
org_file = Origen::OrgFile.open("some_id")

org_file.close
~~~

By default, the Org file will be created at `#{Origen.root}/pattern/org/#{current_target}/#{id}.org`, though the `open` method will accept `:path` and `:filename` options is you want to change it.

The only API the org_file object itself really provides to the application space is to check whether or not the underlying file exists:

~~~ruby
org_file.exist?    # => True if the corresponding .org file is found on disk
~~~

#### To Read an Org File

An example of reading and executing an Org file is shown below:

~~~ruby
org_file.read_line do |operations, cycles|  # => [[<object>, method, *args], [<object>, ...]], cycles
  operations.each do |object, operation, *args|
    object.send(operation, *args)
  end
end
~~~

#### To Write an Org File

The `org_file` instance is not intended to be written to directly by application code. Rather objects such as the pins, tester, etc. can be enabled to record the operations that are performed on them into the currently open org file:

~~~ruby
pin(:tdo).record_to_org_file    # Start recording all default method accesses on this object

# Temporarily pause recording then resume again
pin(:tdo).stop_recording_to_org_file do
  pin(:tdo).expect_lo
end

pin(:tdo).stop_recording_to_org_file

# You can call start again later if you want to
pin(:tdo).record_to_org_file(only: [:assert])   # Only record calls to the assert method

# Or to extend the default methods that are recorded
pin(:tdo).record_to_org_file(also: [:my_method1, :my_method2])
~~~

#### Giving objects record capability

This PR enables this recording feature on Pins and PinCollections (groups).

It can be quite easily enabled for other objects like this:

~~~ruby
class MyObj
  include Origen::OrgFile::Interceptable

  # Any class including the interceptable module must define this method to return a global
  # path to the object. i.e. this is string that will get written to the org file to represent the object
  # that is the target of the given operation, and the Org file reader must be able to eval this to
  # have the object returned
  def global_path_to
    "dut.some_accessor(#{id})"   # e.g. "dut.pins(:tdo)"
  end
end
~~~

By default the above won't capture any methods unless the user defines them when calling
`record_to_org_file` as shown in the above examples.

To define a default set of methods to be captured for the given class, define a method like
this:

~~~ruby
def org_file_intercepted_methods
  [:my_method1, :my_method2, ...]
end
~~~

#### A note on self!

TL:DR - If you include `OrgFile::Interceptable` in a class, never use the `self` keyword with that class's methods, use `myself` instead.

The capture works here by wrapping the object being recorded with a thin wrapper object which intercepts all operations called on the object and selectively records them as they go past before always passing on to the underlying object.

In order for the org file to be an accurate reflection of what a pattern does, it is vital that an un-wrapped copy of the object being recorded never finds its way into user space. i.e. if the application calls an operation on an un-wrapped object then it will not be be recorded.

I think the only way to generate such a reference to the un-wrapped object is when calling `self` from within the object's own methods.
Unfortunately, `self`, being a keyword rather than a method, is one of the few things that you can't override in Ruby.
So to get around that I created the `myself` method which returns the wrapped version of the object rather than the un-wrapped version you would get from `self`.

Generally all you need to do here is find/replace `self` with `myself` and you will see that in the Pin and PinCollection classes in this PR.

#### Notes on creating an Org file generator

@coreyeng, I think this is mostly all useful to you to help create the org file output of a whole pattern so that it can be replayed without the whole app being available.

I think we probably don't want to create an Org file tester driver, rather I would add a `--org-file` switch to `origen g`.

Then enable interceptable on the `OrigenTesters` base class and when you see the switch being set, open up an org file and call record on the tester and all DUT pins.

The `tester.cycle` method may need some special handling, currently there is a `Origen::OrgFile.cycle` method that should be called whenever a cycle occurs.


