### PR TITLE
Added numeric wait helpers

### DIFF
--- a/lib/origen/core_ext/numeric.rb
+++ b/lib/origen/core_ext/numeric.rb
@@ -187,4 +187,24 @@ class Numeric
       self / 1_000_000_000_000.0
     end
   end
+
+  # Shorthand for tester.wait(time_in_ns: 100), e.g. 100.ns!
+  def ns!
+    Origen.app.tester.wait time_in_ns: self
+  end
+
+  # Shorthand for tester.wait(time_in_us: 100), e.g. 100.us!
+  def us!
+    Origen.app.tester.wait time_in_us: self
+  end
+
+  # Shorthand for tester.wait(time_in_ms: 100), e.g. 100.ms!
+  def ms!
+    Origen.app.tester.wait time_in_ms: self
+  end
+
+  # Shorthand for tester.wait(time_in_s: 100), e.g. 100.s!
+  def s!
+    Origen.app.tester.wait time_in_s: self
+  end
 end

--- a/pattern/j750/timing.rb
+++ b/pattern/j750/timing.rb
@@ -52,7 +52,7 @@ Pattern.create do
 
   cc "This should wait for 5 cycles, 1000/200"
   $tester.set_timeset("nvm_slow", 200)
-  $tester.wait(:time_in_ns => 1000)
+  1000.ns!
   cc "This should wait for 25 cycles, 1000/40"
   $tester.set_timeset("nvm_fast", 40)
   $tester.wait(:time_in_ns => 1000)
@@ -69,5 +69,4 @@ Pattern.create do
   ss "Test that Fixnum.cycles works"
   cc "There should be 10 cycles here"
   10.cycles
-
 end


### PR DESCRIPTION
Added helpers to create pattern wait durations like this:

~~~ruby
10.ms!    # Shorthand for tester.wait(time_in_ms: 10)
~~~

The driver for adding this is to make it quick and easy to advance time while in an OrigenSim interactive session.