### PR TITLE
don't assume how many site configs are found in origen

### DIFF
--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -416,9 +416,10 @@ module Origen
       # Load any centralized site configs now.
       centralized_site_config = find_val('centralized_site_config')
       if centralized_site_config
-        # We know the last two site configs will exists (they are in Origen core) and that they contain the default
-        # values. We want the centralized config to load right after those.
-        @configs.insert(-3, Config.new(path: centralized_site_config, parent: self))
+        # The first site configs found will exist in Origen core, and they contain the default values.
+        # We want the centralized config to load right after those.
+        centralized_index = -@configs.select { |c| c.path.start_with?(Origen.top.to_s) }.size
+        @configs.insert(centralized_index, Config.new(path: centralized_site_config, parent: self))
       end
 
       # After all configs have been populated, see if the centralized needs refreshing

--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -418,7 +418,7 @@ module Origen
       if centralized_site_config
         # The first site configs found will exist in Origen core, and they contain the default values.
         # We want the centralized config to load right after those.
-        centralized_index = -@configs.select { |c| c.path.start_with?(Origen.top.to_s) }.size
+        centralized_index = -(@configs.select { |c| c.path.start_with?(Origen.top.to_s) }.size + 1)
         @configs.insert(centralized_index, Config.new(path: centralized_site_config, parent: self))
       end
 


### PR DESCRIPTION
I tried setting up an ORIGEN_CENTRALIZED_SITE_CONFIG environment variable and ran into some issues.

When I point my app to a clone of the origen repo, I find 2 site configs as origen expects:
```
0: /.../origen/origen_site_config.yml (local)
1: /.../origen/origen_site_config.yml.erb (local)
```

When I just use a gem dependency however, I just find 1:
```
0: /.../.origen/gems/ruby/2.6.0/gems/origen-0.57.2/origen_site_config.yml (local)
```

The issue then is that setting a ORIGEN_CENTRALIZED_SITE_CONFIG variable, origen assumes its going to find 2 site configs, and hardcodes its insertion into the configs array with an index of -3, which then fails out:
```
/.../ruby-2.6.0/lib/ruby/gems/2.6.0/gems/origen-0.55.3/lib/origen/site_config.rb:421:in `insert': index -3 too small for array; minimum: -2 (IndexError)
```

Note, I'm still working out how to validate this properly, our environment makes this particular fix tricky to trial out
