### PR TITLE
Do not use Bootsnap for LSF remote execution

### DIFF
--- a/bin/origen
+++ b/bin/origen
@@ -170,7 +170,8 @@ if origen_root && File.exist?(ENV['BUNDLE_GEMFILE']) && Origen.site_config.gem_m
     end
   end
   require 'bundler/setup'
-  if Origen.site_config.use_bootsnap && !Origen.os.windows?
+  _exec_remote = ARGV.include?('--exec_remote') ? true : false  
+  if Origen.site_config.use_bootsnap && !Origen.os.windows? && !_exec_remote
     ENV["BOOTSNAP_CACHE_DIR"] ||= "#{origen_root}/tmp/cache"
     require 'bootsnap/setup'
   end


### PR DESCRIPTION
Bootsnap cache is not reliable when running remotely and doesn't really make sense to rebuild it for a one-time run, so just go ahead and disable bootsnap for LSF jobs.