### PR TITLE
Make regular comparison operators work

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -94,7 +94,7 @@ unless defined? RGen::ORIGENTRANSITION
         if str =~ /^\s\s\s\s\s\s\s*(.*)/
           (' ' * 20) + Regexp.last_match(1)
         # http://rubular.com/r/MKmU4xZgO2
-        elsif str =~ /^\s*([^\s]+)\s+*(.*)/
+        elsif str =~ /^\s*([^\s]+)\s+(.*)/
           ' ' + Regexp.last_match(1).ljust(19) + Regexp.last_match(2)
         else
           str

--- a/lib/origen/version_string.rb
+++ b/lib/origen/version_string.rb
@@ -29,25 +29,37 @@ module Origen
       !production?
     end
 
+    alias_method :orig_equal?, :==
+
+    def equal?(version)
+      condition_met?("== #{version}")
+    end
+    alias_method :eq?, :equal?
+    alias_method :==, :equal?
+
     def less_than?(version)
       condition_met?("< #{version}")
     end
     alias_method :lt?, :less_than?
+    alias_method :<, :less_than?
 
     def less_than_or_equal_to?(version)
       condition_met?("<= #{version}")
     end
     alias_method :lte?, :less_than_or_equal_to?
+    alias_method :<=, :less_than_or_equal_to?
 
     def greater_than?(version)
       condition_met?("> #{version}")
     end
     alias_method :gt?, :greater_than?
+    alias_method :>, :greater_than?
 
     def greater_than_or_equal_to?(version)
       condition_met?(">= #{version}")
     end
     alias_method :gte?, :greater_than_or_equal_to?
+    alias_method :>=, :greater_than_or_equal_to?
 
     # Returns true if the version is a correctly formatted semantic
     # or timestamp version number
@@ -169,7 +181,7 @@ module Origen
     alias_method :dev, :pre
 
     def latest?
-      downcase == 'trunk' || downcase == 'latest'
+      downcase.orig_equal?('trunk') || downcase.orig_equal?('latest')
     end
 
     # Returns true if the version is a timestamp format version number
@@ -225,11 +237,11 @@ module Origen
 
       elsif condition =~ /^==?\s*(.*)/
         tag = validate_condition!(condition, Regexp.last_match[1])
-        self == tag
+        self.orig_equal?(tag)
 
       else
         tag = validate_condition!(condition, condition)
-        self == tag
+        self.orig_equal?(tag)
       end
     end
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -141,87 +141,89 @@ describe Origen::VersionString do
 
       it "equal works" do
         ref = Origen::VersionString.new("v2.2.2")
-        ref.condition_met?("v2.2.2").should == true
-        ref.condition_met?("= v2.2.2").should == true
-        ref.condition_met?("== v2.2.2").should == true
-        ref.condition_met?("v1.2.2").should == false
-        ref.condition_met?("v2.1.2").should == false
-        ref.condition_met?("v2.2.1").should == false
-        ref.condition_met?("v2.2.2.dev2").should == false
+        (ref == " v2.2.2").should == true
+        (ref == "v2.2.2").should == true
+        (ref == "v2.2.2").should == true
+        (ref == "v1.2.2").should == false
+        (ref == "v2.1.2").should == false
+        (ref == "v2.2.1").should == false
+        (ref == "v2.2.2.dev2").should == false
         ref = Origen::VersionString.new("2.2.2")
-        ref.condition_met?("2.2.2").should == true
-        ref.condition_met?("= 2.2.2").should == true
-        ref.condition_met?("== 2.2.2").should == true
-        ref.condition_met?("1.2.2").should == false
-        ref.condition_met?("2.1.2").should == false
-        ref.condition_met?("2.2.1").should == false
-        ref.condition_met?("2.2.2.pre2").should == false
+        (ref == " 2.2.2").should == true
+        (ref == "2.2.2").should == true
+        (ref == "2.2.2").should == true
+        (ref == "1.2.2").should == false
+        (ref == "2.1.2").should == false
+        (ref == "2.2.1").should == false
+        (ref == "2.2.2.pre2").should == false
       end
 
       it "greater than works" do
         ref = Origen::VersionString.new("v2.2.2")
-        ref.condition_met?("> v2.2.2").should == false
+        (ref > " v2.2.2").should == false
 
-        ref.condition_met?("> v1.2.2").should == true
-        ref.condition_met?("> v3.2.2").should == false
-        ref.condition_met?(">v2.1.2").should == true
-        ref.condition_met?(">v2.3.2").should == false
-        ref.condition_met?(">v2.2.1").should == true
-        ref.condition_met?(">v2.2.3").should == false
-        ref.condition_met?("> v2.2.1.dev2").should == true
-        ref.condition_met?("> v2.2.2.dev2").should == false
+        (ref > " v1.2.2").should == true
+        (ref > " v3.2.2").should == false
+        (ref > "v2.1.2").should == true
+        (ref > "v2.3.2").should == false
+        (ref > "v2.2.1").should == true
+        (ref > "v2.2.3").should == false
+        (ref > " v2.2.1.dev2").should == true
+        (ref > " v2.2.2.dev2").should == false
 
         ref = Origen::VersionString.new("2.2.2")
-        ref.condition_met?("> 2.2.2").should == false
+        (ref > " 2.2.2").should == false
 
-        ref.condition_met?("> 1.2.2").should == true
-        ref.condition_met?("> 3.2.2").should == false
-        ref.condition_met?(">2.1.2").should == true
-        ref.condition_met?(">2.3.2").should == false
-        ref.condition_met?(">2.2.1").should == true
-        ref.condition_met?(">2.2.3").should == false
-        ref.condition_met?("> 2.2.1.dev2").should == true
-        ref.condition_met?("> 2.2.2.dev2").should == false
+        (ref > " 1.2.2").should == true
+        (ref > " 3.2.2").should == false
+        (ref > "2.1.2").should == true
+        (ref > "2.3.2").should == false
+        (ref > "2.2.1").should == true
+        (ref > "2.2.3").should == false
+        (ref > " 2.2.1.dev2").should == true
+        (ref > " 2.2.2.dev2").should == false
       end
 
       it "greater than equal works" do
         ref = Origen::VersionString.new("v2.2.2")
-        ref.condition_met?(">= v2.2.2").should == true
+        (ref >= "v2.2.2").should == true
         ref = Origen::VersionString.new("2.2.2")
-        ref.condition_met?(">= 2.2.2").should == true
+        (ref >= "2.2.2").should == true
       end
 
       it "less than works" do
         ref = Origen::VersionString.new("v2.2.2")
-        ref.condition_met?("> v2.2.2").should == false
+        (ref > "v2.2.2").should == false
 
-        ref.condition_met?("< v1.2.2").should == false
-        ref.condition_met?("< v3.2.2").should == true
-        ref.condition_met?("<v2.1.2").should == false
-        ref.condition_met?("<v2.3.2").should == true
-        ref.condition_met?("<v2.2.1").should == false
-        ref.condition_met?("<v2.2.3").should == true
-        ref.condition_met?("< v2.2.1.dev2").should == false
-        ref.condition_met?("< v2.2.2.dev2").should == true
+        (ref < "v1.2.2").should == false
+        (ref < "v3.2.2").should == true
+        (ref < "v2.1.2").should == false
+        (ref < "v2.3.2").should == true
+        (ref < "v2.2.1").should == false
+        (ref < "v2.2.3").should == true
+        (ref < "v2.2.1.dev2").should == false
+        (ref < "v2.2.2.dev2").should == true
 
         ref = Origen::VersionString.new("2.2.2")
-        ref.condition_met?("> 2.2.2").should == false
+        (ref > "2.2.2").should == false
 
-        ref.condition_met?("< 1.2.2").should == false
-        ref.condition_met?("< 3.2.2").should == true
-        ref.condition_met?("<2.1.2").should == false
-        ref.condition_met?("<2.3.2").should == true
-        ref.condition_met?("<2.2.1").should == false
-        ref.condition_met?("<2.2.3").should == true
-        ref.condition_met?("< 2.2.1.dev2").should == false
-        ref.condition_met?("< 2.2.2.dev2").should == true
+        (ref < "1.2.2").should == false
+        (ref < "3.2.2").should == true
+        (ref < "2.1.2").should == false
+        (ref < "2.3.2").should == true
+        (ref < "2.2.1").should == false
+        (ref < "2.2.3").should == true
+        (ref < "2.2.1.dev2").should == false
+        (ref < "2.2.2.dev2").should == true
+
+        (Origen::VersionString.new('0.10.0') < Origen::VersionString.new('0.8.0')).should == false
       end
 
       it "less than equal works" do
         ref = Origen::VersionString.new("v2.2.2")
-        ref.condition_met?("<= v2.2.2").should == true
+        (ref <= "v2.2.2").should == true
         ref = Origen::VersionString.new("2.2.2")
-        ref.condition_met?("<= 2.2.2").should == true
+        (ref <= "2.2.2").should == true
       end
 
       it "production works" do


### PR DESCRIPTION
I just found a bug in OrigenSim because I expected this to work:

~~~ruby
Origen::VersionString.new('0.10.0') < '0.8.8'
~~~

Now it does, and so do all other regular comparison operators.

The original API is still supported for masochists, but the specs have been re-written to be examples of using the improved alias methods.