### PR TITLE
Dynamic Testflow Comments

### DIFF
--- a/lib/origen/global_methods.rb
+++ b/lib/origen/global_methods.rb
@@ -6,7 +6,12 @@ module Origen
     end
 
     def c1(msg, options = {})
-      Origen.app.tester.c1(msg, options)
+      if Origen.tester.generating == :program
+        # Test Flow cc call must be on the line directly before test method
+        Origen.app.tester.c3(msg, options, caller_locations(1, 1)[0].lineno + 1)
+      else
+        Origen.app.tester.c1(msg, options)
+      end
     end
     alias_method :cc, :c1
 


### PR DESCRIPTION
Hijack cc method when called during program generation for creating dynamic descriptions, requires corresponding origen_testers change.