### PR TITLE
Express global commands bugfix

### DIFF
--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -54,8 +54,11 @@ module Origen
       append = find_val('append_dot_origen')
       append = '.origen' if append == true || append.nil?
 
+      gem_append = find_val('append_dot_origen')
+      gem_append = 'gems' if gem_append == true || gem_append.nil?
+
       if append
-        unless path.end_with?(append)
+        unless path.end_with?(append) || path.end_with?(File.join(append, gem_append))
           path = File.join(path, append)
         end
       end
@@ -202,7 +205,7 @@ module Origen
           configs << YAML.load_file(file) if File.exist?(file) && YAML.load_file(file)
           path = path.parent
         end
-        
+
         # Add and any site_configs from the directory hierarchy where Ruby is installed
         path = Pathname.new($LOAD_PATH.last)
         until path.root?
@@ -210,13 +213,13 @@ module Origen
           configs << YAML.load_file(file) if File.exist?(file) && YAML.load_file(file)
           path = path.parent
         end
-        
+
         # Add the one from the Origen core as the lowest priority, this one defines
         # the default values
         configs << YAML.load_file(File.expand_path('../../../origen_site_config.yml', __FILE__))
         configs
       end
-      
+
       # Add the site_config from the user's home directory as highest priority, if it exists
       # But, make sure we take the site installation's setup into account.
       # That is, if user's home directories are somewhere else, make sure we use that directory to the find
@@ -225,7 +228,7 @@ module Origen
       if File.exist?(user_config)
         @configs.unshift(YAML.load_file(user_config)) if YAML.load_file(user_config)
       end
-      
+
       @configs
     end
   end

--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -54,11 +54,11 @@ module Origen
       append = find_val('append_dot_origen')
       append = '.origen' if append == true || append.nil?
 
-      gem_append = find_val('append_dot_origen')
+      gem_append = find_val('append_gems')
       gem_append = 'gems' if gem_append == true || gem_append.nil?
 
       if append
-        unless path.end_with?(append) || path.end_with?(File.join(append, gem_append))
+        unless path.end_with?(append) || (path.end_with?(File.join(append, gem_append)) if gem_append)
           path = File.join(path, append)
         end
       end


### PR DESCRIPTION
@ginty was able to update our system gems to use Origen post express-global-commands. The main feature worked but there was one bug and one inconsistency (I wouldn't call it a bug based on what I meant to do, but was convinced that what I meant to do was wrong... so okay, two bugs).

Firstly, the user's site config was being ignored. Since the home_dir is now being evaluated during the site config parsing, the user_install_dir was actually pointing to nil the first time around. So, even if you had a user site config, it wouldn't be added. Updated the site config to first parse all the site configs in the normal sense, then jump to <code>home_dir</code> and throw in that site config, if it exist. This should get user installs going again. This still takes place before any gems are installed and before anything is booted, so the net effect stays the same.

Secondly, if you have a site config setup already, the paths may evaluate differently then before. For example, our site config sets <code>gem_install_dir</code> as <code>~/.origen/gems</code>. This would evaluate the <code>gem_install_dir</code> as <code>/home/coreyeng/.origen/gems</code>, then append <code>.origen</code> then append <code>gems</code>. This was my intended behavior. Who am I to say you can't you can't put your gems at <code>/home/coreyeng/.origen/gems/.origen/gems</code>? New site configs wouldn't have <code>gem_install_dir</code> set at all so this would be a non-issue. However, for backwards compatibility purposes, an additional check was added to not append the <code>append_dot_origen</code> and <code>append_gems</code> values, if they already exist. This  should mean legacy site configs are left alone and if you really want to do the above, you can edit your <code>append_gems</code> to be <code>gems/.origen/gems</code>. So, the flexibility exist and its backwards compatible.