### PR TITLE
Patch PR #271 implementation

### DIFF
--- a/lib/origen/registers.rb
+++ b/lib/origen/registers.rb
@@ -140,6 +140,11 @@ module Origen
         @name = name
         @attributes = attributes
         @feature = attributes[:_feature] if attributes.key?(:_feature)
+
+        # Give reg.new a way to tell if coming from Placeholder
+        if attributes[:bit_info].is_a? Hash
+          attributes[:bit_info][:from_placeholder] = true
+        end
       end
 
       # Make this appear like a reg to any application code

--- a/lib/origen/registers/reg.rb
+++ b/lib/origen/registers/reg.rb
@@ -516,14 +516,14 @@ module Origen
             bind(bit_id, bit_params.delete(:bind)) if bit_params[:bind]
             position = bit_params[:pos] || 0
             num_bits = bit_params[:bits] || 1
-            if @reset
-              if @reset.is_a?(Symbol)
-                bit_params[:res] = @reset
+            if @_reset
+              if @_reset.is_a?(Symbol)
+                bit_params[:res] = @_reset
               else
-                bit_params[:res] = @reset[(num_bits + position - 1), position]
+                bit_params[:res] = @_reset[(num_bits + position - 1), position]
               end
             end
-            bit_params[:access] = @access if bit_params[:access].nil?
+            bit_params[:access] = @_access if bit_params[:access].nil?
             bit_params[:res] = bit_params[:data] if bit_params[:data]
             bit_params[:res] = bit_params[:reset] if bit_params[:reset]
             if num_bits == 1

--- a/lib/origen/registers/reg.rb
+++ b/lib/origen/registers/reg.rb
@@ -517,14 +517,14 @@ module Origen
             bind(bit_id, bit_params.delete(:bind)) if bit_params[:bind]
             position = bit_params[:pos] || 0
             num_bits = bit_params[:bits] || 1
-            if @_reset
-              if @_reset.is_a?(Symbol)
-                bit_params[:res] = @_reset
+            if @reset
+              if @reset.is_a?(Symbol)
+                bit_params[:res] = @reset
               else
-                bit_params[:res] = @_reset[(num_bits + position - 1), position]
+                bit_params[:res] = @reset[(num_bits + position - 1), position]
               end
             end
-            bit_params[:access] = @_access if bit_params[:access].nil?
+            bit_params[:access] = @access if bit_params[:access].nil?
             bit_params[:res] = bit_params[:data] if bit_params[:data]
             bit_params[:res] = bit_params[:reset] if bit_params[:reset]
             if num_bits == 1

--- a/lib/origen/registers/reg.rb
+++ b/lib/origen/registers/reg.rb
@@ -509,8 +509,6 @@ module Origen
         # options is now an array for split bit groups or a hash if single bit/range bits
         # Now add the requested bits to the register, removing the unwritable bits as required
         options.each do |bit_id, bit_params|
-          puts bit_id
-          puts bit_params
           if bit_params.is_a? Hash
             description = bit_params.delete(:description)
             if description

--- a/lib/origen/registers/reg.rb
+++ b/lib/origen/registers/reg.rb
@@ -68,13 +68,14 @@ module Origen
         @name = name
         @init_as_writable = options.delete(:init_as_writable)
         @define_file = options.delete(:define_file)
+        @from_placeholder = options.delete(:from_placeholder) || false
         REG_LEVEL_ATTRIBUTES.each do |attribute, _meta|
-          if options[attribute[1..-1].to_sym]
+          if @from_placeholder
+            instance_variable_set("@#{attribute[1..-1]}", options.delete(attribute))
+          else
             # If register creation is coming directly from Reg.new, instead of Placeholder,
             #   it may not have attributes with '_' prefix
             instance_variable_set("@#{attribute[1..-1]}", options.delete(attribute[1..-1].to_sym))
-          else
-            instance_variable_set("@#{attribute[1..-1]}", options.delete(attribute))
           end
         end
         @description_from_api = {}
@@ -508,6 +509,8 @@ module Origen
         # options is now an array for split bit groups or a hash if single bit/range bits
         # Now add the requested bits to the register, removing the unwritable bits as required
         options.each do |bit_id, bit_params|
+          puts bit_id
+          puts bit_params
           if bit_params.is_a? Hash
             description = bit_params.delete(:description)
             if description

--- a/spec/reg_spec.rb
+++ b/spec/reg_spec.rb
@@ -703,6 +703,7 @@ module RegTest
       bits_copy = {
         b0: {pos: 0, bits: 8, writable: false},
         b1: {pos: 8, bits: 8, res: 4},
+        from_placeholder: true
       }
       add_reg :dummy, 0x10, 16, bits
       bits.should == bits_copy


### PR DESCRIPTION
PR #271 attempted to handle bit names that matched any of the REG_ATTRIBUTE keys by adding an underscore to the REG_ATTRIBUTES key strings and then remove the underscore when creating the instance_variables during initialization.  This PR adds an additional key:val in the bit_info hash created in the  reg Placeholder, so that the reg.initialize can correctly determine when to remove a non-underscored attribute.