### PR TITLE
Add absolute value checks to as_units for negative inputs

### DIFF
--- a/lib/origen/core_ext/numeric.rb
+++ b/lib/origen/core_ext/numeric.rb
@@ -54,27 +54,27 @@ class Numeric
   end
 
   def as_units(units)
-    if self.abs >= 1_000_000_000_000_000
+    if abs >= 1_000_000_000_000_000
       "#{self / 1_000_000_000_000_000.0}P#{units}"
-    elsif self.abs >= 1_000_000_000_000
+    elsif abs >= 1_000_000_000_000
       "#{self / 1_000_000_000_000.0}T#{units}"
-    elsif self.abs >= 1_000_000_000
+    elsif abs >= 1_000_000_000
       "#{self / 1_000_000_000.0}G#{units}"
-    elsif self.abs >= 1_000_000
+    elsif abs >= 1_000_000
       "#{self / 1_000_000.0}M#{units}"
-    elsif self.abs >= 1_000
+    elsif abs >= 1_000
       "#{self / 1_000.0}k#{units}"
-    elsif self.abs >= 1
+    elsif abs >= 1
       "#{self}#{units}"
-    elsif self.abs >= 1e-3
+    elsif abs >= 1e-3
       "#{self * 1_000}m#{units}"
-    elsif self.abs >= 1e-6
+    elsif abs >= 1e-6
       "#{self * 1_000_000}u#{units}"
-    elsif self.abs >= 1e-9
+    elsif abs >= 1e-9
       "#{self * 1_000_000_000}n#{units}"
-    elsif self.abs >= 1e-12
+    elsif abs >= 1e-12
       "#{self * 1_000_000_000_000}p#{units}"
-    elsif self.abs >= 1e-15
+    elsif abs >= 1e-15
       "#{self * 1_000_000_000_000_000}a#{units}"
     else
       "%.3e#{units}" % self

--- a/lib/origen/core_ext/numeric.rb
+++ b/lib/origen/core_ext/numeric.rb
@@ -54,27 +54,27 @@ class Numeric
   end
 
   def as_units(units)
-    if self >= 1_000_000_000_000_000
+    if self.abs >= 1_000_000_000_000_000
       "#{self / 1_000_000_000_000_000.0}P#{units}"
-    elsif self >= 1_000_000_000_000
+    elsif self.abs >= 1_000_000_000_000
       "#{self / 1_000_000_000_000.0}T#{units}"
-    elsif self >= 1_000_000_000
+    elsif self.abs >= 1_000_000_000
       "#{self / 1_000_000_000.0}G#{units}"
-    elsif self >= 1_000_000
+    elsif self.abs >= 1_000_000
       "#{self / 1_000_000.0}M#{units}"
-    elsif self >= 1_000
+    elsif self.abs >= 1_000
       "#{self / 1_000.0}k#{units}"
-    elsif self >= 1
+    elsif self.abs >= 1
       "#{self}#{units}"
-    elsif self >= 1e-3
+    elsif self.abs >= 1e-3
       "#{self * 1_000}m#{units}"
-    elsif self >= 1e-6
+    elsif self.abs >= 1e-6
       "#{self * 1_000_000}u#{units}"
-    elsif self >= 1e-9
+    elsif self.abs >= 1e-9
       "#{self * 1_000_000_000}n#{units}"
-    elsif self >= 1e-12
+    elsif self.abs >= 1e-12
       "#{self * 1_000_000_000_000}p#{units}"
-    elsif self >= 1e-15
+    elsif self.abs >= 1e-15
       "#{self * 1_000_000_000_000_000}a#{units}"
     else
       "%.3e#{units}" % self

--- a/spec/numeric_spec.rb
+++ b/spec/numeric_spec.rb
@@ -66,5 +66,6 @@ describe Numeric do
     5.1e-14.as_units("parsec").should == '51.0aparsec'  # About 15.7cm
     6.12e-100.as_units("googol").should == '6.120e-100googol'  # 6.12
     1e20.as_units("hp").should == '100000.0Php'
+    -10.as_units('[mV]') == '-10[mV]'
   end
 end

--- a/spec/numeric_spec.rb
+++ b/spec/numeric_spec.rb
@@ -66,6 +66,6 @@ describe Numeric do
     5.1e-14.as_units("parsec").should == '51.0aparsec'  # About 15.7cm
     6.12e-100.as_units("googol").should == '6.120e-100googol'  # 6.12
     1e20.as_units("hp").should == '100000.0Php'
-    -10.as_units('[mV]') == '-10[mV]'
+    -10.as_units('[mV]').should == '-10[mV]'
   end
 end


### PR DESCRIPTION
This is to handle negative as_units inputs the same as positive inputs. If we do not compare absolute value, we will fall through to the else block for all negatives.

Current:
irb(main):001:0> 10.as_units('[mA]')
=> "10[mA]"
irb(main):002:0> -10.as_units('[mA]')
=> "-1.000e+01[mA]"
irb(main):003:0>

Desired:
irb(main):001:0> 10.as_units('[mA]')
=> "10[mA]"
irb(main):002:0> -10.as_units('[mA]')
=> "-10[mA]"