### PR TITLE
Revert including the entire Origen module in the site config. Created…

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -28,7 +28,6 @@ unless defined? RGen::ORIGENTRANSITION
   require 'bundler'
   require 'origen/undefined'
   require 'origen/componentable'
-  require 'socket'
 
   module Origen
     autoload :Features,          'origen/features'
@@ -670,11 +669,6 @@ unless defined? RGen::ORIGENTRANSITION
         !!@running_interactively
       end
       alias_method :interactive?, :running_interactively?
-
-      # Platform independent way of retrieving the hostname
-      def hostname
-        Socket.gethostbyname(Socket.gethostname).first.downcase
-      end
 
       # Returns true if Origen is running with the -d or --debug switches enabled
       def debug?

--- a/lib/origen/boot_api.rb
+++ b/lib/origen/boot_api.rb
@@ -1,0 +1,13 @@
+# Helper methods here and in the required files can be used by Origen during the bootup process.
+# (e.g., in site config ERB files)
+# This can be expanded as needed to provide more helpers.
+
+module Origen
+  require 'socket'
+  require_relative './operating_systems'
+
+  # Platform independent means of retrieving the hostname
+  def self.hostname
+    Socket.gethostbyname(Socket.gethostname).first.downcase
+  end
+end

--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -8,8 +8,8 @@ module Origen
     require 'httparty'
     require_relative 'site_config/config'
 
-    # require this version of Origen
-    require_relative '../origen'
+    # require some useful methods from Origen without requiring the entire module
+    require_relative './boot_api'
 
     TRUE_VALUES = ['true', 'TRUE', '1', 1]
     FALSE_VALUES = ['false', 'FALSE', '0', 0]

--- a/templates/web/guides/starting/company.md.erb
+++ b/templates/web/guides/starting/company.md.erb
@@ -45,6 +45,24 @@ and edit it as required.
 The values present in this default file are the ones that will be applied by default in
 an installation where no custom configs are present.
 
+#### Dynamic Configuration Files
+
+Origen supports a static <code>origen_site_config.yml</code>, but also supports a template <code>origen_site_config.yml.erb</code>.
+If Origen encounters a site config with the extension <code>.yml.erb</code>, it will invoke the [ERB](https://ruby-doc.org/stdlib-2.5.3/libdoc/erb/rdoc/ERB.html)
+template, adding some dynamic nature to the configuration. With this, the same configuration file can be used throughout
+but can set the site according to the current operating system, the hostname, or anything else. If you are not familiar with
+ERB templating, you can view a [quickstart guide on the Origen docs](https://origen-sdk.org/origen/guides/compiler/creating/).
+
+The site config will automatically include Origen's [Boot API](https://github.com/Origen-SDK/origen/blob/master/lib/origen/boot_api.rb),
+and can be used freely out of the gate. Other methods and libraries can be added as needed to the ERB itself (or to helper
+<code>.rb</code> files then required by the ERB).
+
+<div class="alert alert-warning">
+The ERB template format is hard-coded to match that of the <a href="https://origen-sdk.org/origen/guides/compiler/creating/#Template_Syntax">compiler</a>.
+That is, the <code>%<></code> template setting. See the <code>trim_mode</code> option of ERB's <code>::new</code> method
+<a href="https://ruby-doc.org/stdlib-2.5.3/libdoc/erb/rdoc/ERB.html#method-c-new">on the ERB docs page</a> for additional details.
+</div>
+
 #### Testing the Configuration File
 
 ##### Command Line Driven

--- a/templates/web/guides/starting/company.md.erb
+++ b/templates/web/guides/starting/company.md.erb
@@ -54,8 +54,12 @@ but can set the site according to the current operating system, the hostname, or
 ERB templating, you can view a [quickstart guide on the Origen docs](https://origen-sdk.org/origen/guides/compiler/creating/).
 
 The site config will automatically include Origen's [Boot API](https://github.com/Origen-SDK/origen/blob/master/lib/origen/boot_api.rb),
-and can be used freely out of the gate. Other methods and libraries can be added as needed to the ERB itself (or to helper
-<code>.rb</code> files then required by the ERB).
+and can be used freely out of the gate.
+
+<div class="alert alert-warning">
+  <strong>Warning!</strong> You should not require any gems (including Origen) within your ERB code. The amount of logic
+  should be kept to a minimum and only be used to customize parameter values to the environment OS or a particular host.
+</div>
 
 <div class="alert alert-warning">
 The ERB template format is hard-coded to match that of the <a href="https://origen-sdk.org/origen/guides/compiler/creating/#Template_Syntax">compiler</a>.


### PR DESCRIPTION
Reverted including the entire Origen module in the site config as this was causing some problems in a feature @ginty is working on. Created a <code>boot_api.rb</code> file to house helpers that site config ERB templates can use instead. Its very small but can grow as/if needed.

Updated the docs to cover ERB templating in the site config, since this slipped through the original PR (was only discussed with regards to a centralized config)