### PR TITLE
Include pin type in exported models

### DIFF
--- a/lib/origen/model/exporter.rb
+++ b/lib/origen/model/exporter.rb
@@ -193,6 +193,9 @@ module Origen
         if (d = pin.direction) != :io
           line << ", direction: :#{d}"
         end
+        if (t = pin.type)
+          line << ", type: :#{t}"
+        end
         pkg_meta = write_pin_packages(pin)
         line << ", #{pkg_meta}" unless pkg_meta == ''
         Array(options[:attributes]).each do |attr|


### PR DESCRIPTION
Includes the pin type attribute in exported models.

This enables the pins file generated by the `origen sim:build` to identify WREAL pins as analog type.