### PR TITLE
Fix typo

### DIFF
--- a/lib/origen/generator/pattern_sequence.rb
+++ b/lib/origen/generator/pattern_sequence.rb
@@ -200,7 +200,7 @@ module Origen
         elsif time < 1.s
           "%.#{number_decimal_places}fms" % (time * 1_000)
         else
-          "%.#{number_decimal_places}fs" % tick_time
+          "%.#{number_decimal_places}fs" % time
         end
       end
 


### PR DESCRIPTION
Fixes a typo bug which caused concurrent pattern generation to crash when it was hit