### PR TITLE
Caller info splitter utility

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -782,6 +782,13 @@ unless defined? RGen::ORIGENTRANSITION
         end
       end
 
+      # OS agnostic split of a caller line into file and line number
+      def split_caller_line(line)
+        arr = line.split(':')
+        arr[0] = arr[0] + ':' + arr.delete_at(1) if Origen.os.windows?
+        arr
+      end
+
       private
 
       def current_command=(val)

--- a/lib/origen/sub_blocks.rb
+++ b/lib/origen/sub_blocks.rb
@@ -298,9 +298,7 @@ module Origen
           fail "You have already defined a sub-block named #{name} within class #{self.class}"
         end
         if respond_to?(name)
-          callers = caller[0].split(':')
-          # reunite the drive and path if on windows os
-          callers[0] = callers[0] + ':' + callers.delete_at(1) if Origen.os.windows?
+          callers = Origen.split_caller_line caller[0]
           Origen.log.warning "The sub_block defined at #{Pathname.new(callers[0]).relative_path_from(Pathname.pwd)}:#{callers[1]} is overriding an existing method called #{name}"
         end
         define_singleton_method name do
@@ -354,9 +352,7 @@ module Origen
       yield                  # any sub_block calls within this block will have their ID added to @current_group
       my_group = @current_group.dup
       if respond_to?(id)
-        callers = caller[0].split(':')
-        # reunite the drive and path if on windows os
-        callers[0] = callers[0] + ':' + callers.delete_at(1) if Origen.os.windows?
+        callers = Origen.split_caller_line caller[0]
         Origen.log.warning "The sub_block_group defined at #{Pathname.new(callers[0]).relative_path_from(Pathname.pwd)}:#{callers[1]} is overriding an existing method called #{id}"
       end
       define_singleton_method "#{id}" do


### PR DESCRIPTION
There are several places in the core and origen_testers (likely other plugins as well) where the file path + name and/or number are extracted from the caller by splitting on ':'. On windows the file path includes a ':' after the drive letter. Most of the instances of this that I found have been patched by recombining the first 2 array elements after the split if running on Windows.

This PR is to add a centralized splitter utility rather than either duplicating the patch repeatedly.

Here is an existing example of the bug
https://github.com/Origen-SDK/origen_testers/blob/bbff2a296eaffbdcf696e16fb09f91444de80a4e/lib/origen_testers/flow.rb#L169-L173

When running from Windows, called_from[1] will be the file path and name excluding the drive letter.

The fix would be

~~~ruby
      called_from = caller.find { |l| l =~ /^#{flow_file}:.*/ }
      desc = nil
      if called_from
        called_from = Origen.split_caller_line called_from
        line_no = called_from[1].to_i
~~~