### PR TITLE
rspec 3 formatter support

### DIFF
--- a/spec/format/origen_formatter.rb
+++ b/spec/format/origen_formatter.rb
@@ -1,14 +1,26 @@
 require 'rspec/core/formatters/base_formatter'
 
 class OrigenFormatter < RSpec::Core::Formatters::BaseFormatter
-
-  def dump_summary(duration, example_count, failure_count, pending_count)
-    if failure_count > 0
-      Origen.app.stats.report_fail
-    else
-      Origen.app.stats.report_pass
+  if Gem::Version.new(RSpec::Version::STRING) < Gem::Version.new('3.0.0')
+    # legacy formatter
+    def dump_summary(duration, example_count, failure_count, pending_count)
+      if failure_count > 0
+        Origen.app.stats.report_fail
+      else
+        Origen.app.stats.report_pass
+      end
+      super(duration, example_count, failure_count, pending_count)
     end
-    super(duration, example_count, failure_count, pending_count)
+  else
+    # RSpec 3 API
+    RSpec::Core::Formatters.register self, :dump_summary
+    def dump_summary(summary)
+      puts
+      if summary.failed_examples.size > 0
+        Origen.app.stats.report_fail
+      else
+        Origen.app.stats.report_pass
+      end
+    end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 $VERBOSE=nil  # Don't care about world writable dir warnings and the like
 
 require "origen"
-require "rspec/legacy_formatters"
+require "rspec/legacy_formatters" if Gem::Version.new(RSpec::Version::STRING) < Gem::Version.new('3.0.0')
 require "#{Origen.top}/spec/shared/common_helpers"
 require "#{Origen.top}/spec/format/origen_formatter"
 require "origen_core_support"


### PR DESCRIPTION
When using rspec 3.x, a failing spec test would result in a stack trace rather than rspecs helpful summary output of failures.

Now support for rspec3, while maintaining < rspec 3 versions