### PR TITLE
Remove dependency on p4ruby gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ PATH
       log4r (~> 1.1.10, ~> 1.1)
       nanoc (~> 3.7)
       net-ldap (~> 0.13)
-      p4ruby (~> 2015.2, >= 2015.2.1313860)
       pry (~> 0.10)
       rake (~> 10)
       rspec (~> 3)
@@ -103,8 +102,7 @@ GEM
       require_all (~> 1)
     origen_updater (0.7.0)
       origen
-    p4ruby (2015.2.1313860)
-    parser (2.5.0.3)
+    parser (2.5.0.4)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.11.3)

--- a/lib/origen/revision_control/perforce.rb
+++ b/lib/origen/revision_control/perforce.rb
@@ -1,109 +1,18 @@
-require 'P4'
 module Origen
   module RevisionControl
     class Perforce < Base
-      # P4 session
-      attr_reader :p4
-
-      # e.g. myfile.txt
-      attr_accessor :remote_file
-
       def initialize(options = {})
         super
-        @remotes_method = :print
-        @p4 = P4.new
-        @p4.maxresults = 1
-        parse_remote
-        @p4.connect
-        unless @p4.connected?
-          Origen.log.error("Could not connect to port #{@p4.port} on client #{@p4.client}!")
-          fail
-        end
-        @p4.run_login
-      end
-
-      # Downloads a file to a local directory, no workspace/client is created.  Perfect
-      # for read-only access like an application remote
-      def print(options = {})
-        options = {
-          verbose: true,
-          version: 'Latest'
-        }.merge(options)
-        cmd = [__method__.to_s, '-o', "#{@local}/#{@remote_file.to_s.split('/')[-1]}", @remote_file.to_s]
-        run cmd
-      end
-
-      def checkout(path = nil, options = {})
-        not_yet_supported(__method__)
-      end
-
-      def root
-        not_yet_supported(__method__)
-      end
-
-      def current_branch
-        not_yet_supported(__method__)
-      end
-
-      def diff_cmd
-        not_yet_supported(__method__)
-      end
-
-      def unmanaged
-        not_yet_supported(__method__)
-      end
-
-      def local_modifications
-        not_yet_supported(__method__)
-      end
-
-      def changes
-        not_yet_supported(__method__)
-      end
-
-      def checkin
-        not_yet_supported(__method__)
-      end
-
-      def build
-        not_yet_supported(__method__)
-      end
-
-      private
-
-      # Needs to be in the form of an Array with command, as a Sting, as the first argument
-      # e.g. ["print", "-o", "pins/myfile.txt", "//depot/myprod/main/doc/pinout/myfile.txt"]
-      def run(cmd)
-        p4.run cmd
-      end
-
-      def not_yet_supported(m)
-        Origen.log.warn("The method #{m} is not currently supported by the Perforce API")
-        nil
-      end
-
-      def parse_remote
-        (@p4.port, @remote_file) = @remote.to_s.match(/^p4\:\/\/(\S+\:\d+)(.*)/).captures unless @remote.nil?
-      end
-
-      def configure_client(options)
-        unless options.include? :local
-          Origen.log.error('Need options[:local] to know how to configure the Perforce client!')
-          fail
-        end
-        client_name = "#{Origen.app.name}_#{User.current.id}_#{Time.now.to_i}"
         begin
-          client_spec = @p4.fetch_client
-          client_spec['Root'] = options[:local].to_s
-          client_spec['Client'] = client_name
-          client_spec['View'] = ["#{@remote_file} //#{client_name}/#{@remote_file.split('/')[-1]}"]
-          client_spec['Host'] = nil
-          @p4.save_client(client_spec)
-          @p4.client = client_name
-        rescue P4Exception
-          @p4.errors.each { |e| Origen.log.error e }
-          raise
+          require 'origen_perforce'
+        rescue LoadError
+          puts 'To use the Perforce revision control system with Origen, you must add the following gem to your Gemfile:'
+          puts
+          puts "  gem 'origen_perforce'"
+          puts
+          exit 1
         end
+        _initialize_(options)
       end
     end
   end

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -51,5 +51,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sinatra", "~>1" # Not required by Origen, but Geminabox. V1 required to avoid Ruby 2.3 requirement.
   spec.add_runtime_dependency "dentaku", "~>2"
   spec.add_runtime_dependency "colorize", "~> 0.8.1"
-  spec.add_runtime_dependency 'p4ruby', '~> 2015.2', '>= 2015.2.1313860'
 end


### PR DESCRIPTION
The p4ruby gem has caused a bit of havoc within the NXP environment due to it requiring a native extension which it seems to want to download from a 3rd party location via FTP.

We could probably update our firewall rules or whatever to fix this, but it generally highlights that its not worth including non-native Ruby gems if they don't add significant value to a majority of users.

For this reason, the Perforce driver has been extracted to a plugin, making the p4ruby dependency opt-in rather than included by default.

All this means is that any applications that want to use the Perforce driver capability must now add this to their Gemfile:

~~~ruby
gem 'origen_perforce'
~~~

After that, it is business as usual.


