### PR TITLE
changed when Origen.current_command is available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       require_all (~> 1)
     origen_updater (0.7.0)
       origen
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.11.3)

--- a/lib/origen/commands.rb
+++ b/lib/origen/commands.rb
@@ -26,6 +26,9 @@ ORIGEN_COMMAND_ALIASES = {
 @command = ORIGEN_COMMAND_ALIASES[@command] || @command
 @global_commands = []
 
+# Moved here so boot.rb file can know the current command
+Origen.send :current_command=, @command
+
 # Don't log to file during the save command since we need to preserve the last log,
 # this is done as early in the process as possible so any deprecation warnings during
 # load don't trigger a new log
@@ -91,7 +94,6 @@ require 'origen/global_methods'
 include Origen::GlobalMethods
 
 Origen.lsf.current_command = @command
-Origen.send :current_command=, @command
 
 if ARGV.delete('-d') || ARGV.delete('--debug')
   begin


### PR DESCRIPTION
this allows code in `boot.rb` to query `Origen.current_command`, relating to [this discussion](https://stackoverflow.com/questions/49636962/can-origen-current-command-be-nil).