### PR TITLE
Pin group offsets

### DIFF
--- a/lib/origen/pins.rb
+++ b/lib/origen/pins.rb
@@ -229,21 +229,23 @@ module Origen
 
         rtl_name = options[:rtl_name]
         force = options[:force]
+        offset = options.delete(:offset) || 0
         options.delete(:size).times do |i|
-          options[:name] = "#{id}#{i}".to_sym
-          options[:rtl_name] = "#{rtl_name}#{i}".to_sym if rtl_name
-          options[:force] = force[i] if force
+          pin_index = offset + i
+          options[:name] = "#{id}#{pin_index}".to_sym
+          options[:rtl_name] = "#{rtl_name}#{pin_index}".to_sym if rtl_name
+          options[:force] = force[pin_index] if force
 
           if power_pin
-            group[i] = PowerPin.new(i, self, options)
+            group[i] = PowerPin.new(pin_index, self, options)
           elsif ground_pin
-            group[i] = GroundPin.new(i, self, options)
+            group[i] = GroundPin.new(pin_index, self, options)
           elsif virtual_pin
-            group[i] = VirtualPin.new(i, self, options)
+            group[i] = VirtualPin.new(pin_index, self, options)
           elsif other_pin
-            group[i] = OtherPin.new(i, self, options)
+            group[i] = OtherPin.new(pin_index, self, options)
           else
-            group[i] = Pin.new(i, self, options)
+            group[i] = Pin.new(pin_index, self, options)
           end
           group[i].invalidate_group_cache
         end

--- a/spec/pins_v3_spec.rb
+++ b/spec/pins_v3_spec.rb
@@ -376,6 +376,20 @@ describe "Origen Pin API v3" do
       $dut.add_pins :pd, size: 16
       $dut.pins(:pd).size.should == 16
     end
+    
+    it "pin groups can be declared directly with an offset" do
+      $dut.add_pins :offset_pins, size: 4, offset: 1
+      $dut.pins(:offset_pins).size.should == 4
+      [:offset_pins1, :offset_pins2, :offset_pins3, :offset_pins4].each do |pin_name|
+        $dut.has_pin?(pin_name).should == true
+        
+        # Origen will attempt to kill rspec if an undefined pin error is hit. The above test will fail still, so can
+        # skip these to avoid an early termination.
+        $dut.pins(pin_name).name.should == pin_name if $dut.has_pin?(pin_name)
+        $dut.pins(pin_name).rtl_name.should == pin_name.to_s if $dut.has_pin?(pin_name)
+      end
+      $dut.has_pin?(:offset_pins0).should == false
+    end
 
     it "endianness of pin group tests" do
       $dut.add_pins :pb, size: 4

--- a/templates/web/guides/models/pins.md.erb
+++ b/templates/web/guides/models/pins.md.erb
@@ -112,6 +112,8 @@ Some points to note in the above code:
   objects named <code>:porta0</code> through <code>:porta31</code>.
   See below for how to define pin groups based on existing pins.
 * Pin groups can be any size, define via the <code>:size</code> option.
+* For pin groups whose indexes should start somewhere other than <code>0</code> (e.g. modeling the port
+  <code>portc[8:1]</code> instead of <code>portc[7:0]</code>), an <code>:offset</code> option can be provided.
 * Pin groups are big endian by default, however little endian can be specified via the
   <code>:endian</code> option. Changing this attribute will have the effect of reversing the
   order that data is applied in a test pattern.


### PR DESCRIPTION
I didn't see any existing option to model pin groups whose indexes don't start at 0, so added an <code>:offset</code> option to <code>#add_pins</code> for this.

This was actually noticed from using OrigenSim where my <code>origen.v</code> file wasn't correctly mapping <code>ptc[19:1]</code> and I was having to manually adjust all the pin drivers. Nothing a find & replace couldn't fix, but still seemed like something to fix upstream. Traced this back to <code>#add_pins</code> not having an option for an offset.

In general, we don't see this very much here and up until the introduction of OrigenSim I never added entire pin groups before anyway, so this just surfaced.

If this is accepted, I'll update OrigenVerilog to pass this option to <code>#add_pins</code>.