### PR TITLE
fix for when rspec is on latest version 3.9 and you run bundle exec rspec

### DIFF
--- a/spec/format/origen_formatter.rb
+++ b/spec/format/origen_formatter.rb
@@ -1,7 +1,8 @@
 require 'rspec/core/formatters/base_formatter'
 
 class OrigenFormatter < RSpec::Core::Formatters::BaseFormatter
-  if Gem::Version.new(RSpec::Version::STRING) < Gem::Version.new('3.0.0')
+  rspec_version = RSpec.constants.include?(:Version) ? RSpec::Core::Version::STRING : RSpec::Version::STRING
+  if Gem::Version.new(rspec_version) < Gem::Version.new('3.0.0')
     # legacy formatter
     def dump_summary(duration, example_count, failure_count, pending_count)
       if failure_count > 0

--- a/spec/format/origen_formatter.rb
+++ b/spec/format/origen_formatter.rb
@@ -1,7 +1,7 @@
 require 'rspec/core/formatters/base_formatter'
 
 class OrigenFormatter < RSpec::Core::Formatters::BaseFormatter
-  rspec_version = RSpec.constants.include?(:Version) ? RSpec::Core::Version::STRING : RSpec::Version::STRING
+  rspec_version = RSpec.constants.include?(:Version) ? RSpec::Version::STRING : RSpec::Core::Version::STRING 
   if Gem::Version.new(rspec_version) < Gem::Version.new('3.0.0')
     # legacy formatter
     def dump_summary(duration, example_count, failure_count, pending_count)


### PR DESCRIPTION
I ran into this with rspec version 3.9 and I ran `bundle exec rspec spec/myspec.rb`.  It gives this error:

~~~shell
An error occurred while loading ./spec/pin_groups_spec.rb.
Failure/Error: require "#{Origen.top}/spec/format/origen_formatter"

NameError:
  uninitialized constant RSpec::Version
# /users/user/origen_gems/workstation1/.origen/gems/ruby/2.6.0/gems/origen-0.59.1/spec/format/origen_formatter.rb:4:in `<class:OrigenFormatter>'
~~~

