### PR TITLE
Fix sourceless pattern generation for sequences

### DIFF
--- a/approved/nvm_concurrent.atp
+++ b/approved/nvm_concurrent.atp
@@ -1,6 +1,6 @@
 // ***************************************************************************
 // GENERATED:
-//   Time:    27-May-2019 16:33PM
+//   Time:    19-Sep-2019 02:40AM
 //   By:      Stephen McGinty
 //   Mode:    debug
 //   Command: origen g concurrent -t origen_sim_dut.rb
@@ -8,20 +8,19 @@
 // ENVIRONMENT:
 //   Application
 //     Source:    git@github.com:Origen-SDK/origen.git
-//     Version:   0.44.0
-//     Branch:    app_dir(1e184e87a72)
+//     Version:   0.54.0
+//     Branch:    sourceless_sequence(ae6315851df) (+local edits)
 //   Origen
 //     Source:    https://github.com/Origen-SDK/origen
-//     Version:   0.44.0
+//     Version:   0.54.0
 //   Plugins
-//     atp:                      1.1.3
-//     origen_app_generators:    1.2.0
+//     origen_app_generators:    2.1.1
 //     origen_core_support:      0.2.3
-//     origen_debuggers:         0.6.0
-//     origen_doc_helpers:       0.8.0
-//     origen_jtag:              0.21.1
-//     origen_sim:               0.20.0
-//     origen_testers:           0.21.0
+//     origen_debuggers:         0.6.1
+//     origen_doc_helpers:       0.8.1
+//     origen_jtag:              0.22.0
+//     origen_sim:               0.20.5
+//     origen_testers:           0.41.0
 // ***************************************************************************
 // Header Comments From Application: origen_core:
 //   This is a dummy pattern created by the Origen test environment
@@ -51,7 +50,13 @@ repeat 11                                                        > func         
 repeat 11                                                        > func                         1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
 repeat 11                                                        > func                         1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
 // ######################################################################
+// ## [ip1] START OF PATTERN: ip1_test.rb
+// ######################################################################
+// ######################################################################
 // ## [ip1] Communication test with ip1
+// ######################################################################
+// ######################################################################
+// ## [ip2] START OF PATTERN: ip2_test.rb
 // ######################################################################
 // ######################################################################
 // ## [ip2] Communication test with ip2
@@ -755,7 +760,11 @@ repeat 16                                                        > func         
                                                                  > func                         1 0 X 1 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
 // [ip2] [JTAG] /Read DR: 0xXXXXX00000000
                                                                  > func                         1 0 X 1 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
-repeat 19783                                                     > func                         1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
+                                                                 > func                         1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
+// ######################################################################
+// ## [ip2] END OF PATTERN: ip2_test.rb
+// ######################################################################
+repeat 19782                                                     > func                         1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
 repeat 2                                                         > func                         1 0 X 1 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
 repeat 2                                                         > func                         1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
 // [ip1] [JTAG] Write IR: 0x5
@@ -785,6 +794,9 @@ repeat 16                                                        > func         
 // [ip1] [JTAG] /Read DR: 0xXXXXX00000000
                                                                  > func                         1 0 X 1 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
                                                                  > func                         1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X ;
+// ######################################################################
+// ## [ip1] END OF PATTERN: ip1_test.rb
+// ######################################################################
 // ######################################################################
 // ## Pattern complete
 // ######################################################################

--- a/lib/origen/generator/pattern_sequence.rb
+++ b/lib/origen/generator/pattern_sequence.rb
@@ -18,7 +18,8 @@ module Origen
 
       # Execute the given pattern
       def run(pattern_name)
-        ss "START OF PATTERN: #{pattern_name}"
+        name = Pathname.new(pattern_name).basename
+        ss "START OF PATTERN: #{name}"
         # Give the app a chance to handle pattern dispatch
         skip = false
         Origen.app.listeners_for(:before_pattern_lookup).each do |listener|
@@ -29,7 +30,7 @@ module Origen
           pattern = pattern[:pattern] if pattern.is_a?(Hash)
           load pattern
         end
-        ss "END OF PATTERN: #{pattern_name}"
+        ss "END OF PATTERN: #{name}"
       end
       alias_method :call, :run
 

--- a/lib/origen/generator/pattern_sequence.rb
+++ b/lib/origen/generator/pattern_sequence.rb
@@ -18,9 +18,18 @@ module Origen
 
       # Execute the given pattern
       def run(pattern_name)
-        pattern = Origen.generator.pattern_finder.find(pattern_name.to_s, {})
-        pattern = pattern[:pattern] if pattern.is_a?(Hash)
-        load pattern
+        ss "START OF PATTERN: #{pattern_name}"
+        # Give the app a chance to handle pattern dispatch
+        skip = false
+        Origen.app.listeners_for(:before_pattern_lookup).each do |listener|
+          skip ||= !listener.before_pattern_lookup(pattern_name.to_s)
+        end
+        unless skip
+          pattern = Origen.generator.pattern_finder.find(pattern_name.to_s, {})
+          pattern = pattern[:pattern] if pattern.is_a?(Hash)
+          load pattern
+        end
+        ss "END OF PATTERN: #{pattern_name}"
       end
       alias_method :call, :run
 


### PR DESCRIPTION
Sourceless pattern generation was broken when running `origen g` with the `--seq` option to generate a (concurrent) sequence, this fixes it.