### PR TITLE
Origen.top isnt defined during bootup phase in SiteConfig class

### DIFF
--- a/lib/origen/site_config.rb
+++ b/lib/origen/site_config.rb
@@ -418,7 +418,7 @@ module Origen
       if centralized_site_config
         # The first site configs found will exist in Origen core, and they contain the default values.
         # We want the centralized config to load right after those.
-        centralized_index = -(@configs.select { |c| c.path.start_with?(Origen.top.to_s) }.size + 1)
+        centralized_index = -(@configs.select { |c| c.path.start_with?(File.expand_path('../../../')) }.size + 1)
         @configs.insert(centralized_index, Config.new(path: centralized_site_config, parent: self))
       end
 


### PR DESCRIPTION
My previous PR introduced a bug, seems that it hits this code multiple times. My debugger statement was getting hit after some initializations were done, and Origen.top was in scope.

Seems during initial boot up (which in my testing was running a different Origen installation, which I can't modify based off how our company infrastructure is setup, making it difficult to test), it is not:
```
/usr/local/bundle/gems/origen-0.59.4/lib/origen/site_config.rb:421:in `block in configs!': undefined method `top' for Origen:Module (NoMethodError)
```
