### PR TITLE
Allow bit names that are similar to 'reg level attributes'

### DIFF
--- a/lib/origen/registers.rb
+++ b/lib/origen/registers.rb
@@ -313,12 +313,12 @@ module Origen
       local_vars = {}
 
       Reg::REG_LEVEL_ATTRIBUTES.each do |attribute, meta|
-        aliases = [attribute]
+        aliases = [attribute[1..-1].to_sym]
         aliases += meta[:aliases] if meta[:aliases]
-        aliases.each { |_a| local_vars[attribute] = bit_info.delete(attribute) if bit_info.key?(attribute) }
+        aliases.each { |_a| local_vars[attribute] = bit_info.delete(_a) if bit_info.key?(_a) }
       end
 
-      local_vars[:reset] ||= :memory if local_vars[:memory]
+      local_vars[:_reset] ||= :memory if local_vars[:_memory]
       @min_reg_address ||= address
       @max_reg_address ||= address
       # Must set an initial value, otherwise max_address_reg_size will be nil if a sub_block contains only

--- a/lib/origen/registers.rb
+++ b/lib/origen/registers.rb
@@ -139,7 +139,7 @@ module Origen
         @owner = owner
         @name = name
         @attributes = attributes
-        @feature = attributes[:feature] if attributes.key?(:feature)
+        @feature = attributes[:_feature] if attributes.key?(:_feature)
       end
 
       # Make this appear like a reg to any application code

--- a/lib/origen/registers/reg.rb
+++ b/lib/origen/registers/reg.rb
@@ -14,13 +14,13 @@ module Origen
       # to all of its contained bits unless a specific bit has its own definition of the same
       # attribute
       REG_LEVEL_ATTRIBUTES = {
-        feature:   {},
-        reset:     { aliases: [:res] },
-        memory:    {},
-        path:      { aliases: [:hdl_path] },
-        abs_path:  { aliases: [:absolute_path] },
-        access:    {},
-        bit_order: {}
+        _feature:   {},
+        _reset:     { aliases: [:res] },
+        _memory:    {},
+        _path:      { aliases: [:hdl_path] },
+        _abs_path:  { aliases: [:absolute_path] },
+        _access:    {},
+        _bit_order: {}
       }
 
       # Returns the object that own the register.
@@ -69,7 +69,7 @@ module Origen
         @init_as_writable = options.delete(:init_as_writable)
         @define_file = options.delete(:define_file)
         REG_LEVEL_ATTRIBUTES.each do |attribute, _meta|
-          instance_variable_set("@#{attribute}", options.delete(attribute))
+          instance_variable_set("@#{attribute[1..-1]}", options.delete(attribute))
         end
         @description_from_api = {}
         description = options.delete(:description)

--- a/lib/origen/registers/reg.rb
+++ b/lib/origen/registers/reg.rb
@@ -69,7 +69,13 @@ module Origen
         @init_as_writable = options.delete(:init_as_writable)
         @define_file = options.delete(:define_file)
         REG_LEVEL_ATTRIBUTES.each do |attribute, _meta|
-          instance_variable_set("@#{attribute[1..-1]}", options.delete(attribute))
+          if options[attribute[1..-1].to_sym]
+            # If register creation is coming directly from Reg.new, instead of Placeholder,
+            #   it may not have attributes with '_' prefix
+            instance_variable_set("@#{attribute[1..-1]}", options.delete(attribute[1..-1].to_sym))
+          else
+            instance_variable_set("@#{attribute[1..-1]}", options.delete(attribute))
+          end
         end
         @description_from_api = {}
         description = options.delete(:description)


### PR DESCRIPTION
Any bit name that matched a reg_level_attribute ('feature', **'reset'**, 'memory', etc.) was being clobbered during register creation (using add_reg or reg do block).  Patch that adds a underscore prefix to the attributes in the class hash and handles ignoring it when creating the instance variable associated with those attributes.
