### PR TITLE
Fix for GC bug

### DIFF
--- a/lib/origen/application.rb
+++ b/lib/origen/application.rb
@@ -50,6 +50,8 @@ module Origen
               Origen.register_application(app)
             end
             app.add_lib_to_load_path!
+            # Also blow this cache as a new app has just been added
+            @apps_by_namespace = nil
           end
         end
       end
@@ -135,11 +137,6 @@ module Origen
     #
     # Returns a lookup table for all block definitions (app/blocks) that the app contains
     def blocks_files
-      # There seems to be some issue with this cache being corrupted when running the test suite
-      # in Travis, but don't believe that this is really an issue in practice and cannot replicate
-      # it locally. Therefore maintaining the cache of this potentially expensive operation except
-      # from when running in CI.
-      @blocks_files = nil if ENV['CONTINUOUS_INTEGRATION']
       @blocks_files ||= begin
         files = {}
         block_dir = Pathname.new(File.join(root, 'app', 'blocks'))
@@ -167,7 +164,7 @@ module Origen
         type = file.basename('.rb').to_s.to_sym
         unless type == :model || type == :controller
           files[path][type] ||= []
-          files[path][type] << file
+          files[path][type] << file.to_s
         end
       end
       derivatives = current_dir.join('derivatives')

--- a/lib/origen/loader.rb
+++ b/lib/origen/loader.rb
@@ -94,8 +94,12 @@ module Origen
 
     # @api private
     def self.load_block_file(file, model)
-      e = File.exist?(file.to_s)
-      model.instance_eval(file.read, file.to_s) if e
+      file = file.to_s
+      if File.exist?(file)
+        File.open(file, 'r') do |f|
+          model.instance_eval(f.read, file)
+        end
+      end
       true
     end
 


### PR DESCRIPTION
Fix for an intermittent bug which we believe is caused by the paths in the `@blocks_files` being partially garbage collected in error.

This change stores the paths as strings rather than `Pathname` objects and hopefully the simpler object storage circumvents whatever the root cause is.
It seems to in repeated loop testing, I have not been able to invoke the problem with this change after running continuously for a few hours.
