### PR TITLE
Exporter updates

### DIFF
--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -8,8 +8,7 @@ module Origen
       #   include_registers:  true
       #   include_sub_blocks: true
       #   include_timestamp:  true
-      #   file_path:          nil     # default path is Origen.root!/vendor/lib/models/name
-      #   rm_rb_only:         nil     # delete only .rb files, default is rm -rf * Origen.root!/vendor/lib/models/name
+      #   rm_rb_only:         nil     # delete only .rb files, default is rm -rf * Origen.root/vendor/lib/models/name
       #
       # Use the rm_rb_only option if the export dir is under revision control and the dir contains revision control metadata
       def export(name, options = {})

--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -165,7 +165,7 @@ module Origen
       end
 
       def export_dir(options = {})
-        options[:dir] || File.join(Origen.root, 'vendor', 'lib', 'models')
+        options[:dir] || File.join(Origen.root!, 'vendor', 'lib', 'models')
       end
 
       def export_pin(id, pin, options = {})
@@ -224,7 +224,7 @@ module Origen
         indent = ' ' * (options[:indent] || 0)
         file_path = File.join(Pathname.new(options[:file_path]).sub_ext(''), "#{id}.rb")
         dir_path = options[:dir_path]
-        line = indent + "model.sub_block :#{id}, file: '#{file_path}', dir: '#{dir_path}', lazy: true"
+        line = indent + "model.sub_block :#{id}, file: '#{file_path}', dir: \"#{dir_path.gsub(Origen.root!.to_s, '#{Origen.root!}')}\", lazy: true"
         unless block.base_address == 0
           line << ", base_address: #{block.base_address.to_hex}"
         end

--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -182,7 +182,7 @@ module Origen
       end
 
       def export_dir(options = {})
-        options[:dir] || File.join(Origen.root!, 'vendor', 'lib', 'models')
+        options[:dir] || File.join(Origen.root, 'vendor', 'lib', 'models')
       end
 
       def export_pin(id, pin, options = {})
@@ -241,7 +241,7 @@ module Origen
         indent = ' ' * (options[:indent] || 0)
         file_path = File.join(Pathname.new(options[:file_path]).sub_ext(''), "#{id}.rb")
         dir_path = options[:dir_path]
-        line = indent + "model.sub_block :#{id}, file: '#{file_path}', dir: \"#{dir_path.gsub(Origen.root!.to_s, '#{Origen.root!}')}\", lazy: true"
+        line = indent + "model.sub_block :#{id}, file: '#{file_path}', dir: \"#{dir_path.gsub(Origen.root.to_s, '#{Origen.root!}')}\", lazy: true"
         unless block.base_address == 0
           line << ", base_address: #{block.base_address.to_hex}"
         end

--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -1,6 +1,17 @@
 module Origen
   module Model
     module Exporter
+      # Export the model
+      #
+      # Options defaults:
+      #   include_pins:       true
+      #   include_registers:  true
+      #   include_sub_blocks: true
+      #   include_timestamp:  true
+      #   file_path:          nil     # default path is Origen.root!/vendor/lib/models/name
+      #   rm_rb_only:         nil     # delete only .rb files, default is rm -rf * Origen.root!/vendor/lib/models/name
+      #
+      # Use the rm_rb_only option if the export dir is under revision control and the dir contains revision control metadata
       def export(name, options = {})
         options = {
           include_pins:       true,
@@ -14,7 +25,13 @@ module Origen
         file = options[:file_path] || export_path(name, options)
         dir = options[:dir_path] || export_dir(options)
         path_to_file = Pathname.new(File.join(dir, file))
-        FileUtils.rm_rf(path_to_file.sub_ext('').to_s) if File.exist?(path_to_file.sub_ext('').to_s)
+        if File.exist?(path_to_file.sub_ext('').to_s)
+          if options[:rm_rb_only]
+            Dir.glob(path_to_file.sub_ext('').to_s + '/**/*.rb').each { |f| FileUtils.rm_f(f) }
+          else
+            FileUtils.rm_rf(path_to_file.sub_ext('').to_s)
+          end
+        end
         FileUtils.rm_rf(path_to_file.to_s) if File.exist?(path_to_file.to_s)
         FileUtils.mkdir_p(path_to_file.dirname)
         File.open(path_to_file, 'w') do |f|

--- a/spec/import_and_export_spec.rb
+++ b/spec/import_and_export_spec.rb
@@ -104,6 +104,17 @@ describe "Model import and export" do
     File.exist?("#{Origen.root}/vendor/lib/models/origen/export1.rb").should == true
   end
 
+  it "export optionally only clobbers rb files" do
+    FileUtils.rm_rf(File.join(Origen.root, 'vendor', 'lib'))
+    load_export_model
+    File.exist?("#{Origen.root}/vendor/lib/models/origen/export1.rb").should == false
+    dut.export 'export1', include_timestamp: false
+    File.exist?("#{Origen.root}/vendor/lib/models/origen/non_origen_meta_data.md").should == false
+    File.open("#{Origen.root}/vendor/lib/models/origen/non_origen_meta_data.md", "w") { |f| f.puts 'pretend metadata file' }
+    dut.export 'export1', include_timestamp: false, rm_rb_only: true
+    File.exist?("#{Origen.root}/vendor/lib/models/origen/non_origen_meta_data.md").should == true    
+  end
+
   it "import is alive" do
     load_import_model
     dut.is_a?(ImportModel).should == true


### PR DESCRIPTION
- Changed exported directory path to sub_block class files to use <code>"#{Origen.root!}/"</code> (relative paths)
- Added an export option <code>:rm_rb_only</code> to leave behind non-ruby code (ie revision control metadata) for cases where an existing model is being updated

@williamcheong I think this will resolve your issues with exporter