### PR TITLE
updated clock API to have min/max methods based on freq range.  Creat…

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -68,6 +68,7 @@ unless defined? RGen::ORIGENTRANSITION
     autoload :Clocks,            'origen/clocks'
     autoload :Value,             'origen/value'
     autoload :OrgFile,           'origen/org_file'
+    autoload :Limits,            'origen/limits'
 
     attr_reader :switch_user
 

--- a/lib/origen/clocks/clock.rb
+++ b/lib/origen/clocks/clock.rb
@@ -78,6 +78,24 @@ module Origen
       end
       alias_method :target, :freq_target
 
+      # min method
+      def min
+        if @freq_range == :fixed
+          @freq_target
+        else
+          @freq_range.first
+        end
+      end
+
+      # max method
+      def max
+        if @freq_range == :fixed
+          @freq_target
+        else
+          @freq_range.last
+        end
+      end
+
       # Check if the clock users are defined anywhere in the DUT
       def users_defined?
         undefined_ips = ips - Origen.all_sub_blocks

--- a/lib/origen/limits.rb
+++ b/lib/origen/limits.rb
@@ -1,0 +1,37 @@
+require_relative './limits/limit'
+require_relative './limits/limit_set'
+module Origen
+  module Limits
+    TYPES = [:min, :typ, :max, :target]
+
+    def add_limits(set, options)
+      @_limits ||= {}
+      options.ids.each do |limit_type|
+        unless TYPES.include? limit_type
+          Origen.log.error("Limit type '#{limit_type}' not supported, choose from #{TYPES}!")
+          fail
+        end
+      end
+      if @_limits.include? set
+        # Limit set already exists, modify it unless it is frozen
+        unless @_limits[set].frozen?
+          options.each do |limit_type, limit_expr|
+            @_limits[set].send("#{limit_type}=", limit_expr)
+          end
+        end
+      else
+        # Create a default limit set
+        @_limits[set] = LimitSet.new(set, self, options)
+      end
+    end
+
+    def limits(set = nil)
+      @_limits ||= {}
+      if set.nil?
+        @_limits
+      else
+        @_limits[set]
+      end
+    end
+  end
+end

--- a/lib/origen/limits/limit.rb
+++ b/lib/origen/limits/limit.rb
@@ -1,0 +1,126 @@
+module Origen
+  module Limits
+    class Limit
+      attr_accessor :expr, :value, :owner, :type
+
+      def initialize(expr, type, owner, options = {})
+        @expr = expr
+        @owner = owner
+        @type = type
+        @value = evaluate_expr
+      end
+
+      # If the value is still a String then it could be
+      # due to referencing another LimitSet that is
+      # yet to be defined
+      def value
+        if @value.is_a?(String)
+          evaluate_expr
+        else
+          @value
+        end
+      end
+
+      # Backwards compatibility
+      def exp
+        @expr
+      end
+
+      private
+
+      def fetch_reference_value(ref)
+        ref = ref.to_sym unless ref.is_a?(Symbol)
+        # Check if the reference is to another limit set
+        if owner.limits.include? ref
+          return owner.limits(ref).send(type).value
+          # Check if the reference is to a power domain
+        end
+        if Origen.top_level.respond_to? :power_domains
+          if Origen.top_level.power_domains.include? ref
+            # Need to check the limit type and retrieve the appropriate value
+            case @type.to_s
+            when /target|typ/
+              return Origen.top_level.power_domains(ref).nominal_voltage
+            else
+              return Origen.top_level.power_domains(ref).send(@type)
+            end
+          end
+        end
+        # Check if the reference is to a clock
+        if Origen.top_level.respond_to? :clocks
+          if Origen.top_level.clocks.include? ref
+            # Need to check the limit type and retrieve the appropriate value
+            case @type.to_s
+            when /target|typ/
+              return Origen.top_level.clocks(ref).freq_target
+            else
+              return Origen.top_level.clocks(ref).send(@type)
+            end
+          end
+        end
+      end
+
+      def evaluate_expr
+        return @expr if @expr.is_a?(Numeric)
+        return nil if @expr.nil?
+        if @expr.is_a? Symbol
+          @expr = ':' + @expr.to_s
+        else
+          @expr.gsub!("\n", ' ')
+          @expr.scrub!
+        end
+        result = false
+        if @expr.match(/\:\S+/)
+          limit_items = @expr.split(/\:|\s+/).reject(&:empty?)
+          if limit_items.size == 1
+            return fetch_reference_value(limit_items.first)
+          else
+            references = @expr.split(/\:|\s+/).select { |var| var.match(/^[a-zA-Z]\S+$/) }
+            new_limit_items = [].tap do |limit_ary|
+              limit_items.each do |item|
+                if references.include? item
+                  limit_ary << fetch_reference_value(item)
+                  next
+                else
+                  limit_ary << item
+                end
+              end
+            end
+            new_limit = new_limit_items.join(' ')
+            new_limit_references = new_limit.split(/\:|\s+/).select { |var| var.match(/^[a-zA-Z]\S+$/) }
+            if new_limit_references.empty?
+              result = eval(new_limit).round(4)
+            else
+              return @expr
+            end
+          end
+        elsif !!(@expr.match(/^\d+\.\d+$/)) || !!(@expr.match(/^-\d+\.\d+$/))
+          result = Float(@expr).round(4) rescue false # rubocop:disable Style/RescueModifier
+        elsif !!(@expr.match(/\d+\.\d+\s+\d+\.\d+/))
+          Origen.log.debug "Found two numbers without an operator in the @expr string '#{@expr}', choosing the first..."
+          first_number = @expr.match(/(\d+\.\d+)\s+\d+\.\d+/).captures.first
+          result = Float(first_number).round(4) rescue false # rubocop:disable Style/RescueModifier
+        else
+          result = Integer(@expr) rescue false # rubocop:disable Style/RescueModifier
+        end
+        if result == false
+          # Attempt to eval the @expr because users could write a @expr like "3.3 + 50.mV"
+          # which would not work with the code above but should eval to a number 3.35
+          begin
+            result = eval(@expr)
+            return result.round(4) if result.is_a? Numeric
+            rescue ::SyntaxError, ::NameError, ::TypeError
+              Origen.log.debug "Limit '#{@expr}' had to be rescued, storing it as a #{@expr.class}"
+              if @expr.is_a? Symbol
+                return @expr
+              else
+                return "#{@expr}"
+              end
+          end
+        else
+          return result
+        end
+      end
+    end
+  end
+end

--- a/lib/origen/limits/limit_set.rb
+++ b/lib/origen/limits/limit_set.rb
@@ -1,0 +1,120 @@
+require_relative './limit'
+module Origen
+  module Limits
+    class LimitSet
+      attr_accessor :id, :min, :typ, :max, :target, :description, :static, :owner, :type
+
+      def initialize(id, owner, options)
+        @id = id
+        @description = options[:description]
+        @owner = owner
+        @min = Limit.new(options[:min], :min, @owner) unless options[:min].nil?
+        @typ = Limit.new(options[:typ], :typ, @owner) unless options[:typ].nil?
+        @max = Limit.new(options[:max], :max, @owner) unless options[:max].nil?
+        @target = Limit.new(options[:target], :target, @owner) unless options[:target].nil?
+        unless options[:static].nil?
+          unless [true, false].include? options[:static]
+            Origen.log.error("Static option must be set to 'true' or 'false'!")
+            fail
+          end
+        end
+        @static = options[:static].nil? ? false : options[:static]
+        fail unless limits_ok?
+      end
+
+      # Common alias
+      def name
+        @id
+      end
+
+      def frozen?
+        @static
+      end
+
+      def min=(val)
+        if frozen?
+          Origen.log.warn('Cannot change a frozen limit set!')
+        else
+          @min = Limit.new(val, :min, @owner)
+        end
+      end
+
+      def max=(val)
+        if frozen?
+          Origen.log.warn('Cannot change a frozen limit set!')
+        else
+          @max = Limit.new(val, :max, @owner)
+        end
+      end
+
+      def typ=(val)
+        if frozen?
+          Origen.log.warn('Cannot change a frozen limit set!')
+        else
+          @typ = Limit.new(val, :typ, @owner)
+        end
+      end
+
+      def target=(val)
+        if frozen?
+          Origen.log.warn('Cannot change a frozen limit set!')
+        else
+          @target = Limit.new(val, :target, @owner)
+        end
+      end
+
+      private
+
+      # Check that min, max are not mixed with typ.  If a user wants
+      # a baseline value for a spec use target as it will not be
+      # checked against pass/fail
+      def limits_ok?
+        status = true
+        # Must have at least one of the limit types defined
+        if @min.nil? && @max.nil? && @typ.nil? && @target.nil?
+          Origen.log.error("Limit set #{@id} does not have any limits defined!")
+          return false
+        end
+        if @min.nil? ^ @max.nil?
+          @type = :single_sided
+          unless @typ.nil?
+            status = false
+            Origen.log.error "Limit set #{@id} has a typical limit defined with either min or max.  They are mutually exclusive, use 'target' when using min or max"
+          end
+          # Check if the target is OK
+          unless @target.nil?
+            if @min.nil?
+              unless @target < @max
+                status = false
+                Origen.log.error("Limit set #{@id} has the target value #{@target} set greater than the max value #{@max}!")
+              end
+            else
+              unless @target > @min
+                status = false
+                Origen.log.error("Limit set #{@id} has the target value #{@target} set less than the min value #{@min}!")
+              end
+            end
+          end
+        elsif @min.expr && @max.expr
+          @type = :double_sided
+          # Both min and max must be numerical to compare them
+          if @min.value.is_a?(Numeric) && @max.value.is_a?(Numeric)
+            # Check that min and max make sense
+            if @max.value <= @min.value || @min.value >= @max.value
+              status = false
+              Origen.log.error "Limit set #{@id} has min (#{@min.value}) and max (#{@max.value}) reversed"
+            end
+            # Check that target is OK
+            unless @target.nil?
+              if @target.value <= @min.value || @target.value >= @max.value
+                status = false
+                Origen.log.error "Limit set #{@id} has a target (#{@target.value}) that is not within the min (#{@min.value}) and max #{@max.value}) values"
+              end
+            end
+          end
+        end
+        status
+      end
+    end
+  end
+end

--- a/lib/origen/model.rb
+++ b/lib/origen/model.rb
@@ -34,6 +34,7 @@ module Origen
       include Origen::Clocks
       include Origen::Model::Exporter
       include Origen::Component
+      include Origen::Limits
     end
 
     module ClassMethods

--- a/lib/origen/tests/test.rb
+++ b/lib/origen/tests/test.rb
@@ -1,6 +1,9 @@
+require 'origen/limits'
 module Origen
   module Tests
     class Test
+      include Limits
+
       attr_accessor :id, :owner, :description, :conditions, :platforms
 
       def initialize(id, options = {}, &block)

--- a/spec/clocks_spec.rb
+++ b/spec/clocks_spec.rb
@@ -47,6 +47,8 @@ describe "Clocks" do
     dut.clocks.size.should == 3
     dut.clocks(:cclk).description.should == 'Core complex clock'
     dut.clocks(:cclk).range.should == (0.8.Ghz..3.2.Ghz)
+    dut.clocks(:cclk).min.should == 0.8.Ghz
+    dut.clocks(:cclk).max.should == 3.2.Ghz
     dut.clocks(:cclk).setpoint.should == 2.5.Ghz
     dut.clocks(:cclk).users.should == [:core_complex]
     dut.clocks(:ddrclk).setpoint.should == 2.0.Ghz
@@ -61,6 +63,8 @@ describe "Clocks" do
     dut.clocks(:ddrclk).setpoint = 1.6.Ghz
     dut.clocks(:socclk).setpoint = 800.Mhz
     dut.clocks(:socclk).setpoint.should == 800.Mhz
+    dut.clocks(:socclk).min.should == 1.2.Ghz
+    dut.clocks(:socclk).min.should == dut.clocks(:socclk).max
     dut.clocks.inspect
   end
 

--- a/spec/limits_spec.rb
+++ b/spec/limits_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+
+class SoC_With_TestLimits
+  include Origen::TopLevel
+  
+  # EDS == Electrical Data Sheet
+  EDS_PIN_LKG_SPEC = 1.uA
+
+  def initialize(options = {}) 
+    add_power_domain :vddio do |d|
+      d.description = '1.8V I/Os'
+      d.nominal_voltage = 1.8.V
+      d.maximum_voltage_rating = 2.50.V
+      d.min = 1.62.V
+      d.max = 1.98.V 
+    end
+    add_clock :core_clk do |c|
+      c.description = 'Core clock'
+      c.freq_target = 2.5.Ghz
+      c.freq_range = 0.8.Ghz..3.2.Ghz
+      c.users = [:core_complex]
+      c.instantiate_users = false
+    end  
+    add_test :pin_leakage do |t|
+      t.description = 'pin leakage, pin to GND and pin to RAIL'
+      t.conditions  = [:minvdd, :maxvdd]
+      t.platforms   = [:v93k]
+    end.add_limits(:eds, min: (EDS_PIN_LKG_SPEC * -1), max: EDS_PIN_LKG_SPEC, )
+    tests(:pin_leakage).add_limits(:ws, min: -100.nA, max: 100.nA)
+    tests(:pin_leakage).add_limits(:ft, min: -500.nA, max: 500.nA)
+    add_test :voh do |t|
+      t.description = 'I/O voltage output high'
+      t.conditions  = [:minvdd, :maxvdd]
+      t.platforms   = [:v93k]
+    end.add_limits(:eds, min: ":vddio * 0.7" )
+    tests(:voh).add_limits(:ws, min: ":vddio * 0.55")
+    tests(:voh).add_limits(:ft, min: ":eds - 10.mV")
+    add_test :fmin do |t|
+      t.description = 'Frequency Min'
+      t.conditions  = [:minvdd, :maxvdd]
+      t.platforms   = [:v93k]
+    end.add_limits(:eds, min: :core_clk )
+    tests(:fmin).add_limits(:ws, min: :eds)
+    tests(:fmin).add_limits(:ft, min: ":eds + 50.Mhz")
+  end
+end
+
+describe "Origen Limits" do
+
+  before :each do
+    Origen.app.unload_target!
+    Origen.target.temporary = -> { SoC_With_TestLimits.new }
+    Origen.load_target
+  end
+
+  after :all do
+    Origen.app.unload_target!
+  end
+  
+  it 'can add limits to an existing test' do
+    dut.tests.size.should == 3
+    dut.tests(:pin_leakage).limits.class.should == Hash
+    dut.tests(:pin_leakage).limits(:eds).min.value.should == -1.uA
+    dut.tests(:pin_leakage).limits(:eds).min.value.should == dut.tests(:pin_leakage).limits(:eds).min.expr
+    dut.tests(:pin_leakage).limits(:eds).max.value.should == 1.uA
+    dut.tests(:pin_leakage).limits(:eds).max.value.should == dut.tests(:pin_leakage).limits(:eds).max.expr
+    dut.tests(:pin_leakage).limits(:ws).min.value.should == -100.nA
+    dut.tests(:pin_leakage).limits(:ws).min.value.should == dut.tests(:pin_leakage).limits(:ws).min.expr
+    dut.tests(:pin_leakage).limits(:ws).max.value.should == 100.nA
+    dut.tests(:pin_leakage).limits(:ws).max.value.should == dut.tests(:pin_leakage).limits(:ws).max.expr
+    dut.tests(:pin_leakage).limits(:ft).min.value.should == -500.nA
+    dut.tests(:pin_leakage).limits(:ft).min.value.should == dut.tests(:pin_leakage).limits(:ft).min.expr
+    dut.tests(:pin_leakage).limits(:ft).max.value.should == 500.nA
+    dut.tests(:pin_leakage).limits(:ft).max.value.should == dut.tests(:pin_leakage).limits(:ft).max.expr
+  end
+  
+  it 'can reference a clock object in a limit expression' do
+    dut.tests(:fmin).limits(:eds).min.expr.should == ":core_clk"
+    dut.clocks(:core_clk).min.should == 0.8.Ghz
+    dut.tests(:fmin).limits(:eds).min.value.should == dut.clocks(:core_clk).min
+  end
+  
+  it 'can reference a power domain object in a limit expression' do
+    dut.tests(:voh).limits(:eds).min.expr.should == ":vddio * 0.7"
+    dut.power_domains(:vddio).min.should == 1.62.V
+    dut.tests(:voh).limits(:eds).min.value.should == dut.power_domains(:vddio).min * 0.7
+  end
+  
+  it 'can use references to another limit set in a limit expression' do
+    dut.tests(:fmin).limits(:ws).min.value.should == dut.tests(:fmin).limits(:eds).min.value
+    dut.tests(:fmin).limits(:ws).min.value.should == 0.8.Ghz
+    dut.tests(:fmin).limits(:ft).min.value.should == dut.tests(:fmin).limits(:eds).min.value + 50.Mhz
+    dut.tests(:fmin).limits(:ft).min.value.should == 0.8.Ghz + 50.Mhz
+  end
+    
+end 
+    


### PR DESCRIPTION
Eventually Origen::Specs would incorporate this module.  Why would someone use Limits by itself?  Origen::Specs is designed to model a four dimensional specification universe that is more than what many folks need.  This PR also includes the enhancement of allowing users to create limit sets versus just one static limit set.  Users can reference other objects using symbols in formulas with the following scope hierarchy:

1. Another limit set
2. Power domains
3. Clocks

I think eventually the user will be able to pass in any object path (similar to Parameters) as an option to change where to look for symbol references.  Here are some examples of adding in limits to tests, for each of the 3 cases above.

~~~ruby
    add_test :pin_leakage do |t|
      t.description = 'pin leakage, pin to GND and pin to RAIL'
      t.conditions  = [:minvdd, :maxvdd]
      t.platforms   = [:v93k]
    end.add_limits(:eds, min: (EDS_PIN_LKG_SPEC * -1), max: EDS_PIN_LKG_SPEC, )
    tests(:pin_leakage).add_limits(:ws, min: -100.nA, max: 100.nA)
    tests(:pin_leakage).add_limits(:ft, min: -500.nA, max: 500.nA)
    add_test :voh do |t|
      t.description = 'I/O voltage output high'
      t.conditions  = [:minvdd, :maxvdd]
      t.platforms   = [:v93k]
    end.add_limits(:eds, min: ":vddio * 0.7" )
    tests(:voh).add_limits(:ws, min: ":vddio * 0.55")
    tests(:voh).add_limits(:ft, min: ":eds - 10.mV")
    add_test :fmin do |t|
      t.description = 'Frequency Min'
      t.conditions  = [:minvdd, :maxvdd]
      t.platforms   = [:v93k]
    end.add_limits(:eds, min: :core_clk )
    tests(:fmin).add_limits(:ws, min: :eds)
    tests(:fmin).add_limits(:ft, min: ":eds + 50.Mhz")
~~~

Hope this explains it better @ginty 