### PR TITLE
Allow self-identification in on_mode_changed callback

### DIFF
--- a/lib/origen/model.rb
+++ b/lib/origen/model.rb
@@ -219,7 +219,7 @@ module Origen
     def current_mode=(id)
       @current_mode = id.is_a?(ChipMode) ? id.id : id
       Origen.app.listeners_for(:on_mode_changed).each do |listener|
-        listener.on_mode_changed(mode: @current_mode, klass: self)
+        listener.on_mode_changed(mode: @current_mode, instance: self)
       end
       @current_mode
     end

--- a/lib/origen/model.rb
+++ b/lib/origen/model.rb
@@ -219,7 +219,7 @@ module Origen
     def current_mode=(id)
       @current_mode = id.is_a?(ChipMode) ? id.id : id
       Origen.app.listeners_for(:on_mode_changed).each do |listener|
-        listener.on_mode_changed(mode: @current_mode)
+        listener.on_mode_changed(mode: @current_mode, klass: self)
       end
       @current_mode
     end

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -279,13 +279,15 @@ such as clocks and register settings.
 
 ~~~ruby
 def on_mode_changed(options)
-  case options[:mode]
-  when :mode1
-    clocks(:coreclk).setpoint = 1.2.Ghz
-    clocks(:memclk).setpoint = 600.Mhz
-  when :mode2
-    clocks(:coreclk).setpoint = 1.0.Ghz
-    clocks(:memclk).setpoint = 500.Mhz
+  if options[:klass] == self
+    case options[:mode]
+    when :mode1
+      clocks(:coreclk).setpoint = 1.2.Ghz
+      clocks(:memclk).setpoint = 600.Mhz
+    when :mode2
+      clocks(:coreclk).setpoint = 1.0.Ghz
+      clocks(:memclk).setpoint = 500.Mhz
+    end
   end
 end
 ~~~

--- a/templates/web/guides/misc/callbacks.md.erb
+++ b/templates/web/guides/misc/callbacks.md.erb
@@ -279,7 +279,7 @@ such as clocks and register settings.
 
 ~~~ruby
 def on_mode_changed(options)
-  if options[:klass] == self
+  if options[:instance] == self
     case options[:mode]
     when :mode1
       clocks(:coreclk).setpoint = 1.2.Ghz


### PR DESCRIPTION
Pass self into on_mode_changed so that listeners can self-identify (and then optionally perform some task).  Mainly used when sub-models (e.g. sub-blocks) contain modes that are separate from any top-level modes (or modes of other sub-models).