### PR TITLE
Added new site config variable 

### DIFF
--- a/lib/origen/application/lsf_manager.rb
+++ b/lib/origen/application/lsf_manager.rb
@@ -15,6 +15,7 @@ module Origen
         unless File.exist?(log_file_directory)
           FileUtils.mkdir_p(log_file_directory)
         end
+        @use_command_prefix = Origen.site_config.use_command_prefix
       end
 
       # Picks and returns either the application's LSF instance or the global LSF instance
@@ -421,11 +422,17 @@ module Origen
 
       def command_prefix(id, dependents)
         origen = `which origen`
-        # http://rubular.com/r/wgKi73KjUo
-        if origen =~ /(^\/run\/pkg\/fs-origen-\/[^\/]+)/
-          prefix = "source #{Regexp.last_match[1]}/origen_setup; "
+        # This is boolean that is setup in the site config file
+        if @use_command_prefix
+          # http://rubular.com/r/wgKi73KjUo
+          if origen =~ /(^\/run\/pkg\/fs-origen-\/[^\/]+)/
+            prefix = "source #{Regexp.last_match[1]}/origen_setup; "
+          else
+            prefix = "cd #{Origen.top}; source source_setup; "
+          end
         else
-          prefix = "cd #{Origen.top}; source source_setup; "
+          # define prefix as a blank string if Origen.site_config.use_command_prefix is false
+          prefix = ''
         end
         prefix += "cd #{Origen.root}; origen l --execute --id #{id} "
         unless dependents.empty?

--- a/lib/origen/application/lsf_manager.rb
+++ b/lib/origen/application/lsf_manager.rb
@@ -422,7 +422,7 @@ module Origen
       def command_prefix(id, dependents)
         # define prefix as a blank string if Origen.site_config.lsf_command_prefix is not defined
         if Origen.site_config.lsf_command_prefix
-         prefix = Origen.site_config.lsf_command_prefix
+          prefix = Origen.site_config.lsf_command_prefix
         else
           prefix = ''
         end

--- a/lib/origen/application/lsf_manager.rb
+++ b/lib/origen/application/lsf_manager.rb
@@ -15,7 +15,6 @@ module Origen
         unless File.exist?(log_file_directory)
           FileUtils.mkdir_p(log_file_directory)
         end
-        @use_command_prefix = Origen.site_config.use_command_prefix
       end
 
       # Picks and returns either the application's LSF instance or the global LSF instance
@@ -421,17 +420,10 @@ module Origen
       end
 
       def command_prefix(id, dependents)
-        origen = `which origen`
-        # This is boolean that is setup in the site config file
-        if @use_command_prefix
-          # http://rubular.com/r/wgKi73KjUo
-          if origen =~ /(^\/run\/pkg\/fs-origen-\/[^\/]+)/
-            prefix = "source #{Regexp.last_match[1]}/origen_setup; "
-          else
-            prefix = "cd #{Origen.top}; source source_setup; "
-          end
+        # define prefix as a blank string if Origen.site_config.lsf_command_prefix is not defined
+        if Origen.site_config.lsf_command_prefix
+         prefix = Origen.site_config.lsf_command_prefix
         else
-          # define prefix as a blank string if Origen.site_config.use_command_prefix is false
           prefix = ''
         end
         prefix += "cd #{Origen.root}; origen l --execute --id #{id} "

--- a/templates/web/guides/runtime/global.md.erb
+++ b/templates/web/guides/runtime/global.md.erb
@@ -44,7 +44,7 @@ if the site_config variable is not defined the prefix is an empty string.
 In your origen_site_config.yml file, you can specify the site_config variable as shown below
 
 ~~~ruby
-Origen.site_config.lsf_command_prefix = '/run/pkg/fs-rgen-latest/origen_setup'
+Origen.site_config.lsf_command_prefix = '/location/where_tool_is_installed/origen_setup'
 ~~~
 
 % end

--- a/templates/web/guides/runtime/global.md.erb
+++ b/templates/web/guides/runtime/global.md.erb
@@ -36,4 +36,15 @@ $dut = MyApp::Falcon.new(version: 1)
 Origen.config.lsf.project =  "falcon.te"
 ~~~
 
+#### Origen LSF command prefix
+The Origen runtime environment can be configured to run a prefix command before running any job on the LSF.
+There is a site config variable now available to define what that prefix command is. By default,
+if the site_config variable is not defined the prefix is an empty string.
+
+In your origen_site_config.yml file, you can specify the site_config variable as shown below
+
+~~~ruby
+Origen.site_config.lsf_command_prefix = '/run/pkg/fs-rgen-latest/origen_setup'
+~~~
+
 % end


### PR DESCRIPTION
Added new site config variable so that the sourcing of the setup file gets skipped.

The source_setup is needed for the 'older' RGen installations (which no one should be currently using anyways)