### PR TITLE
on_mode_changed callback added

### DIFF
--- a/lib/origen/model.rb
+++ b/lib/origen/model.rb
@@ -206,6 +206,7 @@ module Origen
         unless top_level?
           # Need to do this in case a class besides SubBlock includes Origen::Model
           obj_above_self = parent.nil? ? Origen.top_level : parent
+          return nil if obj_above_self.nil?
           if obj_above_self.current_mode
             _modes[obj_above_self.current_mode.id] if _modes.include? obj_above_self.current_mode.id
           end
@@ -217,6 +218,10 @@ module Origen
     # Set the current mode configuration of the current model
     def current_mode=(id)
       @current_mode = id.is_a?(ChipMode) ? id.id : id
+      Origen.app.listeners_for(:on_mode_changed).each do |listener|
+        listener.on_mode_changed(mode: @current_mode)
+      end
+      @current_mode
     end
     alias_method :mode=, :current_mode=
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -4,8 +4,15 @@ module ModelSpec
   class MyModel
     include Origen::Model
     attr_reader :my_version
+    attr_accessor :mode_changed_count
     def initialize
       @my_version = version
+       add_mode :mode1
+      @mode_changed_count = 0
+    end
+    
+    def on_mode_changed(options)
+      @mode_changed_count += 1
     end
   end
 
@@ -48,6 +55,15 @@ module ModelSpec
     it "model hierarchy from c90tfs micros works" do
       P2.new(2, blah: 3).some_val.should == "hello"
       P2.new(2, blah: 3).version.should == 2
+    end
+    
+    it 'on_mode_changed callback works' do
+      m = MyModel.new
+      m.modes.should == [:mode1]
+      m.mode.should == nil
+      m.mode_changed_count.should == 0
+      m.mode = :mode1
+      m.mode_changed_count.should == 1
     end
   end
 end

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -144,13 +144,13 @@ There now follows a listing of all available callbacks, these have been split up
 
 * [Environment Setup](#environment_setup)
 * [Environment Teardown](#environment_teardown)
+* [Mode Changed](#mode_changed)
 * [Generation](#generation)
 * [Reset](#reset)
 * [Pattern Generation](#pattern_generation)
 * [Program Generation](#program_generation)
 * [Web Compiler](#web_compiler)
 * [Release Process](#release_process)
-* [Intializing Models](#initializing_models)
 
 <a class="anchor" name="environment_setup"></a>
 
@@ -265,7 +265,14 @@ guaranteed to be called even if the thread crashes.
 
 An example use cases is to ensure that any temporary files are deleted.
 
+<a class="anchor" name="mode_changed"></a>
 
+### Mode Changed
+
+#### on_mode_changed
+
+This callback is triggered whenever an object [changes its current mode](http://origen-sdk.org/origen/api/Origen/Model.html#current_mode=-instance_method).
+It can be used to change other DUT objects, such as clocks and register settings.
 
 <a class="anchor" name="generation"></a>
 
@@ -678,79 +685,5 @@ def before_deploy_site
   end
 end
 ~~~  
-
-<a class="anchor" name="initializing_models"></a>
-
-### Initializing Models
-
-#### origen_model_init
-
-Called only when a <code>class</code> or <code>module</code> has a <code>class method</code> called
-<code>origen_model_init</code> <u>AND</u> when said class mixes in <code>Origen::Model</code>.
-
-This will be called during the class' instantiation process, when the class has been allocated but before
-it has been initialized using its own <code>initialize</code> method. This can be used to boot modules or
-classes using Origen and leaving a module's <code>included?</code> method alone.
-
-This differs from the <code>pre_initialize</code> callback in that <code>origen_model_init</code> will recurse
-into the inherited modules and classes.
-
-This method should accept a single argument, which is the allocated class instance that called <code>origen_model_init</code>.
-
-For example:
-
-~~~ruby
-module A
-  def self.origen_model_init(instance_of_caller)
-    puts "init module A - called by #{instance_of_caller.class}"
-  end
-  
-  class B
-    def self.origen_model_init(instance_of_caller)
-      puts "init class B in module A - called by #{instance_of_caller.class}"
-    end
-  end
-end
-
-class Parent
-  include Origen::Model
-  include A
-end
-
-Parent.new
-  #=> "init module A - called by Parent"
-  #=> "init class B in module A - called by Parent" <= this is called prior to any A::B initialization.
-#=> Instance of Parent class
-
-~~~
-
-Note that included modules and classes do not need to mix in <code>Origen::Model</code>. Only the class including
-said modules and classes.
-
-Again, this is for use in booting included classes and modules, not in booting the parent. <code>origen_model_init</code>
-will NOT be called in following and <code>pre_initialize</code> should be used:
-
-~~~ruby
-
-class Parent
-  include Origen::Model
-  include A
-  
-  def self.origen_model_init(instance_of_caller)
-    puts "origen_model_init in Parent"
-  end
-  
-  def self.pre_initialize
-    puts "pre_initialize in Parent"
-  end
-end
-
-Parent.new
-  #=> "init module A - called by Parent"
-  #=> "init class B in module A - called by Parent"
-  #=> "pre_initialize in Parent"
-#=> Instance of Parent class
-
-~~~
 
 % end

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -274,7 +274,7 @@ An example use cases is to ensure that any temporary files are deleted.
 #### on_mode_changed
 
 This callback is triggered whenever an object [changes its current mode](<%= path "api/Origen/Model.html#current_mode=-instance_method" %>).
-It takes an options hash as an arguement with the recently changed mode being passed.  It can be used to change other DUT objects, 
+It takes an options hash as an argument with the recently changed mode being passed.  It can be used to change other DUT objects, 
 such as clocks and register settings.  
 
 ~~~ruby

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -144,13 +144,14 @@ There now follows a listing of all available callbacks, these have been split up
 
 * [Environment Setup](#environment_setup)
 * [Environment Teardown](#environment_teardown)
-* [Mode Changed](#mode_changed)
 * [Generation](#generation)
+* [Mode Changed](#mode_changed)
 * [Reset](#reset)
 * [Pattern Generation](#pattern_generation)
 * [Program Generation](#program_generation)
 * [Web Compiler](#web_compiler)
 * [Release Process](#release_process)
+* [Intializing Models](#initializing_models)
 
 <a class="anchor" name="environment_setup"></a>
 
@@ -265,6 +266,7 @@ guaranteed to be called even if the thread crashes.
 
 An example use cases is to ensure that any temporary files are deleted.
 
+
 <a class="anchor" name="mode_changed"></a>
 
 ### Mode Changed
@@ -273,6 +275,7 @@ An example use cases is to ensure that any temporary files are deleted.
 
 This callback is triggered whenever an object [changes its current mode](http://origen-sdk.org/origen/api/Origen/Model.html#current_mode=-instance_method).
 It can be used to change other DUT objects, such as clocks and register settings.
+
 
 <a class="anchor" name="generation"></a>
 
@@ -685,5 +688,79 @@ def before_deploy_site
   end
 end
 ~~~  
+
+<a class="anchor" name="initializing_models"></a>
+
+### Initializing Models
+
+#### origen_model_init
+
+Called only when a <code>class</code> or <code>module</code> has a <code>class method</code> called
+<code>origen_model_init</code> <u>AND</u> when said class mixes in <code>Origen::Model</code>.
+
+This will be called during the class' instantiation process, when the class has been allocated but before
+it has been initialized using its own <code>initialize</code> method. This can be used to boot modules or
+classes using Origen and leaving a module's <code>included?</code> method alone.
+
+This differs from the <code>pre_initialize</code> callback in that <code>origen_model_init</code> will recurse
+into the inherited modules and classes.
+
+This method should accept a single argument, which is the allocated class instance that called <code>origen_model_init</code>.
+
+For example:
+
+~~~ruby
+module A
+  def self.origen_model_init(instance_of_caller)
+    puts "init module A - called by #{instance_of_caller.class}"
+  end
+  
+  class B
+    def self.origen_model_init(instance_of_caller)
+      puts "init class B in module A - called by #{instance_of_caller.class}"
+    end
+  end
+end
+
+class Parent
+  include Origen::Model
+  include A
+end
+
+Parent.new
+  #=> "init module A - called by Parent"
+  #=> "init class B in module A - called by Parent" <= this is called prior to any A::B initialization.
+#=> Instance of Parent class
+
+~~~
+
+Note that included modules and classes do not need to mix in <code>Origen::Model</code>. Only the class including
+said modules and classes.
+
+Again, this is for use in booting included classes and modules, not in booting the parent. <code>origen_model_init</code>
+will NOT be called in following and <code>pre_initialize</code> should be used:
+
+~~~ruby
+
+class Parent
+  include Origen::Model
+  include A
+  
+  def self.origen_model_init(instance_of_caller)
+    puts "origen_model_init in Parent"
+  end
+  
+  def self.pre_initialize
+    puts "pre_initialize in Parent"
+  end
+end
+
+Parent.new
+  #=> "init module A - called by Parent"
+  #=> "init class B in module A - called by Parent"
+  #=> "pre_initialize in Parent"
+#=> Instance of Parent class
+
+~~~
 
 % end

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -274,8 +274,21 @@ An example use cases is to ensure that any temporary files are deleted.
 #### on_mode_changed
 
 This callback is triggered whenever an object [changes its current mode](http://origen-sdk.org/origen/api/Origen/Model.html#current_mode=-instance_method).
-It can be used to change other DUT objects, such as clocks and register settings.
+It takes an options hash as an arguement with the recently changed mode being passed.  It can be used to change other DUT objects, 
+such as clocks and register settings.  
 
+~~~ruby
+def on_mode_changed(options)
+  case options[:mode]
+  when :mode1
+    clocks(:coreclk).setpoint = 1.2.Ghz
+    clocks(:memclk).setpoint = 600.Mhz
+  when :mode2
+    clocks(:coreclk).setpoint = 1.0.Ghz
+    clocks(:memclk).setpoint = 500.Mhz
+  end
+end
+~~~
 
 <a class="anchor" name="generation"></a>
 

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -273,7 +273,7 @@ An example use cases is to ensure that any temporary files are deleted.
 
 #### on_mode_changed
 
-This callback is triggered whenever an object [changes its current mode](http://origen-sdk.org/origen/api/Origen/Model.html#current_mode=-instance_method).
+This callback is triggered whenever an object [changes its current mode](<%= path "api/Origen/Model.html#current_mode=-instance_method" %>).
 It takes an options hash as an arguement with the recently changed mode being passed.  It can be used to change other DUT objects, 
 such as clocks and register settings.  
 


### PR DESCRIPTION
First discussed [here](https://stackoverflow.com/questions/48811004/changing-object-data-using-with-mode-method).

~~~ruby
  class MyModel
    include Origen::Model
    attr_reader :my_version
    attr_accessor :mode_changed_count
    def initialize
      @my_version = version
       add_mode :mode1
      @mode_changed_count = 0
    end
    
    def on_mode_changed(options)
      @mode_changed_count += 1
    end
  end

    it 'on_mode_changed callback works' do
      m = MyModel.new
      m.modes.should == [:mode1]
      m.mode.should == nil
      m.mode_changed_count.should == 0
      m.mode = :mode1
      m.mode_changed_count.should == 1
    end
~~~