### PR TITLE
Fixed tester.handshake crash for concurrent pats

### DIFF
--- a/approved/nvm_concurrent_delays_with_sync.avc
+++ b/approved/nvm_concurrent_delays_with_sync.avc
@@ -1,0 +1,109 @@
+# [main] ***************************************************************************
+# [main] GENERATED:
+# [main]   Time:    11-Nov-2020 09:54AM
+#   By:      Stephen McGinty
+# [main]   Mode:    debug
+#   Command: origen g concurrent_delays_with_sync.rb -t origen_sim_dut.rb -e v93k.rb
+# [main] ***************************************************************************
+# [main] ENVIRONMENT:
+# [main]   Application
+# [main]     Source:    git@github.com:Origen-SDK/origen.git
+# [main]     Version:   0.59.3
+# [main]     Branch:    master(5a5e8d2821b) (+local edits)
+# [main]   Origen
+# [main]     Source:    https://github.com/Origen-SDK/origen
+# [main]     Version:   0.59.3
+# [main]   Plugins
+# [main]     origen_app_generators:    2.1.1
+# [main]     origen_core_support:      0.2.3
+# [main]     origen_debuggers:         0.6.1
+# [main]     origen_doc_helpers:       0.8.2
+# [main]     origen_jtag:              0.22.1
+# [main]     origen_sim:               0.20.7
+# [main]     origen_testers:           0.45.4
+# [main] ***************************************************************************
+# Header Comments From Application: origen_core:
+#   This is a dummy pattern created by the Origen test environment
+# [main] ***************************************************************************
+FORMAT TCK TDI TDO TMS RSTN TRSTN dout test_bus din_port P1 P2 p3 p4 V1 V2 DONE NOT_PRESENT ANA;
+#                                                   t t t t r t d                                t                d                                p p p    p    v v d n a
+#                                                   c d d m s r o                                e                i                                1 2 3    4    1 2 o o n
+#                                                   k i o s t s u                                s                n                                                  n t a
+#                                                           n t t                                t                -                                                  e -  
+#                                                             n                                  -                p                                                    p  
+# [main]                                                                                                b                o                                                    r  
+# [main]                                                                                                u                r                                                    e  
+# [main]                                                                                                s                t                                                    s  
+# [main]                                                                                                                                                                      e  
+#                                                                                                                                                                      n  
+# [main]                                                                                                                                                                      t  
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R11 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R10 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R9 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R8 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R7 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R6 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R5 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R4 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R3 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R2 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R1 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R11 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R10 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R9 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R8 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R7 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R6 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R5 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R4 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R3 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R2 ;
+R1                       func                       0 0 X 0 0 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R1 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R11 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R10 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R9 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R8 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R7 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R6 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R5 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R4 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R3 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R2 ;
+R1                       func                       0 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R1 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R11 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R10 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R9 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R8 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R7 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R6 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R5 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R4 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R3 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R2 ;
+R1                       func                       1 0 X 0 1 0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R1 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R11 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R10 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R9 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R8 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R7 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R6 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R5 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R4 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R3 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R2 ;
+R1                       func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # R1 ;
+# [main] Wait for 10.0ms
+R65535                   func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # [main] Wait for 10.0ms;
+R34465                   func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # ;
+# Wait for 10.0ms
+# Wait for 20.0ms
+R65535                   func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # Wait for 10.0msWait for 20.0ms;
+R65535                   func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # ;
+R65535                   func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # ;
+R3395                    func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # ;
+# [main] Wait for 5.0ms
+R50000                   func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # [main] Wait for 5.0ms;
+# ######################################################################
+# ## Pattern complete
+# ######################################################################
+SQPG STOP;

--- a/approved/nvm_concurrent_delays_with_sync_part1.avc
+++ b/approved/nvm_concurrent_delays_with_sync_part1.avc
@@ -1,0 +1,45 @@
+# ***************************************************************************
+# GENERATED:
+#   Time:    11-Nov-2020 09:54AM
+#   By:      Stephen McGinty
+#   Mode:    debug
+#   Command: origen g concurrent_delays_with_sync.rb -t origen_sim_dut.rb -e v93k.rb
+# ***************************************************************************
+# ENVIRONMENT:
+#   Application
+#     Source:    git@github.com:Origen-SDK/origen.git
+#     Version:   0.59.3
+#     Branch:    master(5a5e8d2821b) (+local edits)
+#   Origen
+#     Source:    https://github.com/Origen-SDK/origen
+#     Version:   0.59.3
+#   Plugins
+#     origen_app_generators:    2.1.1
+#     origen_core_support:      0.2.3
+#     origen_debuggers:         0.6.1
+#     origen_doc_helpers:       0.8.2
+#     origen_jtag:              0.22.1
+#     origen_sim:               0.20.7
+#     origen_testers:           0.45.4
+# ***************************************************************************
+# Header Comments From Application: origen_core:
+#   This is a dummy pattern created by the Origen test environment
+# ***************************************************************************
+FORMAT TCK TDI TDO TMS RSTN TRSTN dout test_bus din_port P1 P2 p3 p4 V1 V2 DONE NOT_PRESENT ANA;
+#                                                   t t t t r t d                                t                d                                p p p    p    v v d n a
+#                                                   c d d m s r o                                e                i                                1 2 3    4    1 2 o o n
+#                                                   k i o s t s u                                s                n                                                  n t a
+#                                                           n t t                                t                -                                                  e -  
+#                                                             n                                  -                p                                                    p  
+#                                                                                                b                o                                                    r  
+#                                                                                                u                r                                                    e  
+#                                                                                                s                t                                                    s  
+#                                                                                                                                                                      e  
+#                                                                                                                                                                      n  
+#                                                                                                                                                                      t  
+# [main] Wait for 5.0ms
+R50000                   func                       1 0 X 0 1 1 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXX 00000000000000000000000000000000 X X XXXX XXXX X X X X X # [main] Wait for 5.0ms;
+# ######################################################################
+# ## Pattern complete
+# ######################################################################
+SQPG STOP;

--- a/environment/j750.rb
+++ b/environment/j750.rb
@@ -1,0 +1,1 @@
+OrigenTesters::J750.new

--- a/environment/v93k.rb
+++ b/environment/v93k.rb
@@ -1,0 +1,1 @@
+OrigenTesters::V93K.new

--- a/examples/pattern_generator.rb
+++ b/examples/pattern_generator.rb
@@ -21,9 +21,13 @@ load "origen/commands/generate.rb"
 # Test the --sequence option to create a concurrent pattern
 ARGV = %W(#{Origen.root(:origen_sim)}/pattern/ip1_test.rb
           #{Origen.root(:origen_sim)}/pattern/ip2_test.rb
-          --sequence concurrent -t origen_sim_dut -r approved --plugin origen_sim)
+          --sequence concurrent -t origen_sim_dut -r approved --plugin origen_sim -e j750.rb)
 load "origen/commands/generate.rb"
 
 # Other concurrent pattern tests
-ARGV = %w(concurrent.list -t origen_sim_dut -r approved --plugin none)
+ARGV = %w(concurrent.list -t origen_sim_dut -r approved --plugin none -e j750.rb)
+load "origen/commands/generate.rb"
+
+# Other concurrent pattern tests
+ARGV = %w(concurrent_delays_with_sync.rb -t origen_sim_dut -r approved --plugin none -e v93k.rb)
 load "origen/commands/generate.rb"

--- a/lib/origen/generator/pattern_sequence.rb
+++ b/lib/origen/generator/pattern_sequence.rb
@@ -132,6 +132,13 @@ module Origen
             line_size = 150
           end
           line_size -= 16 if tester.try(:sim?)
+          # This should only occur when $tester.handshake has been called on the V93K or a similar API
+          # which splits a pattern up until multiple outputs.
+          # This is a quick patch to skip rendering an execution profile for pattern parts 1 to n, instead
+          # of crashing.
+          # It should be possible to get an execution profile in these cases if someone were to invest the
+          # time in it to workout why this variable is not set upstream in these cases.
+          return unless @cycle_count_stop
           cycles_per_tick = (@cycle_count_stop / (line_size * 1.0)).ceil
           if tester.try(:sim?)
             execution_time = tester.execution_time_in_ns / 1_000_000_000.0

--- a/pattern/concurrent_delays_with_sync.rb
+++ b/pattern/concurrent_delays_with_sync.rb
@@ -12,4 +12,10 @@ Pattern.sequence do |seq|
   PatSeq.wait_for_threads_to_complete
 
   5.ms!
+
+  if tester.v93k?
+    tester.handshake
+
+    5.ms!
+  end
 end

--- a/target/origen_sim_dut.rb
+++ b/target/origen_sim_dut.rb
@@ -1,3 +1,2 @@
 OrigenSimDev::DUT.new
-OrigenTesters::J750.new
 Origen.mode = :debug


### PR DESCRIPTION
This stops Origen crashing when calling tester.handshake for the V93K in a concurrent pattern scenario.

90% of the diff here is adding a new test case, the fix is just a simple bandaid added to `lib/origen/generator/pattern_sequence.rb`
