### PR TITLE
Added site config broadcast system

### DIFF
--- a/bin/origen
+++ b/bin/origen
@@ -182,6 +182,29 @@ else
 end
 
 begin
+  require 'colored'
+  # Emit all broadcast messages before executing all commands
+  if Origen.site_config.broadcast_info
+    puts
+    Array(Origen.site_config.broadcast_info).each { |line| puts line }
+    puts
+  end
+  if Origen.site_config.broadcast_warning
+    puts
+    Array(Origen.site_config.broadcast_warning).each { |line| puts line.yellow }
+    puts
+  end
+  if Origen.site_config.broadcast_danger
+    puts
+    Array(Origen.site_config.broadcast_danger).each { |line| puts line.red }
+    puts
+  end
+  if Origen.site_config.broadcast_success
+    puts
+    Array(Origen.site_config.broadcast_success).each { |line| puts line.green }
+    puts
+  end
+
   # If this script has been invoked from within an Origen application then open
   # up all commands, if not then only allow the command to create a new Origen
   # application.

--- a/origen_site_config.yml
+++ b/origen_site_config.yml
@@ -1,3 +1,15 @@
+# BROADCAST MESSAGES
+
+# All broadcast messages will output to the console for all users every time Origen is invoked
+#broadcast_info:
+# - These lines will be output to the console in regular text
+#broadcast_warning:
+# - These lines will be output to the console in amber text
+#broadcast_danger:
+# - These lines will be output to the console in red text
+#broadcast_success:
+# - These lines will be output to the console in green text
+
 # GENERAL SETUP
 
 # Application generator plugins can be used to extend the available new application templates


### PR DESCRIPTION
A small update to add the ability to output broadcast messages (shown to all users every time they invoke Origen) from site configs.

The given text it just output verbatim to the console and can be optionally colored, the example output is shown below.

The intended use case within NXP is to allow us to deprecate Origen/Ruby installations and advise users to transition to a supported installation.

~~~text
stephen@xwing:~/Code/github/origen$ origen -v

These lines will be output to the console in regular text

These lines will be output to the console in amber text

These lines will be output to the console in red text

These lines will be output to the console in green text

Application: 0.38.0
     Origen: 0.38.0
~~~