### PR TITLE
Feature/regression and log

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -610,6 +610,9 @@ unless defined? RGen::ORIGENTRANSITION
         else
           @interface.reset_globals if @interface.respond_to?(:reset_globals)
         end
+        if @interface.respond_to?(:on_interface_reset)
+          @interface.on_interface_reset
+        end
         @interface
       end
 

--- a/lib/origen/application/lsf_manager.rb
+++ b/lib/origen/application/lsf_manager.rb
@@ -252,8 +252,9 @@ module Origen
       end
 
       # Build the log file from the completed jobs
-      def build_log(_options = {})
-        Origen.log.info '*' * 70
+      def build_log(options = {})
+        log_method = options[:log_file] ? options[:log_file] : :info
+        Origen.log.send(log_method, '*' * 70)
         completed_jobs.each do |job|
           File.open(log_file(job[:id])) do |f|
             last_line_blank = false
@@ -291,12 +292,12 @@ module Origen
                   stats.failed_files += Regexp.last_match[1].to_i
                 elsif line =~ /ERROR!/
                   stats.errors += 1
-                  Origen.log.send :relog, line
+                  Origen.log.send :relog, line, options
                 else
                   # Compress multiple blank lines
                   if line =~ /^\s*$/ || line =~ /.*\|\|\s*$/
                     unless last_line_blank
-                      Origen.log.info
+                      Origen.log.send(log_method, nil)
                       last_line_blank = true
                     end
                   else
@@ -305,8 +306,7 @@ module Origen
                            line =~ /Insecure world writable dir/ ||
                            line =~ /To save all of/
                       line.strip!
-                      # line.sub!(/.*\|\| /, '')
-                      Origen.log.send :relog, line
+                      Origen.log.send :relog, line, options
                       last_line_blank = false
                     end
                   end
@@ -319,7 +319,7 @@ module Origen
             end
           end
         end
-        Origen.log.info '*' * 70
+        Origen.log.send(log_method, '*' * 70)
         stats.print_summary
       end
 
@@ -409,7 +409,7 @@ module Origen
         end
 
         str = "#{action} #{cmd}".strip
-        str.sub('origen ', '') if str =~ /^origen /
+        str.sub!('origen ', '') if str =~ /^origen /
 
         # Append the --exec_remote switch to all Origen commands, this allows command
         # processing to be altered based on whether it is running locally or

--- a/lib/origen/application/workspace_manager.rb
+++ b/lib/origen/application/workspace_manager.rb
@@ -114,7 +114,7 @@ module Origen
           fail "Sorry but #{path} already exists!"
         end
         FileUtils.rm_rf(path.to_s) if File.exist?(path.to_s)
-        rc = RevisionControl.new remote: options[:rc_url], local: path.to_s
+        rc = RevisionControl.new options.merge(remote: options[:rc_url], local: path.to_s)
         rc.build
       end
 

--- a/lib/origen/log.rb
+++ b/lib/origen/log.rb
@@ -274,6 +274,7 @@ module Origen
       else
         msg = format_msg(method.to_s.upcase, msg)
       end
+      console.info msg if options[:verbose]
       @custom_logs[method.to_sym].info(msg)
     end
 
@@ -364,8 +365,10 @@ module Origen
       end
     end
 
-    def relog(msg)
-      if msg =~ /^\[(\w+)\] .*/
+    def relog(msg, options = {})
+      if options[:log_file]
+        send options[:log_file], msg.sub(/.*\|\|\s*/, ''), options
+      elsif msg =~ /^\[(\w+)\] .*/
         method = Regexp.last_match(1).downcase
         if respond_to?(method)
           send method, msg.sub(/.*\|\|\s*/, '')

--- a/lib/origen/regression_manager.rb
+++ b/lib/origen/regression_manager.rb
@@ -27,6 +27,7 @@ module Origen
     # @param [Hash] options Options to customize the run instance
     # @option options [Array]   :target String Array of target names on which to run regression
     # @option options [Boolean] :build_reference (true) Build reference workspace automatically
+    # @option options [Symbol]  :build_method (:init) whether to use a git init or git clone method to build the workspace
     # @option options [Boolean] :send_email (false) Send results email when regression complete
     # @option options [Boolean] :email_all_developers (false) If sending email, whether to email all developers or just user
     # @option options [Boolean] :report_results (false) Whether to report results inline to console
@@ -35,10 +36,11 @@ module Origen
     def run(options = {})
       options = {
         build_reference:      true,
+        build_method:         :init,
         send_email:           false,
         email_all_developers: false,
         report_results:       false,
-        uses_lsf:             true
+        uses_lsf:             true,
       }.merge(options)
       options = load_options if running_in_reference_workspace?
       targets = prepare_targets(options)
@@ -46,7 +48,7 @@ module Origen
         Origen.lsf.clear_all
         yield options
         wait_for_completion(options) if options[:uses_lsf]
-        save_and_delete_output
+        save_and_delete_output(options)
       else
         if options[:build_reference]
           @reference_tag = version_to_tag(options[:version] || get_version(options))
@@ -58,7 +60,8 @@ module Origen
             disable_origen_version_check do
               Dir.chdir reference_origen_root do
                 Bundler.with_clean_env do
-                  system 'rm -rf lbin'
+                  # Origen 0.40.0 started using origen-owned binstubs
+                  system 'rm -rf lbin' if (Gem::Version.new(Origen.version) < Gem::Version.new('0.40.0'))
                   # If regression is run using a service account, we need to setup the path/bundler manually
                   # The regression manager needs to be passed a --service_account option when initiated.
                   if options[:service_account]
@@ -125,7 +128,7 @@ module Origen
     end
 
     def summarize_results(options = {})
-      Origen.lsf.build_log
+      Origen.lsf.build_log(options)
       stats = Origen.app.stats
       if options[:report_results]
         puts "Regression results: \n"
@@ -144,12 +147,16 @@ module Origen
 
     # Saves all generated output (to the reference dir) and then
     # deletes the output directory to save space
-    def save_and_delete_output
-      Origen.lsf.build_log
+    def save_and_delete_output(options = {})
+      Origen.lsf.build_log(options)
       Origen.log.flush
       Dir.chdir reference_origen_root do
         Bundler.with_clean_env do
-          system 'bundle exec origen save all'
+          if options[:log_file]
+            system "bundle exec origen save all -f log/#{options[:log_file]}.txt"
+          else
+            system 'bundle exec origen save all'
+          end
         end
       end
       FileUtils.rm_rf "#{reference_origen_root}/output"
@@ -214,7 +221,7 @@ module Origen
           # Build the new reference workspace now.
           unless File.exist?(@reference_workspace)
             highlight { Origen.log.info 'Building reference workspace...' }
-            ws.build(@reference_workspace)
+            ws.build(@reference_workspace, options)
           end
           ws.set_reference_workspace(@reference_workspace)
         else
@@ -229,7 +236,7 @@ module Origen
         end
         unless File.exist?(@reference_workspace)
           highlight { Origen.log.info 'Building reference workspace...' }
-          ws.build(@reference_workspace)
+          ws.build(@reference_workspace, options)
         end
         ws.set_reference_workspace(@reference_workspace)
       end

--- a/lib/origen/regression_manager.rb
+++ b/lib/origen/regression_manager.rb
@@ -40,7 +40,7 @@ module Origen
         send_email:           false,
         email_all_developers: false,
         report_results:       false,
-        uses_lsf:             true,
+        uses_lsf:             true
       }.merge(options)
       options = load_options if running_in_reference_workspace?
       targets = prepare_targets(options)
@@ -61,7 +61,7 @@ module Origen
               Dir.chdir reference_origen_root do
                 Bundler.with_clean_env do
                   # Origen 0.40.0 started using origen-owned binstubs
-                  system 'rm -rf lbin' if (Gem::Version.new(Origen.version) < Gem::Version.new('0.40.0'))
+                  system 'rm -rf lbin' if Gem::Version.new(Origen.version) < Gem::Version.new('0.40.0')
                   # If regression is run using a service account, we need to setup the path/bundler manually
                   # The regression manager needs to be passed a --service_account option when initiated.
                   if options[:service_account]

--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -345,6 +345,7 @@ module Origen
       end
 
       def initialize_local_dir(options = {})
+        return if options[:build_method] == :clone
         super
         unless initialized?(options)
           Origen.log.debug "Initializing Git workspace at #{local}"

--- a/spec/log_spec.rb
+++ b/spec/log_spec.rb
@@ -118,5 +118,7 @@ describe 'The Origen logger' do
     Origen.log.flush
     File.read(File.join("log", "blah.txt")).should_not include("BLAH")
     File.read(File.join("log", "blah.txt")).should include("Test message 12")
+    Origen.log.reset
+    expect { Origen.log.bond 'Test message 007', verbose: true }.to output(/.*BOND.*Test message 007.*/).to_stdout_from_any_process
   end
 end


### PR DESCRIPTION
- added on on_interface_reset check at the end of reset_interface, since I needed to adjust Origen.interface.flow.subdirectory immediately after the interface was created

- relog can now relog to a custom log, via options[:log_file]

- custom log methods can now output to console if passed verbose: true

- workspace manager can now pass a build_method option, if :clone, then it won't try to init the workspace or make the empty folder

- regression_manager can utilize a custom log

- regression_manager won't delete lbin if Origen is using version 0.40.0 or higher

- fixed typo in submit_origen_job