### PR TITLE
Fix Git remote population

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Development dependencies
 gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ PATH
       yard (~> 0.8)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (4.2.10)
       i18n (~> 0.7)

--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -330,7 +330,7 @@ module Origen
           Origen.log.debug "Initializing Git workspace at #{local}"
           git 'init'
           git 'remote remove origin', verbose: false, check_errors: false
-          git "remote add origin #{remote}"
+          git "remote add origin #{remote}", check_errors: false
         end
       end
 

--- a/lib/origen/version_string.rb
+++ b/lib/origen/version_string.rb
@@ -32,7 +32,12 @@ module Origen
     alias_method :orig_equal?, :==
 
     def equal?(version)
-      condition_met?("== #{version}")
+      # If not a valid version string, compare using regular string comparison
+      if valid?
+        condition_met?("== #{version}")
+      else
+        orig_equal?(version)
+      end
     end
     alias_method :eq?, :equal?
     alias_method :==, :equal?

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -304,6 +304,13 @@ describe Origen::VersionString do
       end
     end
 
+    it 'can be compared to regular text strings' do
+      S = Origen::VersionString
+      (S.new('master') == 'HEAD').should == false
+      (S.new('master') == S.new('HEAD')).should == false
+      ('master' == S.new('HEAD')).should == false
+    end
+
     specify "the minimum_version method works" do
       Origen::VersionString.minimum_version("v1.2.3").should == "1.2.3"
       Origen::VersionString.minimum_version("== v1.2.3").should == "1.2.3"


### PR DESCRIPTION
Population of remotes via Git seemed to be broken when running with older versions of Git (v1).

This patch does the following:

- Comparison of Git version identifiers like 'HEAD' and 'master' would cause an error when they were wrapped in an `Origen::VersionString`. This is likely a regression introduced a while ago. A test for it has been added and a patch to make the `==` comparison fall back to a regular string comparison when the value is not a compliant semantic version string.

- I don't think `git 'remote remove origin', verbose: false, check_errors: false` really works with `v1` Git, so I was getting `origin already exists` type of errors when trying to add the origin remote during an initial remote population. This patch will ignore such errors, which I think is probably preferable in most cases.