### PR TITLE
Updated web links to origen-sdk.org to use HTTPS protocol due to website

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ class OrigenCoreApplication < Origen::Application
   
   config.web_directory = "https://github.com/Origen-SDK/Origen-SDK.github.io.git/origen"
   #config.web_directory = "git@github.com:Origen-SDK/Origen-SDK.github.io.git/origen"
-  config.web_domain = "http://origen-sdk.org/origen"
+  config.web_domain = "https://origen-sdk.org/origen"
   
   config.pattern_prefix = "nvm"
 

--- a/helpers/url.rb
+++ b/helpers/url.rb
@@ -68,7 +68,7 @@ module Origen
         end
 
         # Returns any path attached to the domain, for example will return "/jtag"
-        # for "http://origen-sdk.org/jtag"
+        # for "https://origen-sdk.org/jtag"
         def root_path # :nodoc:
           if domain =~ /\/\/[^\/]*(\/.*)/  # http://rubular.com/r/UY06Z6DXUS
             $1

--- a/lib/origen/commands/new.rb
+++ b/lib/origen/commands/new.rb
@@ -21,7 +21,7 @@ generators regardless of the base Origen version that this command is being laun
 
 See the website for more details:
 
-http://origen-sdk.org/origen_app_generators
+https://origen-sdk.org/origen_app_generators
 
 Usage: origen new [APP_NAME] [options]
 END

--- a/lib/origen/users/user.rb
+++ b/lib/origen/users/user.rb
@@ -165,7 +165,7 @@ module Origen
 
       # Returns a private global Origen session store (stored in the user's home directory and only readable
       # by them).
-      # See - http://origen-sdk.org/origen/guides/misc/session/#Global_Sessions
+      # See - https://origen-sdk.org/origen/guides/misc/session/#Global_Sessions
       def auth_session
         @session ||= begin
           @session = Origen.session.user

--- a/lib/origen/utility/collector.rb
+++ b/lib/origen/utility/collector.rb
@@ -16,7 +16,7 @@ module Origen
       attr_reader :_methods_
 
       # Creates a new Collector object and creates a Hash out of the methods names and values in the given block.
-      # @see http://origen-sdk.org/origen/guides/misc/utilities/#Collector
+      # @see https://origen-sdk.org/origen/guides/misc/utilities/#Collector
       # @example Create a collector to transform a block into a Hash
       #  Origen::Utility::Collector.new { |c| c.my_param 'My Parameter'}.to_h #=> {my_param: 'My Parameter'}
       # @yield [self] Passes the collector to the given block.
@@ -57,7 +57,7 @@ module Origen
       alias_method :to_h, :to_hash
 
       # Using the method name, creates a key in the Collector with argument given to the method.
-      # @see http://origen-sdk.org/origen/guides/misc/utilities/#Collector
+      # @see https://origen-sdk.org/origen/guides/misc/utilities/#Collector
       # @note If no args are given, the method key is set to <code>nil</code>.
       # @raise [ArgumentError] Raised when a method attempts to use both arguments and a block in the same line.
       #   E.g.: <code>collector.my_param 'my_param' { 'MyParam' }</code>

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Stephen McGinty"]
   spec.email         = ["stephen.f.mcginty@gmail.com"]
   spec.summary       = %q{The Semiconductor Developer's Kit}
-  spec.homepage      = "http://origen-sdk.org"
+  spec.homepage      = "https://origen-sdk.org"
   spec.license       = 'MIT'
   spec.required_ruby_version     = '>= 2'
   spec.required_rubygems_version = '>= 1.8.11'

--- a/templates/nanoc/layouts/bootstrap.html.erb
+++ b/templates/nanoc/layouts/bootstrap.html.erb
@@ -29,7 +29,7 @@
     <meta property="og:url" content="<%= @item[:url] %>">
     <meta name="twitter:url" content="<%= @item[:url] %>">
   <% end %>
-  <% image = @item[:image] || "http://origen-sdk.org/favicon-260x260.png" %>
+  <% image = @item[:image] || "https://origen-sdk.org/favicon-260x260.png" %>
     <meta property="og:image" content="<%= image %>">
     <meta name="twitter:image" content="<%= image %>">
     <meta itemprop="image" content="<%= image %>">
@@ -48,7 +48,7 @@
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="http://origen-sdk.org/css/bootstrap_custom.css"></script>
+    <link rel="stylesheet" href="https://origen-sdk.org/css/bootstrap_custom.css"></script>
     <!-- Load this up top to allow pages to execute JQuery snippets -->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 
@@ -71,20 +71,20 @@
     <% end %>
 
     <!-- Fav and touch icons -->
-    <link rel="apple-touch-icon" sizes="57x57" href="http://origen-sdk.org/apple-touch-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="http://origen-sdk.org/apple-touch-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="http://origen-sdk.org/apple-touch-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="http://origen-sdk.org/apple-touch-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="http://origen-sdk.org/apple-touch-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="http://origen-sdk.org/apple-touch-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="http://origen-sdk.org/apple-touch-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="http://origen-sdk.org/apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="http://origen-sdk.org/apple-touch-icon-180x180.png">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/android-chrome-192x192.png" sizes="192x192">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/favicon-96x96.png" sizes="96x96">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="http://origen-sdk.org/manifest.json">
+    <link rel="apple-touch-icon" sizes="57x57" href="https://origen-sdk.org/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="https://origen-sdk.org/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="https://origen-sdk.org/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="https://origen-sdk.org/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="https://origen-sdk.org/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="https://origen-sdk.org/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="https://origen-sdk.org/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="https://origen-sdk.org/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://origen-sdk.org/apple-touch-icon-180x180.png">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="https://origen-sdk.org/manifest.json">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-TileImage" content="/mstile-144x144.png">
     <meta name="theme-color" content="#ffffff">
@@ -102,7 +102,7 @@
     <footer class="footer">
       <div class="container">
         <p class="pull-left text-muted">
-          Generated with the <a href="http://origen-sdk.org">Origen Semiconductor Developer's Kit</a>
+          Generated with the <a href="https://origen-sdk.org">Origen Semiconductor Developer's Kit</a>
         </p>
         <p class="pull-right text-muted">Origen is released under the terms of the <a href="https://choosealicense.com/licenses/mit/">MIT license</a></p>
       </div>
@@ -111,9 +111,9 @@
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-    <script src="http://origen-sdk.org/js/lunr.min.js"></script>
-    <script src="http://origen-sdk.org/js/highlight.js"></script>
-    <script src="http://origen-sdk.org/js/custom.js"></script>
+    <script src="https://origen-sdk.org/js/lunr.min.js"></script>
+    <script src="https://origen-sdk.org/js/highlight.js"></script>
+    <script src="https://origen-sdk.org/js/custom.js"></script>
     <% if @item[:gitter_chat] %>
       <script>
         ((window.gitter = {}).chat = {}).options = {

--- a/templates/shared/web/_logo.html
+++ b/templates/shared/web/_logo.html
@@ -1,4 +1,4 @@
-<a href="http://origen-sdk.org" class=" pull-right">
-  <img src="http://origen-sdk.org/img/origen-device.png" style="height:30px; margin-top: 10px;">
-  <img src="http://origen-sdk.org/img/origen-text.png" style="height:15px; margin-top: 10px; margin-left: 5px;">
+<a href="https://origen-sdk.org" class=" pull-right">
+  <img src="https://origen-sdk.org/img/origen-device.png" style="height:30px; margin-top: 10px;">
+  <img src="https://origen-sdk.org/img/origen-text.png" style="height:15px; margin-top: 10px; margin-left: 5px;">
 </a>

--- a/templates/web/404.html.erb
+++ b/templates/web/404.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="col-centered text-center" style="margin-top: 50px; margin-bottom: 200px;">
       <p style="color: #fff;">The page that you were looking for was not found, if you are looking for documentation
-      please try the <a href="http://origen-sdk.org/guides">Guides</a> section of the site.</p>
+      please try the <a href="https://origen-sdk.org/guides">Guides</a> section of the site.</p>
 
       <p style="color: #fff;">If you think that this is a bug and that something really should be here, please
       <a href="https://github.com/Origen-SDK/Origen-SDK.github.io/issues">file a ticket</a>. Thanks!</p>

--- a/templates/web/guides/advanced/newapps.md.erb
+++ b/templates/web/guides/advanced/newapps.md.erb
@@ -19,7 +19,7 @@ first run `origen new` to create an application generator plugin by selecting th
 To hook your plugin into the `origen new` command, either release it to your private gem server, check it into your
 Git server, or copy it to a central location that is accessible to all of your users.
 Then update the [app_generators](https://github.com/Origen-SDK/origen/blob/master/origen_site_config.yml#L7) attribute within your
-[site_config file](http://origen-sdk.org/origen/guides/installation/company/) to point to wherever you have put it.
+[site_config file](https://origen-sdk.org/origen/guides/installation/company/) to point to wherever you have put it.
 
 If you don't see it straight away, run `origen new` with the `--fetch` option to force it to
 fetch the latest versions of the generators.

--- a/templates/web/guides/controllers/shadow.md.erb
+++ b/templates/web/guides/controllers/shadow.md.erb
@@ -202,7 +202,7 @@ module ATDTestBlock
 end
 ~~~
 
-See the [Cross Origen](http://origen-sdk.org/cross_origen) plugin for more details on
+See the [Cross Origen](https://origen-sdk.org/cross_origen) plugin for more details on
 importing 3rd party data formats.
 
 If on the other hand someone comes along and says, "ok everyone, from now on a full IP-XACT

--- a/templates/web/guides/installation/installwin.md.erb
+++ b/templates/web/guides/installation/installwin.md.erb
@@ -34,7 +34,7 @@ of the settings called <code>Save settings to user directory</code>.
 Execute the following command to get a sensible set settings to start off with:
 
 ~~~text
-@powershell New-Item -ItemType directory -Force -Path %appdata%\Console; (new-object System.Net.WebClient).DownloadFile('http://origen-sdk.org/files/console.xml','%appdata%\Console\console.xml')
+@powershell New-Item -ItemType directory -Force -Path %appdata%\Console; (new-object System.Net.WebClient).DownloadFile('https://origen-sdk.org/files/console.xml','%appdata%\Console\console.xml')
 ~~~
 
 <div class="alert alert-info" role="alert"> <strong>Opening the Console</strong>

--- a/templates/web/guides/models/power.md.erb
+++ b/templates/web/guides/models/power.md.erb
@@ -9,8 +9,8 @@ as power pins, rather power domains contain (indirectly) three types of pins:
 
 The idea behind modeling power domains is to provide a source of truth for the voltages various pins are programmed to
 on the ATE.  There is no native pin levels API yet in Origen but users do create ATE levels using the
-[Origen compiler](http://origen-sdk.org/origen/guides/compiler/introduction/).  Prior to the development of PowerDomains, 
-applications would likely use the [Origen::Parameters](http://origen-sdk.org/origen/guides/models/parameters/) module to store pin levels.
+[Origen compiler](https://origen-sdk.org/origen/guides/compiler/introduction/).  Prior to the development of PowerDomains, 
+applications would likely use the [Origen::Parameters](https://origen-sdk.org/origen/guides/models/parameters/) module to store pin levels.
 The advantage of using PowerDomains is that all pins get a single source of truth for their programmed value.
 
 Here is an example of the PowerDomain API:
@@ -45,7 +45,7 @@ Now we can interact with the power domains using the top level DUT.
 Typically in Origen, models own things directly, but in the case of power domains, they 'own' pins indirectly.  Most apps
 instantiate pins to the top level DUT so the PowerDomains module was written to deal with that reality, versus asking apps
 to instantiate pins within a power domain.  In order for a power domain to be aware of the pins it 'owns', pins must set
-the ['supply'](http://origen-sdk.org/origen/api/Origen/Pins/Pin.html#supply-instance_method) pin attribute.
+the ['supply'](https://origen-sdk.org/origen/api/Origen/Pins/Pin.html#supply-instance_method) pin attribute.
 
 Let's define some pins, for the :vdd power domain, that have the supply attribute defined.
 
@@ -95,8 +95,8 @@ Here are some methods available to interact with the pins associated with a powe
 ~~~
 
 After a power domain is instantiated, its setpoint or value is nil by default.  This behavior is by design, such that the
-user could define [chip modes](http://origen-sdk.org/origen/guides/models/modes/#Mode) or
-[parameter contexts](http://origen-sdk.org/origen/guides/models/parameters/#Defining_a_Set_of_Parameters) that provide scope
+user could define [chip modes](https://origen-sdk.org/origen/guides/models/modes/#Mode) or
+[parameter contexts](https://origen-sdk.org/origen/guides/models/parameters/#Defining_a_Set_of_Parameters) that provide scope
 for a group of power domain values.  Here are some examples of setting power domain setpoints/values.
 
 ~~~ruby

--- a/templates/web/guides/models/registers.md.erb
+++ b/templates/web/guides/models/registers.md.erb
@@ -358,9 +358,9 @@ bit.bit_value_descriptions[1]   # => "FMU clock is the internal oscillator from 
 ~~~
 
 Most commonly these descriptions will be used for documentation, for example the 
-[Documentation Helpers](http://origen-sdk.org/doc_helpers/) plugin provides
+[Documentation Helpers](https://origen-sdk.org/doc_helpers/) plugin provides
 helpers to easily present registers in Origen documentation as shown here -
-[Register Helpers](http://origen-sdk.org/doc_helpers/latest/examples/register/).
+[Register Helpers](https://origen-sdk.org/doc_helpers/latest/examples/register/).
 
 The descriptions can also be supplied as in-line arguments, **but doing so overrides any comment-based
 documentation.**  Thus, it is intended to be used
@@ -450,7 +450,7 @@ register definitions in Origen.
 This will generate the exact same models of the registers as if they had been declared directly
 into Origen.
 
-This import (and export) functionality is provided via the [Cross Origen](http://origen-sdk.org/cross_origen/)
+This import (and export) functionality is provided via the [Cross Origen](https://origen-sdk.org/cross_origen/)
 plugin and this should be consulted directly for the latest information on the API and the supported formats.
 
 However here is a brief example of how it can be used to import from a local XML file:
@@ -474,7 +474,7 @@ end
 By using the above API Origen has now built an accurate register model that will look and behave like the
 real register on silicon.
 This is extremely convenient and useful for pattern generation as we will see later, but it can also
-be very useful for other applications such as [generating documentation](http://origen-sdk.org/doc_helpers/examples/register/).
+be very useful for other applications such as [generating documentation](https://origen-sdk.org/doc_helpers/examples/register/).
 
 Each register created by Origen is an instance of the
 [Origen::Registers::Reg](<%= path "api/Origen/Registers/Reg.html" %>)

--- a/templates/web/guides/models/specs.md.erb
+++ b/templates/web/guides/models/specs.md.erb
@@ -149,8 +149,8 @@ found.  It also auto-adjusts the attribute column padding so no space is wasted.
 
 #### Specs and Modes in Detail
 
-Specs can be defined globally or within nested [sub_blocks](http://origen-sdk.org/origen/api/Origen/SubBlock.html)
- or [controllers](http://origen-sdk.org/origen/api/Origen/Controller.html).  A spec
+Specs can be defined globally or within nested [sub_blocks](https://origen-sdk.org/origen/api/Origen/SubBlock.html)
+ or [controllers](https://origen-sdk.org/origen/api/Origen/Controller.html).  A spec
 is defined in the context of a mode, even if it only has a single mode.  A mode is defined as
 a known device state with a unique name or id.  An simple example could be a basic PORESET
 that defines the clocking and register space state after turning a chip on.  The spec

--- a/templates/web/guides/plugins/creating.md.erb
+++ b/templates/web/guides/plugins/creating.md.erb
@@ -110,7 +110,7 @@ shared template directory (the directory specified in the plugin's
 <code>config.shared[:templates]</code> attribute),
 and then a relative path from there to the required template.
 
-For example the [doc_helpers](http://origen-sdk.org/doc_helpers)
+For example the [doc_helpers](https://origen-sdk.org/doc_helpers)
 plugin contains a test flow layout template at
 <code>templates/shared/test/_flow.md.erb</code>, and an importing
 application would reference this template via the path

--- a/templates/web/guides/plugins/importing.md.erb
+++ b/templates/web/guides/plugins/importing.md.erb
@@ -4,6 +4,6 @@ Plugins are distributed as Ruby gems and are added to an application as describe
 here: [Understanding Gems](<%= path "guides/installation/gems" %>).
 
 All plugins should provide documentation that supplies the required
-details, here is an example - [Origen JTAG Driver](http://origen-sdk.org/jtag)
+details, here is an example - [Origen JTAG Driver](https://origen-sdk.org/jtag)
 
 % end

--- a/templates/web/index.html.erb
+++ b/templates/web/index.html.erb
@@ -1,8 +1,8 @@
 % render "layouts/landing", description: "Origen is an open-source modern framework for creating semiconductor engineering applications, particularly complete, scalable test solutions." do
   <div class="main-content">
     <div class="col-centered text-center" style="margin-top: 150px;">
-      <img src="http://origen-sdk.org/img/origen-device-shadowed.png" class="hidden-xs" height="95" width="95" style="width: 95px; height: 95px; margin-top: -45px; margin-right: 10px;">
-      <img src="http://origen-sdk.org/img/origen-text-shadowed.png" height="75" style="width: 377px; height: 75px; margin-top: -45px;">
+      <img src="https://origen-sdk.org/img/origen-device-shadowed.png" class="hidden-xs" height="95" width="95" style="width: 95px; height: 95px; margin-top: -45px; margin-right: 10px;">
+      <img src="https://origen-sdk.org/img/origen-text-shadowed.png" height="75" style="width: 377px; height: 75px; margin-top: -45px;">
       <p style="font-size: 30px; margin-top: 15px; color: #fff;">The Semiconductor Developer's Kit</p>
     </div>
     <div class="col-centered text-center" style="margin-top: 50px; margin-bottom: 200px;">
@@ -31,6 +31,6 @@
       Origen is an <a href="https://github.com/Origen-SDK">open source</a> framework for creating semiconductor engineering applications, sponsored by:
     </p>
     <div class="sponsors">
-      <a href="http://www.nxp.com"><img width="250" src="http://origen-sdk.org/img/nxp-logo.png"></a>
+      <a href="http://www.nxp.com"><img width="250" src="https://origen-sdk.org/img/nxp-logo.png"></a>
   </div>
 % end  

--- a/templates/web/layouts/_cyborg.html.erb
+++ b/templates/web/layouts/_cyborg.html.erb
@@ -33,7 +33,7 @@ layout: none
     <meta property="og:url" content="<%= @item[:url] %>">
     <meta name="twitter:url" content="<%= @item[:url] %>">
   <% end %>
-  <% image = @item[:image] || "http://origen-sdk.org/favicon-260x260.png" %>
+  <% image = @item[:image] || "https://origen-sdk.org/favicon-260x260.png" %>
     <meta property="og:image" content="<%= image %>">
     <meta name="twitter:image" content="<%= image %>">
     <meta itemprop="image" content="<%= image %>">
@@ -51,7 +51,7 @@ layout: none
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="http://origen-sdk.org/css/cyborg.min.css">
+    <link rel="stylesheet" href="https://origen-sdk.org/css/cyborg.min.css">
     <link rel="stylesheet" href="<%= path "css/landing.css" %>">
     <style type="text/css">
       .col-centered{
@@ -107,20 +107,20 @@ layout: none
     </script>
 
     <!-- Fav and touch icons -->
-    <link rel="apple-touch-icon" sizes="57x57" href="http://origen-sdk.org/apple-touch-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="http://origen-sdk.org/apple-touch-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="http://origen-sdk.org/apple-touch-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="http://origen-sdk.org/apple-touch-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="http://origen-sdk.org/apple-touch-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="http://origen-sdk.org/apple-touch-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="http://origen-sdk.org/apple-touch-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="http://origen-sdk.org/apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="http://origen-sdk.org/apple-touch-icon-180x180.png">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/android-chrome-192x192.png" sizes="192x192">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/favicon-96x96.png" sizes="96x96">
-    <link rel="icon" type="image/png" href="http://origen-sdk.org/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="http://origen-sdk.org/manifest.json">
+    <link rel="apple-touch-icon" sizes="57x57" href="https://origen-sdk.org/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="https://origen-sdk.org/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="https://origen-sdk.org/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="https://origen-sdk.org/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="https://origen-sdk.org/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="https://origen-sdk.org/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="https://origen-sdk.org/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="https://origen-sdk.org/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://origen-sdk.org/apple-touch-icon-180x180.png">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="https://origen-sdk.org/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="https://origen-sdk.org/manifest.json">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-TileImage" content="/mstile-144x144.png">
     <meta name="theme-color" content="#ffffff">

--- a/templates/web/partials/_navbar.html.erb
+++ b/templates/web/partials/_navbar.html.erb
@@ -2,8 +2,8 @@
   <div class="container">
     <div class="navbar-header">
       <a href="/" class="navbar-brand" style="margin-top: -4px;">
-        <img src="http://origen-sdk.org/img/origen-device.png" style="height:30px; margin-right: 2px; display: inline; margin-top: -2px;">
-        <img src="http://origen-sdk.org/img/origen-text.png" style="height:15px; display: inline;">
+        <img src="https://origen-sdk.org/img/origen-device.png" style="height:30px; margin-right: 2px; display: inline; margin-top: -2px;">
+        <img src="https://origen-sdk.org/img/origen-text.png" style="height:15px; display: inline;">
       </a>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
         <span class="sr-only">Toggle navigation</span>

--- a/templates/web/plugins.md.erb
+++ b/templates/web/plugins.md.erb
@@ -27,9 +27,9 @@ with the necessary update.
 
 | Website | Description
 |:--------|:-----------
-| [Documentation Helpers](http://origen-sdk.org/doc_helpers/) | Layouts and helpers for common documentation tasks
-| [Cross Origen](http://origen-sdk.org/cross_origen/) | In an ideal world everyone would use Origen but back in reality design IP exists in many different formats. It is the goal of this plugin to provide import and export methods for all common formats e.g. IPXACT, etc.
-| [Memory Image](http://origen-sdk.org/memory_image/) | Provides a standard API for consuming memory image files in any format e.g. s-record, hex
+| [Documentation Helpers](https://origen-sdk.org/doc_helpers/) | Layouts and helpers for common documentation tasks
+| [Cross Origen](https://origen-sdk.org/cross_origen/) | In an ideal world everyone would use Origen but back in reality design IP exists in many different formats. It is the goal of this plugin to provide import and export methods for all common formats e.g. IPXACT, etc.
+| [Memory Image](https://origen-sdk.org/memory_image/) | Provides a standard API for consuming memory image files in any format e.g. s-record, hex
 
 ### Test Engineering
 
@@ -37,20 +37,20 @@ with the necessary update.
 
 | Website | Description
 |:--------|:-----------
-| [Testers](http://origen-sdk.org/testers) | Provides common ATE models/drivers for test pattern and program generation
-| [Debuggers](http://origen-sdk.org/debuggers) | Want to try out your patterns on the bench? Swap your tester model for one of these bench debugger models and you can do just that.
-| [OrigenLink](http://origen-sdk.org/OrigenLink) | Enable tester emulation for live silicon debug directly from Origen source
+| [Testers](https://origen-sdk.org/testers) | Provides common ATE models/drivers for test pattern and program generation
+| [Debuggers](https://origen-sdk.org/debuggers) | Want to try out your patterns on the bench? Swap your tester model for one of these bench debugger models and you can do just that.
+| [OrigenLink](https://origen-sdk.org/OrigenLink) | Enable tester emulation for live silicon debug directly from Origen source
 
 #### Transaction Protocol Drivers
 
-| [Nexus](http://origen-sdk.org/nexus) | Origen driver for the Nexus (IEEE-STO 5001-2003) protocol
-| [ARM Debug](http://origen-sdk.org/arm_debug) | Origen driver for the ARM debug protocol
-| [AHB](http://origen-sdk.org/ahb) | Origen driver for the AHB bus protocol
+| [Nexus](https://origen-sdk.org/nexus) | Origen driver for the Nexus (IEEE-STO 5001-2003) protocol
+| [ARM Debug](https://origen-sdk.org/arm_debug) | Origen driver for the ARM debug protocol
+| [AHB](https://origen-sdk.org/ahb) | Origen driver for the AHB bus protocol
 
 #### Physical Pin Drivers
 
-| [JTAG](http://origen-sdk.org/jtag) | Origen driver for the JTAG protocol
-| [Single Wire Debug](http://origen-sdk.org/swd) | Origen driver for the ARM Single Wire Debug protocol
-| [SPI](http://origen-sdk.org/origen_spi) | Origen driver for the SPI protocol
+| [JTAG](https://origen-sdk.org/jtag) | Origen driver for the JTAG protocol
+| [Single Wire Debug](https://origen-sdk.org/swd) | Origen driver for the ARM Single Wire Debug protocol
+| [SPI](https://origen-sdk.org/origen_spi) | Origen driver for the SPI protocol
 
 % end

--- a/templates/web/tour/basics.html.erb
+++ b/templates/web/tour/basics.html.erb
@@ -5,8 +5,8 @@
     </div>
     <div class="col-centered text-center" style="margin-top: 50px; margin-bottom: 200px;">
       <p style="color: #fff;">The tour has not been written yet, in the meantime please checkout our
-        <a href="http://origen-sdk.org/guides">Guides</a> and our 
-        <a href="http://origen-sdk.org/videos">Videos</a>.
+        <a href="https://origen-sdk.org/guides">Guides</a> and our 
+        <a href="https://origen-sdk.org/videos">Videos</a>.
       </p>
     </div>
   </div>

--- a/templates/web/tour/design-engineering.html.erb
+++ b/templates/web/tour/design-engineering.html.erb
@@ -5,8 +5,8 @@
     </div>
     <div class="col-centered text-center" style="margin-top: 50px; margin-bottom: 200px;">
       <p style="color: #fff;">The tour has not been written yet, in the meantime please checkout our
-        <a href="http://origen-sdk.org/guides">Guides</a> and our 
-        <a href="http://origen-sdk.org/videos">Videos</a>.
+        <a href="https://origen-sdk.org/guides">Guides</a> and our 
+        <a href="https://origen-sdk.org/videos">Videos</a>.
       </p>
     </div>
   </div>

--- a/templates/web/tour/test-engineering.html.erb
+++ b/templates/web/tour/test-engineering.html.erb
@@ -5,8 +5,8 @@
     </div>
     <div class="col-centered text-center" style="margin-top: 50px; margin-bottom: 200px;">
       <p style="color: #fff;">The tour has not been written yet, in the meantime please checkout our
-        <a href="http://origen-sdk.org/guides">Guides</a> and our 
-        <a href="http://origen-sdk.org/videos">Videos</a>.
+        <a href="https://origen-sdk.org/guides">Guides</a> and our 
+        <a href="https://origen-sdk.org/videos">Videos</a>.
       </p>
     </div>
   </div>

--- a/templates/web/videos/2-model-data-import.md.erb
+++ b/templates/web/videos/2-model-data-import.md.erb
@@ -4,9 +4,9 @@
 #### References
 
 * [Full source code on Github](https://github.com/Origen-Demos/2-model-data-import-and-documentation)
-* [Cross Origen plugin](http://origen-sdk.org/cross_origen/)
-* [Documentation Helpers plugin](http://origen-sdk.org/doc_helpers/)
-* [Example Model Documentation](http://origen-sdk.org/link_demo/models/linkdemo_toplevel/)
+* [Cross Origen plugin](https://origen-sdk.org/cross_origen/)
+* [Documentation Helpers plugin](https://origen-sdk.org/doc_helpers/)
+* [Example Model Documentation](https://origen-sdk.org/link_demo/models/linkdemo_toplevel/)
 * [Callbacks](<%= path "guides/misc/callbacks" %>)
 
 #### Code

--- a/templates/web/videos/6-create-program-tests.md.erb
+++ b/templates/web/videos/6-create-program-tests.md.erb
@@ -5,10 +5,10 @@
 
 * [Full source code on Github](https://github.com/Origen-Demos/6-creating-tests)
 * [Test Program Generator Guide](<%= path "guides/program/introduction" %>)
-* [Origen Testers Release Notes](http://origen-sdk.org/testers/release_notes/)
-* [Test Suite API](http://origen-sdk.org/testers/api/OrigenTesters/SmartestBasedTester/Base/TestSuite.html)
-* [ACTml API](http://origen-sdk.org/testers/api/OrigenTesters/SmartestBasedTester/Base/TestMethods/AcTml.html)
-* [DCTml API](http://origen-sdk.org/testers/api/OrigenTesters/SmartestBasedTester/Base/TestMethods/DcTml.html)
+* [Origen Testers Release Notes](https://origen-sdk.org/testers/release_notes/)
+* [Test Suite API](https://origen-sdk.org/testers/api/OrigenTesters/SmartestBasedTester/Base/TestSuite.html)
+* [ACTml API](https://origen-sdk.org/testers/api/OrigenTesters/SmartestBasedTester/Base/TestMethods/AcTml.html)
+* [DCTml API](https://origen-sdk.org/testers/api/OrigenTesters/SmartestBasedTester/Base/TestMethods/DcTml.html)
 
 #### Code
 


### PR DESCRIPTION
I haven't yet done an update for the `index.html` symlink.

Looking in the code it seems it already has code to generate a symlink for `index.html' pointing to `latest/index.html`, however it is only created if `index.html`.  

[https://github.com/Origen-SDK/origen/blob/master/lib/origen/application/deployer.rb#L155](https://github.com/Origen-SDK/origen/blob/master/lib/origen/application/deployer.rb#L155)

I think we need to update this also to delete the toplevel `index.html` if there and implement the symlink.  This should work even if symlink already there.

Thoughts?