### PR TITLE
make git.can_checkin? robust

### DIFF
--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -148,7 +148,8 @@ module Origen
       # Returns true if the current user can checkin to the given repo (means has permission
       # to push in Git terms)
       def can_checkin?
-        git('push --dry-run', verbose: false)
+        # dry run attempting to create a new remote branch named OrigenWritePermissionsTest
+        git('push --dry-run origin origin:refs/heads/OrigenWritePermissionsTest', verbose: false)
         true
       rescue
         false


### PR DESCRIPTION
This PR is an attempt to make the .can_checkin? method more robust. It was incorrectly returning false on an 'origen web compile -r' operation. There were no local changes at the time. So, the push dry run failed. The expectation is that updating the push dry run to attempt creating a remote branch will prevent this type of false fail.