### PR TITLE
disable lambda style to prevent lint block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.4.7
   - 2.5.6
   - 2.6.4
 before_install:

--- a/config/rubocop/strict_enabled.yml
+++ b/config/rubocop/strict_enabled.yml
@@ -240,7 +240,7 @@ Style/InfiniteLoop:
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#lambda-multi-line'
-  Enabled: true
+  Enabled: false
 
 Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'


### PR DESCRIPTION
With this enabled, there's a scenario where its impossible to get lint to pass, for example in a v93k flow with a multiline proc in the on_fail option:

``` ruby
func :my_test, on_fail: -> do
   # on fail tests
end
```
results in
`Style/Lambda: Use the lambda method for multi-line lambdas.`

So, moving to lambda style:
``` ruby
func :my_test, on_fail: lambda do
   # on fail tests
end
```
throws up a stack trace when I run origen program:
```
COMPLETE CALL STACK
-------------------
tried to create Proc object without a block
```
Found out that to get that to work, I have to use braces {}:
``` ruby
func :my_test, on_fail: lambda {
   # on fail tests
}
```
Which now generates correctly with origen p, but now I'm back to a lint fail:
`Style/BlockDelimiters: Avoid using {...} for multi-line blocks.`