### PR TITLE
fixes #353

### DIFF
--- a/lib/origen/users/user.rb
+++ b/lib/origen/users/user.rb
@@ -14,7 +14,7 @@ module Origen
         # Way to force Origen to use the new user ID in case of WSL where the core ID might not match the WSL login name
         # In the ~/.origen/origen_site_config.yml file, User can define change_user_id: true and new_user_id: "string"
         if Origen.site_config.change_user_id
-          Orgen.site_config.new_user_id
+          Origen.site_config.new_user_id
         else
           `whoami`.strip
         end

--- a/lib/origen/users/user.rb
+++ b/lib/origen/users/user.rb
@@ -3,12 +3,21 @@ module Origen
     class User
       require 'openssl'
       require 'digest/sha1'
+      # Required for STDIN.noecho to work
+      # https://stackoverflow.com/questions/9324697/why-cannot-use-instance-method-noecho-of-class-io
+      require'io/console'
 
       attr_reader :role
       attr_writer :name, :email
 
       def self.current_user_id
-        `whoami`.strip
+        # Way to force Origen to use the new user ID in case of WSL where the core ID might not match the WSL login name
+        # In the ~/.origen/origen_site_config.yml file, User can define change_user_id: true and new_user_id: "string"
+        if Origen.site_config.change_user_id
+          Orgen.site_config.new_user_id
+        else
+         `whoami`.strip
+        end
       end
 
       def self.current

--- a/lib/origen/users/user.rb
+++ b/lib/origen/users/user.rb
@@ -11,13 +11,7 @@ module Origen
       attr_writer :name, :email
 
       def self.current_user_id
-        # Way to force Origen to use the new user ID in case of WSL where the core ID might not match the WSL login name
-        # In the ~/.origen/origen_site_config.yml file, User can define change_user_id: true and new_user_id: "string"
-        if Origen.site_config.change_user_id
-          Origen.site_config.new_user_id
-        else
-          `whoami`.strip
-        end
+        `whoami`.strip
       end
 
       def self.current
@@ -54,7 +48,9 @@ module Origen
       end
 
       def id(options = {})
-        @id.to_s.downcase
+        # Way to force Origen to use the new user ID in case of WSL where the core ID might not match the WSL login name
+        # User needs to setup the environment variable in their .bashrc or .tcshrc file
+        ENV['ORIGEN_USER_ID'] || @id.to_s.downcase
       end
       alias_method :core_id, :id
       alias_method :username, :id
@@ -76,7 +72,7 @@ module Origen
       end
 
       def name
-        @name ||= ENV['ORIGEN_NAME'] || name_from_rc || @id
+        @name ||= ENV['ORIGEN_NAME'] || ENV['ORIGEN_USER_NAME'] || name_from_rc || @id
       end
 
       def name_from_rc
@@ -85,7 +81,7 @@ module Origen
 
       def email(options = {})
         if current?
-          @email ||= ENV['ORIGEN_EMAIL'] || email_from_rc || begin
+          @email ||= ENV['ORIGEN_EMAIL'] || ENV['ORIGEN_USER_EMAIL'] || email_from_rc || begin
             if Origen.site_config.email_domain
               "#{id}@#{Origen.site_config.email_domain}"
             end

--- a/lib/origen/users/user.rb
+++ b/lib/origen/users/user.rb
@@ -5,7 +5,7 @@ module Origen
       require 'digest/sha1'
       # Required for STDIN.noecho to work
       # https://stackoverflow.com/questions/9324697/why-cannot-use-instance-method-noecho-of-class-io
-      require'io/console'
+      require 'io/console'
 
       attr_reader :role
       attr_writer :name, :email
@@ -16,7 +16,7 @@ module Origen
         if Origen.site_config.change_user_id
           Orgen.site_config.new_user_id
         else
-         `whoami`.strip
+          `whoami`.strip
         end
       end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -52,14 +52,4 @@ describe 'Advanced User Options' do
     Origen.current_user.id.should == original_user.id
     Origen.current_user.id.should_not == 'crradm'
   end
-
-  it 'Checks if a different user id is specified in Origen Site Config' do
-    if !Origen.site_config.change_user_id
-      Origen.site_config.change_user_id = false
-      Origen.site_config.user_id = nil
-    else
-      Origen.site_config.change_user_id = Origen.site_config.change_user_id
-      Origen.site_config.user_id = Origen.site_config.user_id
-    end
-  end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -52,4 +52,14 @@ describe 'Advanced User Options' do
     Origen.current_user.id.should == original_user.id
     Origen.current_user.id.should_not == 'crradm'
   end
+
+  it 'Checks if a different user id is specified in Origen Site Config' do
+    if !Origen.site_config.change_user_id
+      Origen.site_config.change_user_id = false
+      Origen.site_config.user_id = nil
+    else
+      Origen.site_config.change_user_id = Origen.site_config.change_user_id
+      Origen.site_config.user_id = Origen.site_config.user_id
+    end
+  end
 end

--- a/templates/web/guides/starting/commit.md.erb
+++ b/templates/web/guides/starting/commit.md.erb
@@ -75,8 +75,8 @@ If you don't have Git available then alternatively you can set the following env
 variables:
 
 ~~~text
-ORIGEN_NAME  = "John Doe"
-ORIGEN_EMAIL = "johndoe@example.com"
+ORIGEN_USER_NAME  = "John Doe"
+ORIGEN_USER_EMAIL = "johndoe@example.com"
 ~~~
 
 If you are using the [Windows Linux Subsystem](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) and have your WSL login different from your corporate login

--- a/templates/web/guides/starting/commit.md.erb
+++ b/templates/web/guides/starting/commit.md.erb
@@ -79,12 +79,20 @@ ORIGEN_NAME  = "John Doe"
 ORIGEN_EMAIL = "johndoe@example.com"
 ~~~
 
+If you are using the [Windows Linux Subsystem](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) and have your WSL login different from your corporate login
+you could also set the ORIGEN_USER_ID environment variable in your .bashrc / .tcshrc file
+
+~~~text
+ORIGEN_USER_ID = "jdoe"
+~~~
+
 You can test whether your changes have been picked up by opening an Origen console (<code>origen i</code>)
 and running the following:
 
 ~~~ruby
 User.current.name    # => "John Doe"
 User.current.email   # => "johndoe@example.com"
+User.current.id      # => "jdoe"
 ~~~
 
 An alternative path to determining your details could be via your company's employee directory


### PR DESCRIPTION
fixes #353 

I also added some code that checks if a different user_id is defined in the site config in the user directory. Running into issues where the Linux Subsystem in windows 10 uses a different user id than the corporate ID. If there is another way to change this, I am open to discussing.

