### PR TITLE
update exporter to skip nil attributes of sub_blocks

### DIFF
--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -234,7 +234,7 @@ module Origen
           elsif value.is_a?(String)
             line << ", #{key}: '#{value}'"
           else
-            line << ", #{key}: #{value}"
+            line << ", #{key}: #{value}" unless value.nil?
           end
         end
         block.export(id, options.merge(file_path: file_path, dir_path: dir_path))

--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -247,7 +247,7 @@ module Origen
         unless reg.description.empty?
           reg.description.each { |l| lines << indent + "# #{l}" }
         end
-        lines << indent + "model.add_reg :#{id}, #{reg.offset.to_hex}, size: #{reg.size} #{reg.bit_order == :msb0 ? ', bit_order: :msb0' : ''} do |reg|"
+        lines << indent + "model.add_reg :#{id}, #{reg.offset.to_hex}, size: #{reg.size} #{reg.bit_order == :msb0 ? ', bit_order: :msb0' : ''}#{build_reg_meta(reg)} do |reg|"
         indent = ' ' * ((options[:indent] || 0) + 2)
         reg.named_bits.each do |name, bits|
           unless bits.description.empty?
@@ -276,6 +276,20 @@ module Origen
         indent = ' ' * (options[:indent] || 0)
         lines << indent + 'end'
         lines.join("\n")
+      end
+
+      def build_reg_meta(reg)
+        ret_str = ''
+        reg.meta.each do |key, value|
+          if value.is_a?(Symbol)
+            ret_str += ", #{key}: :#{value}"
+          elsif value.is_a?(String)
+            ret_str += ", #{key}: '#{value}'"
+          else
+            ret_str += ", #{key}: #{value}" unless value.nil?
+          end
+        end
+        ret_str
       end
     end
   end

--- a/spec/import_and_export_spec.rb
+++ b/spec/import_and_export_spec.rb
@@ -76,7 +76,7 @@ describe "Model import and export" do
       # ** A MSB0 Test Case **
       # Blah-ba-bi-blah
       # just following the comment pattern above
-      reg :msb0_test, 0x0028, size: 16, bit_order: :msb0 do |reg|
+      reg :msb0_test, 0x0028, size: 16, bit_order: :msb0, some_attr: true, another_attr: :testing, third_attr: nil, fourth_attr: 'string_attr' do |reg|
         reg.bit 8,  :ale
         reg.bit 9,  :xsfg
         reg.bit 10, :yml
@@ -194,6 +194,15 @@ describe "Model import and export" do
     reg.bit(:ale).position.should == 7
     reg.bit(:field).position.should == 0
     reg.bit(:field).size.should == 5
+  end
+
+  it "handles register metadata" do
+    load_import_model
+    reg = dut.block1.x.msb0_test
+    reg.meta[:some_attr].should == true
+    reg.meta[:another_attr].should == :testing
+    reg.meta[:third_attr].should == nil
+    reg.meta[:fourth_attr].should == 'string_attr'
   end
 
   it "gracefully adds to existing sub-blocks without instantiating them" do


### PR DESCRIPTION
Just a minor bug fix.