### PR TITLE
Add ability to mark site_config params as non-boolean

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Development dependencies
 gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ PATH
       yard (~> 0.8)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (4.2.10)
       i18n (~> 0.7)
@@ -191,4 +191,4 @@ DEPENDENCIES
   ripper-tags
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -7,6 +7,10 @@ module Origen
     TRUE_VALUES = ['true', 'TRUE', '1', 1]
     FALSE_VALUES = ['false', 'FALSE', '0', 0]
 
+    # Adding parameters to this array will prevent them from being converted to booleans if
+    # they are assigned one of the values in the TRUE_VALUES/FALSE_VALUES arrays
+    NON_BOOLEAN_PARAMETERS = [:lsf_cores]
+
     # Define a couple of site configs variables that need a bit of processing
 
     # Gets the gem_intall_dir. This is either site_config.home_dir/gems or the site configs gem_install_dir
@@ -179,10 +183,12 @@ module Origen
         value = config ? config[val] : nil
       end
 
-      if TRUE_VALUES.include?(value)
-        return true
-      elsif FALSE_VALUES.include?(value)
-        return false
+      unless NON_BOOLEAN_PARAMETERS.include?(val.to_s.downcase.to_sym)
+        if TRUE_VALUES.include?(value)
+          return true
+        elsif FALSE_VALUES.include?(value)
+          return false
+        end
       end
       value
     end

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -67,6 +67,11 @@ describe "Origen.site_config" do
       Origen.site_config.gem_manage_bundler.should == true
     end
   end
+
+  it "allows variables to be marked as non-boolean to prevent casting" do
+    add_config_variable('lsf_cores', '1')
+    Origen.site_config.lsf_cores.should == '1'
+  end
   
   it "allows user overrides" do
     add_config_variable('test', 'test value')


### PR DESCRIPTION
The recent addition of LSF params to site config exposed a bug due to the `lsf_cores` parameter being assigned the default value of `'1'`.
The site config has a long standing feature whereby it will convert values of `1` or `0` into booleans, this is because in environment variables (which can be used to override site_config params) it is common for values of `1` and `0` to mean on/off, but that doesn't translate well to Ruby because `0` is considered truthy.

However, in the case of the `lsf_cores` parameter, a setting of `1` really means that we want a string with that value so that it can be written to the LSF submission string verbatim.

This update adds the ability for parameters to be opted-out of boolean casting and it has been applied initially to the `lsf_cores` parameter.