### PR TITLE
Report syntax errors within sub_block classes properly

### DIFF
--- a/lib/origen/sub_blocks.rb
+++ b/lib/origen/sub_blocks.rb
@@ -478,16 +478,23 @@ module Origen
       def klass
         @klass ||= begin
           class_name = attributes.delete(:class_name)
+          tmp_class = nil
           if class_name
             begin
-              klass = eval("::#{owner.namespace}::#{class_name}")
-            rescue NameError
+              tmp_class = "::#{owner.namespace}::#{class_name}"
+              klass = eval(tmp_class)
+            rescue NameError => e
+              raise if e.message !~ /^uninitialized constant (.*)$/ || tmp_class !~ /#{Regexp.last_match(1)}/
               begin
+                tmp_class = class_name.to_s
                 klass = eval(class_name)
-              rescue NameError
+              rescue NameError => e
+                raise if e.message !~ /^uninitialized constant (.*)$/ || tmp_class !~ /#{Regexp.last_match(1)}/
                 begin
-                  klass = eval("#{owner.class}::#{class_name}")
-                rescue NameError
+                  tmp_class = "#{owner.class}::#{class_name}"
+                  klass = eval(tmp_class)
+                rescue NameError => e
+                  raise if e.message !~ /^uninitialized constant (.*)$/ || tmp_class !~ /#{Regexp.last_match(1)}/
                   puts "Could not find class: #{class_name}"
                   raise 'Unknown sub block class!'
                 end


### PR DESCRIPTION
When sub-blocks are loaded by the autoloader, some errors (those related to missing references) in the sub-block files can be swallowed and in-correctly reported to the user "as unable to find (sub-block) class X".
Such cases were very hard to debug for the user!
This fixes it by being more selective about what is considered a maskable error and it now correctly reports the underlying error in such cases.