### PR TITLE
Updated pin type to be set automatically unless set by user

### DIFF
--- a/lib/origen/pins/pin.rb
+++ b/lib/origen/pins/pin.rb
@@ -22,8 +22,8 @@ module Origen
       # before falling back to a default
       PACKAGE_SCOPED_ATTRIBUTES = [:location, :dib_assignment, :dib_meta]
 
-      # Pin Types
-      TYPES = [:analog, :digital]
+      # Pin Types, 'digital' and 'analog' are legacy types kept for backwards compatibility
+      TYPES = [:digital, :analog, :signal, :ground, :power, :virtual]
 
       attr_accessor :order
       # Inverts pin states for drive and compare, can be useful if a timing set change requires clocks to drive low for example when all pattern logic has been set up to drive them high.
@@ -90,7 +90,7 @@ module Origen
         @open_drain = options[:open_drain]
         @ext_pullup = options[:ext_pullup]
         @ext_pulldown = options[:ext_pulldown]
-        @type = options[:type]
+        @type = options[:type].nil? ? determine_type : options[:type]
         @dib_assignment = [] # Array to handle multi-site testing
         @size = 1
         @value = 0
@@ -1182,6 +1182,11 @@ module Origen
       end
 
       private
+
+      def determine_type
+        class_type = self.class.to_s.split('::').last.downcase
+        class_type == 'pin' ? :signal : class_type.match(/^(\S+)pin$/)[1].to_sym
+      end
 
       def primary_group=(group)
         @primary_group = group

--- a/lib/origen/pins/pin.rb
+++ b/lib/origen/pins/pin.rb
@@ -1185,7 +1185,13 @@ module Origen
 
       def determine_type
         class_type = self.class.to_s.split('::').last.downcase
-        class_type == 'pin' ? :signal : class_type.match(/^(\S+)pin$/)[1].to_sym
+        if class_type == 'pin'
+          return :signal
+        else
+          pin_type_match = class_type.match(/^(\S+)pin$/)
+          return if pin_type_match.nil?
+          pin_type_match[1].to_sym
+        end
       end
 
       def primary_group=(group)

--- a/spec/pins_spec.rb
+++ b/spec/pins_spec.rb
@@ -14,6 +14,9 @@ class PinsDut1
     add_pin_alias :nvm_invoke, :tdi
     add_pin_alias :nvm_done, :tdo
     @sub_module = PinsSubModule1.new
+    add_ground_pin :vss
+    add_power_pin :vdd
+    add_virtual_pin :vdd_sense
   end
 end
 

--- a/spec/pins_spec.rb
+++ b/spec/pins_spec.rb
@@ -14,9 +14,6 @@ class PinsDut1
     add_pin_alias :nvm_invoke, :tdi
     add_pin_alias :nvm_done, :tdo
     @sub_module = PinsSubModule1.new
-    add_ground_pin :vss
-    add_power_pin :vdd
-    add_virtual_pin :vdd_sense
   end
 end
 

--- a/spec/pins_v3_spec.rb
+++ b/spec/pins_v3_spec.rb
@@ -70,6 +70,7 @@ describe "Origen Pin API v3" do
       $dut.pin[:pinz].direction.should == :io
       $dut.pin[:pinz].rtl_name.should == "pinz"
       $dut.pin[:piny].rtl_name.should == "piny[0]"
+      $dut.pin[:piny].type.should == :signal
     end
 
     it "pins know what packages they are in" do
@@ -745,6 +746,7 @@ describe "Origen Pin API v3" do
       $dut.power_pins(:vdd0).voltage = [1.2,2.5]
       $dut.power_pins(:vdd0).voltage.should == [1.2,2.5]
       $dut.power_pins(:vdd0).voltages.should == [1.2,2.5]
+      $dut.power_pins(:vdd0).type.should == :power
     end
 
     it "power pin data can be set at instantiation time" do
@@ -781,6 +783,8 @@ describe "Origen Pin API v3" do
       $dut.pins.size.should == 2
       $dut.ground_pins.size.should == 1
       $dut.ground_pins(:gnd0).should == gnd0
+      $flag = 1
+      $dut.ground_pins(:gnd0).type.should == :ground
     end
 
     it "ground pin groups can be added" do
@@ -811,11 +815,13 @@ describe "Origen Pin API v3" do
       virtual0 = $dut.add_virtual_pin(:virtual0, type: :virtual_bit)
       $dut.add_virtual_pin(:virtual1, type: :virtual_bit)
       $dut.add_virtual_pin(:virtual2, type: :ate_ch)
+      $dut.add_virtual_pin(:virtual3)
       $dut.pins.size.should == 2
-      $dut.virtual_pins.size.should == 3
+      $dut.virtual_pins.size.should == 4
       $dut.virtual_pins(:virtual0).should == virtual0
       $dut.virtual_pins(:virtual0).type = :virtual_bit
       $dut.virtual_pins(:virtual2).type = :ate_ch
+      $dut.virtual_pins(:virtual3).type.should == :virtual
     end
 
     it "virtual pin groups can be added" do

--- a/spec/pins_v3_spec.rb
+++ b/spec/pins_v3_spec.rb
@@ -783,7 +783,6 @@ describe "Origen Pin API v3" do
       $dut.pins.size.should == 2
       $dut.ground_pins.size.should == 1
       $dut.ground_pins(:gnd0).should == gnd0
-      $flag = 1
       $dut.ground_pins(:gnd0).type.should == :ground
     end
 


### PR DESCRIPTION
The reason for this change is so we can put the pin type in the metadata automatically vs having to set it.  It is backwards compatible.