### PR TITLE
Minor updates for OrigenSim

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -82,6 +82,7 @@ unless defined? RGen::ORIGENTRANSITION
     class RevisionControlUninitializedError < OrigenError; end
     class SyntaxError < OrigenError; end
     class BinStrValError < OrigenError; end
+    class HexStrValError < OrigenError; end
 
     class << self
       include Origen::Utility::TimeAndDate

--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -75,17 +75,13 @@ unless defined? RGen::ORIGENTRANSITION
 
     APP_CONFIG = File.join('config', 'application.rb')
 
-    class OrigenError < StandardError
-      def self.status_code(code)
-        define_method(:status_code) { code }
-      end
-    end
-
-    class PerforceError < OrigenError;  status_code(11); end
-    class GitError < OrigenError; status_code(11); end
-    class DesignSyncError < OrigenError; status_code(12); end
-    class RevisionControlUninitializedError < OrigenError; status_code(13); end
-    class SyntaxError < OrigenError; status_code(14); end
+    class OrigenError < StandardError; end
+    class PerforceError < OrigenError; end
+    class GitError < OrigenError; end
+    class DesignSyncError < OrigenError; end
+    class RevisionControlUninitializedError < OrigenError; end
+    class SyntaxError < OrigenError; end
+    class BinStrValError < OrigenError; end
 
     class << self
       include Origen::Utility::TimeAndDate

--- a/lib/origen/registers/bit.rb
+++ b/lib/origen/registers/bit.rb
@@ -97,6 +97,8 @@ module Origen
       # Returns the basic access string for a given access method.  Possible values: read-write, read-only,
       # write-only, writeOnce, read-writeOnce.  Used primarily by CrossOrigen IP-XACT import/export.
       attr_reader :base_access
+      # Can be set to indicate that the current state of the bit is unknown, e.g. after reading X from a simulation
+      attr_accessor :unknown
 
       def initialize(owner, position, options = {}) # rubocop:disable MethodLength
         options = {
@@ -290,7 +292,7 @@ module Origen
       # unknown in cases where the reset value is undefined or determined by a memory location
       # and where the bit has not been written or read to a specific value yet.
       def has_known_value?
-        !@reset_val.is_a?(Symbol) || @updated_post_reset
+        !@unknown && (!@reset_val.is_a?(Symbol) || @updated_post_reset)
       end
 
       # Set the data value of the bit to the given value (1 or 0)

--- a/lib/origen/registers/bit_collection.rb
+++ b/lib/origen/registers/bit_collection.rb
@@ -15,6 +15,7 @@ module Origen
       DONT_CARE_CHAR = 'X'
       OVERLAY_CHAR = 'V'
       STORE_CHAR = 'S'
+      UNKNOWN_CHAR = '?'
 
       attr_accessor :name
       alias_method :id, :name
@@ -388,6 +389,11 @@ module Origen
       alias_method :data=, :write
       alias_method :value=, :write
       alias_method :val=, :write
+
+      # Sets the unknown attribute on all contained bits
+      def unknown=(val)
+        each { |bit| bit.unknown = val }
+      end
 
       # Will tag all bits for read and if a data value is supplied it
       # will update the expected data for when the read is performed.
@@ -902,7 +908,11 @@ module Origen
               if bit.has_overlay? && options[:mark_overlays]
                 str += OVERLAY_CHAR
               else
-                str += bit.data.to_s
+                if bit.has_known_value?
+                  str += bit.data.to_s
+                else
+                  str += UNKNOWN_CHAR
+                end
               end
             else
               str += DONT_CARE_CHAR
@@ -913,7 +923,11 @@ module Origen
             if bit.has_overlay? && options[:mark_overlays]
               str += OVERLAY_CHAR
             else
-              str += bit.data.to_s
+              if bit.has_known_value?
+                str += bit.data.to_s
+              else
+                str += UNKNOWN_CHAR
+              end
             end
           end
         else
@@ -987,7 +1001,7 @@ module Origen
 
         nibbles.each_with_index do |nibble, i|
           # If contains any special chars...
-          if nibble =~ /[#{DONT_CARE_CHAR}#{STORE_CHAR}#{OVERLAY_CHAR}]/
+          if nibble =~ /[#{UNKNOWN_CHAR}#{DONT_CARE_CHAR}#{STORE_CHAR}#{OVERLAY_CHAR}]/
             # If all the same...
             if nibble[0] == nibble[1] && nibble[1] == nibble[2] && nibble[2] == nibble[3]
               outstr += nibble[0, 1] # .to_s

--- a/lib/origen/value/bin_str_val.rb
+++ b/lib/origen/value/bin_str_val.rb
@@ -64,7 +64,7 @@ module Origen
         if val =~ /^[01_xXzZ]+$/
           true
         else
-          fail Origen::SyntaxError, 'Binary string values can only contain: 0, 1, _, x, X, z, Z'
+          fail Origen::BinStrValError, "Binary string values can only contain: 0, 1, _, x, X, z, Z, this is invalid: #{val}"
         end
       end
     end

--- a/lib/origen/value/hex_str_val.rb
+++ b/lib/origen/value/hex_str_val.rb
@@ -92,7 +92,7 @@ module Origen
         if val =~ /^[0-9a-fA-F_xXzZ]+$/
           true
         else
-          fail Origen::SyntaxError, 'Hex string values can only contain: 0-9, a-f, A-F, _, x, X, z, Z'
+          fail Origen::HexStrValError, "Hex string values can only contain: 0-9, a-f, A-F, _, x, X, z, Z, this is invalid: #{val}"
         end
       end
     end

--- a/spec/reg_spec.rb
+++ b/spec/reg_spec.rb
@@ -684,6 +684,8 @@ module RegTest
       reg.status_str(:read).should == "[x0xv]V5S"
       reg[15].store
       reg.status_str(:read).should == "[s0xv]V5S"
+      reg[7..4].unknown = true
+      reg.status_str(:read).should == "[s0xv]V?S"
     end
 
     it "status_str works on non-nibble aligned regs" do

--- a/spec/value_spec.rb
+++ b/spec/value_spec.rb
@@ -18,7 +18,7 @@ describe Origen::Value do
     end
 
     it "will reject invalid formatted values" do
-      expect { Origen::Value.new(:h12Y4) }.to raise_error(Origen::BinStrValError)
+      expect { Origen::Value.new(:h12Y4) }.to raise_error(Origen::HexStrValError)
     end
 
     it "converts to an integer and a string" do
@@ -68,7 +68,7 @@ describe Origen::Value do
     end
 
     it "will reject invalid formatted values" do
-      expect { Origen::Value.new(:b10yx) }.to raise_error(Origen::SyntaxError)
+      expect { Origen::Value.new(:b10yx) }.to raise_error(Origen::BinStrValError)
     end
 
     it "converts to an integer and a string" do

--- a/spec/value_spec.rb
+++ b/spec/value_spec.rb
@@ -18,7 +18,7 @@ describe Origen::Value do
     end
 
     it "will reject invalid formatted values" do
-      expect { Origen::Value.new(:h12Y4) }.to raise_error(Origen::SyntaxError)
+      expect { Origen::Value.new(:h12Y4) }.to raise_error(Origen::BinStrValError)
     end
 
     it "converts to an integer and a string" do


### PR DESCRIPTION
Contains the following fairly minor updates to support the latest version of OrigenSim:

- Adds an `unknown` attribute to bit objects that can also be set on a bit collection via `my_bit_collection.unknown = true`.
  - This is not really intended for user space usage and it is to provide a way for OrigenSim to track when an X or Z has been read back from a simulation
  - The `BitCollection#status_str` method has been updated to return `?` for the value of such bits
- Improved the error message when creating a hex or bin string value that contains illegal characters and gave each case a dedicated error to give OrigenSim or other higher level code the possibility of handling such errors in future.
-  Took the opportunity to clean up by removing the status code attribute from Origen errors. This was something I copied from Bundler but have never used, so removed it to avoid any confusion.