### PR TITLE
Adding support for 'origen rc tag' without prepending 'v' to the tag

### DIFF
--- a/lib/origen/application/configuration.rb
+++ b/lib/origen/application/configuration.rb
@@ -20,7 +20,7 @@ module Origen
                     :strict_errors, :unmanaged_dirs, :unmanaged_files, :remotes,
                     :external_app_dirs, :lint_test, :shared, :yammer_group, :rc_url, :rc_workflow,
                     :user_aliases, :release_externally, :gem_name, :disqus_shortname,
-                    :default_plugin
+                    :default_plugin, :rc_tag_prepend_v
 
       # Mark any attributes that are likely to depend on properties of the target here,
       # this will raise an error if they are ever accessed before the target has been
@@ -99,6 +99,7 @@ module Origen
         @remotes = []
         @lint_test = {}
         @user_aliases = {}
+        @rc_tag_prepend_v = true
       end
 
       # This defines an enhanced accessor for these attributes that allows them to be assigned

--- a/lib/origen/application/plugins.rb
+++ b/lib/origen/application/plugins.rb
@@ -14,17 +14,15 @@ module Origen
       # Will raise an error if any plugins are currently imported from a path reference
       # in the Gemfile
       def validate_production_status(force = false)
-        unless Origen.app.session.origen_core[:mode] == 'debug'
-          if Origen.mode.production? || force
-            if File.exist?("#{Origen.root}/Gemfile")
-              File.readlines("#{Origen.root}/Gemfile").each do |line|
-                # http://rubular.com/r/yNGDGB6M2r
-                if line =~ /^\s*gem\s+(("|')\w+("|')),.*(:path\s*=>|path:)/
-                  fail "The following gem is defined as a path in your Gemfile, but that is not allowed in production: #{Regexp.last_match[1]}"
-                end
-                if line =~ /ORIGEN PLUGIN AUTO-GENERATED/
-                  fail 'Fetched gems are currently being used in your Gemfile, but that is not allowed in production!'
-                end
+        if Origen.mode.production? || force
+          if File.exist?("#{Origen.root}/Gemfile")
+            File.readlines("#{Origen.root}/Gemfile").each do |line|
+              # http://rubular.com/r/yNGDGB6M2r
+              if line =~ /^\s*gem\s+(("|')\w+("|')),.*(:path\s*=>|path:)/
+                fail "The following gem is defined as a path in your Gemfile, but that is not allowed in production: #{Regexp.last_match[1]}"
+              end
+              if line =~ /ORIGEN PLUGIN AUTO-GENERATED/
+                fail 'Fetched gems are currently being used in your Gemfile, but that is not allowed in production!'
               end
             end
           end

--- a/lib/origen/application/plugins.rb
+++ b/lib/origen/application/plugins.rb
@@ -14,15 +14,17 @@ module Origen
       # Will raise an error if any plugins are currently imported from a path reference
       # in the Gemfile
       def validate_production_status(force = false)
-        if Origen.mode.production? || force
-          if File.exist?("#{Origen.root}/Gemfile")
-            File.readlines("#{Origen.root}/Gemfile").each do |line|
-              # http://rubular.com/r/yNGDGB6M2r
-              if line =~ /^\s*gem\s+(("|')\w+("|')),.*(:path\s*=>|path:)/
-                fail "The following gem is defined as a path in your Gemfile, but that is not allowed in production: #{Regexp.last_match[1]}"
-              end
-              if line =~ /ORIGEN PLUGIN AUTO-GENERATED/
-                fail 'Fetched gems are currently being used in your Gemfile, but that is not allowed in production!'
+        unless Origen.app.session.origen_core[:mode] == 'debug'
+          if Origen.mode.production? || force
+            if File.exist?("#{Origen.root}/Gemfile")
+              File.readlines("#{Origen.root}/Gemfile").each do |line|
+                # http://rubular.com/r/yNGDGB6M2r
+                if line =~ /^\s*gem\s+(("|')\w+("|')),.*(:path\s*=>|path:)/
+                  fail "The following gem is defined as a path in your Gemfile, but that is not allowed in production: #{Regexp.last_match[1]}"
+                end
+                if line =~ /ORIGEN PLUGIN AUTO-GENERATED/
+                  fail 'Fetched gems are currently being used in your Gemfile, but that is not allowed in production!'
+                end
               end
             end
           end

--- a/lib/origen/application/release.rb
+++ b/lib/origen/application/release.rb
@@ -174,7 +174,7 @@ Your workspace has local modifications that are preventing the requested action
       # Pull the latest versions of the history and version ID files into the workspace
       def get_latest_version_files
         # Get the latest version of the version and history files
-        if Origen.app.rc.dssc? && !which('dssc').nil?
+        if Origen.app.rc.dssc?
           # Legacy code that makes use of the fact that DesignSync can handle different branch selectors
           # for individual files, this capability has not been abstracted by the newer object oriented
           # revision controllers since most others cannot do it

--- a/lib/origen/application/release.rb
+++ b/lib/origen/application/release.rb
@@ -32,7 +32,7 @@ module Origen
         if authorized?
           Origen.app.plugins.validate_production_status(true)
           fail 'No revision control configured for this application, cannot release a new version' if Origen.app.rc.nil?
-          if Origen.app.rc.local_modifications.empty?
+          unless Origen.app.rc.local_modifications.empty?
             puts <<-EOT
 Your workspace has local modifications that are preventing the requested action
   - run 'origen rc mods' to see them.

--- a/lib/origen/utility.rb
+++ b/lib/origen/utility.rb
@@ -8,6 +8,7 @@ module Origen
     autoload :BlockArgs, 'origen/utility/block_args'
     autoload :FileDiff,  'origen/utility/file_diff.rb'
     autoload :Collector, 'origen/utility/collector.rb'
+    autoload :ApplicationSupport, 'origen/utility/application_support'
 
     # Creates a hex-like representation of a register read value, where bits within
     # a nibble have different flags set the nibble will be expanded to bits
@@ -99,6 +100,18 @@ module Origen
 
     def self.collector(options = {}, &block)
       Origen::Utility::Collector.new(options, &block)
+    end
+
+    # https://stackoverflow.com/a/5471032/8511822
+    def which(cmd)
+      exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+        exts.each do |ext|
+          exe = File.join(path, "#{cmd}#{ext}")
+          return exe if File.executable?(exe) && !File.directory?(exe)
+        end
+      end
+      nil
     end
   end
 end

--- a/lib/origen/version_string.rb
+++ b/lib/origen/version_string.rb
@@ -75,9 +75,7 @@ module Origen
     # Returns true if the version is a semantic format version number
     def semantic?
       !!(self =~ /^v?\d+\.\d+\.\d+$/ ||
-         self =~ /^v?\d+\.\d+\.\d+\.(dev|pre)\d+$/ ||
-         self =~ /^\d+\.\d+\.\d+$/ ||
-         self =~ /^\d+\.\d+\.\d+\.(dev|pre)\d+$/
+         self =~ /^v?\d+\.\d+\.\d+\.(dev|pre)\d+$/
         )
     end
 
@@ -143,11 +141,8 @@ module Origen
     def major
       @major ||= begin
         if semantic?
-          if self =~ /v?(\d+)/
-            Regexp.last_match[1].to_i
-          elsif self =~ /(\d+)/
-            Regexp.last_match[1].to_i
-          end
+          self =~ /v?(\d+)/
+          Regexp.last_match[1].to_i
         else
           fail "#{self} is not a valid semantic version number!"
         end
@@ -157,11 +152,8 @@ module Origen
     def minor
       @minor ||= begin
         if semantic?
-          if self =~ /v?\d+.(\d+)/
-            Regexp.last_match[1].to_i
-          elsif self =~ /\d+.(\d+)/
-            Regexp.last_match[1].to_i
-          end
+          self =~ /v?\d+.(\d+)/
+          Regexp.last_match[1].to_i
         else
           fail "#{self} is not a valid semantic version number!"
         end
@@ -171,11 +163,8 @@ module Origen
     def bugfix
       @bugfix ||= begin
         if semantic?
-          if self =~ /v?\d+.\d+.(\d+)/
-            Regexp.last_match[1].to_i
-          elsif self =~ /\d+.\d+.(\d+)/
-            Regexp.last_match[1].to_i
-          end
+          self =~ /v?\d+.\d+.(\d+)/
+          Regexp.last_match[1].to_i
         else
           fail "#{self} is not a valid semantic version number!"
         end

--- a/lib/origen/version_string.rb
+++ b/lib/origen/version_string.rb
@@ -258,27 +258,16 @@ module Origen
       elsif semantic?
         # This assumes each counter will never go > 1000
         if development?
-          if self =~ /v?(\d+).(\d+).(\d+).(dev|pre)(\d+)/
-            (Regexp.last_match[1].to_i * 1000 * 1000 * 1000) +
-              (Regexp.last_match[2].to_i * 1000 * 1000) +
-              (Regexp.last_match[3].to_i * 1000) +
-              Regexp.last_match[5].to_i
-          elsif self =~ /(\d+).(\d+).(\d+).(dev|pre)(\d+)/
-            (Regexp.last_match[1].to_i * 1000 * 1000 * 1000) +
-              (Regexp.last_match[2].to_i * 1000 * 1000) +
-              (Regexp.last_match[3].to_i * 1000) +
-              Regexp.last_match[5].to_i
-          end
+          self =~ /v?(\d+).(\d+).(\d+).(dev|pre)(\d+)/
+          (Regexp.last_match[1].to_i * 1000 * 1000 * 1000) +
+            (Regexp.last_match[2].to_i * 1000 * 1000) +
+            (Regexp.last_match[3].to_i * 1000) +
+            Regexp.last_match[5].to_i
         else
-          if self =~ /v?(\d+).(\d+).(\d+)/
-            (Regexp.last_match[1].to_i * 1000 * 1000 * 1000) +
-              (Regexp.last_match[2].to_i * 1000 * 1000) +
-              (Regexp.last_match[3].to_i * 1000)
-          elsif self =~ /(\d+).(\d+).(\d+)/
-            (Regexp.last_match[1].to_i * 1000 * 1000 * 1000) +
-              (Regexp.last_match[2].to_i * 1000 * 1000) +
-              (Regexp.last_match[3].to_i * 1000)
-          end
+          self =~ /v?(\d+).(\d+).(\d+)/
+          (Regexp.last_match[1].to_i * 1000 * 1000 * 1000) +
+            (Regexp.last_match[2].to_i * 1000 * 1000) +
+            (Regexp.last_match[3].to_i * 1000)
         end
       elsif timestamp?
         to_time.to_i


### PR DESCRIPTION
The change in the plugins file was a workaround so I could test out the PR.  **Question:** Would we ever allow someone to make a release where the session mode is set to 'debug'?