### PR TITLE
Export register file link by flexible path to subblocks 

### DIFF
--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -13,6 +13,8 @@ module Origen
         # want to change where the exported files are
         file = options[:file_path] || export_path(name, options)
         dir = options[:dir_path] || export_dir(options)
+        options[:dir_print] = options[:dir_path] || export_dir_print(options) # to print path link to Origen.root top level
+        
         path_to_file = Pathname.new(File.join(dir, file))
         FileUtils.rm_rf(path_to_file.sub_ext('').to_s) if File.exist?(path_to_file.sub_ext('').to_s)
         FileUtils.rm_rf(path_to_file.to_s) if File.exist?(path_to_file.to_s)
@@ -168,6 +170,10 @@ module Origen
         options[:dir] || File.join(Origen.root, 'vendor', 'lib', 'models')
       end
 
+      def export_dir_print(options = {})
+        options[:dir] || File.join('#{Origen.root}/', 'vendor', 'lib', 'models')
+      end
+
       def export_pin(id, pin, options = {})
         indent = ' ' * (options[:indent] || 0)
         line = indent + "model.#{options[:method] || 'add_pin'} :#{id}"
@@ -224,7 +230,8 @@ module Origen
         indent = ' ' * (options[:indent] || 0)
         file_path = File.join(Pathname.new(options[:file_path]).sub_ext(''), "#{id}.rb")
         dir_path = options[:dir_path]
-        line = indent + "model.sub_block :#{id}, file: '#{file_path}', dir: '#{dir_path}', lazy: true"
+        line = indent + "model.sub_block :#{id}, file: '#{file_path}', dir: \"#{options[:dir_print]}\", lazy: true"
+        #line = indent + "model.sub_block :#{id}, file: '#{file_path}', dir: '#{dir_path}', lazy: true"
         unless block.base_address == 0
           line << ", base_address: #{block.base_address.to_hex}"
         end


### PR DESCRIPTION
Exported ruby register definition file can point to the vendor directory under Origen.root instead of the hard path to particular directory under specific user which not accessible by other users. Changes on exporter.rb:
1. Add options[:dir_print], the path to print.
2. Add function export_dir_print, to be used to construct the path to '#{Origen.root}/vendor/lib' to print onto the exported file.
3. Modified dir: content, from dir_path to options[:dir_print]