### PR TITLE
origen archive command bugfix

### DIFF
--- a/lib/origen/commands/archive.rb
+++ b/lib/origen/commands/archive.rb
@@ -62,9 +62,9 @@ unless options[:local]
     Origen.log.info 'Creating a copy of the application'
     if Origen.os.linux?
       Dir.chdir Origen.root do
-        cmd = "rsync -av --progress . tmp/#{name} --exclude tmp"
+        cmd = "rsync -av --progress . tmp/#{name} --exclude /tmp"
         exclude_dirs.each do |dir|
-          cmd += " --exclude #{dir}"
+          cmd += " --exclude /#{dir}"
         end
         passed = system cmd
         unless passed


### PR DESCRIPTION
This fixes a bug in the archive command where any directory within the application matching one of the exclude dir names is excluded, whereas the intention was for only directories matching the exact path to be excluded.
e.g. currently any dir named 'dist' anywhere in the app will be excluded, but now only `#{Origen.root}/dist` will be excluded.