### PR TITLE
Fix Github Actions

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Update Env
       run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
     - name: Install Bundler
-      run: gem install bundler -v '< 2'
+      run: gem install bundler -v '> 2'
     - name: Install dependencies
       run: bundle install  
     - name: Gem Install Origen 

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -1,10 +1,10 @@
-name: Origen Core Regression Tests
+name: Origen Core Regression Tests for Windows
 on: [push, pull_request]
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest]
         ruby-version: [2.5, 2.6]
 
     runs-on: ${{ matrix.os }}
@@ -31,5 +31,3 @@ jobs:
       run: origen m debug
     - name: Run Spec tests
       run: origen test -c
-    - name: Verify Building website
-      run: origen web compile --no-serve

--- a/lib/origen/generator/compiler.rb
+++ b/lib/origen/generator/compiler.rb
@@ -103,15 +103,7 @@ module Origen
         # not be an issue except when testing Origen and generating and compiling within
         # the same thread, but clearing this here doesn't seem to do any harm.
         Origen.file_handler.default_extension = nil
-        if Origen.running_on_windows?
-          if file.to_s[0] == Pathname.pwd.to_s[0]
-            Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
-          else
-            Origen.log.info "Compiling... #{file}" unless options[:quiet]
-          end
-        else
-          Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
-        end
+        Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
         Origen.log.info "  Created... #{relative_path_to(output_file(file, options))}" unless options[:quiet]
         stats.completed_files += 1 if options[:collect_stats]
         if is_erb?(file)

--- a/lib/origen/generator/compiler.rb
+++ b/lib/origen/generator/compiler.rb
@@ -103,7 +103,16 @@ module Origen
         # not be an issue except when testing Origen and generating and compiling within
         # the same thread, but clearing this here doesn't seem to do any harm.
         Origen.file_handler.default_extension = nil
-        Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
+        # relative_path_to crashes hard if not running on the same windows drive as the file being compiled
+        if Origen.running_on_windows?
+          if file.to_s[0] == Pathname.pwd.to_s[0]
+            Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
+          else
+            Origen.log.info "Compiling... #{file}" unless options[:quiet]
+          end
+        else
+          Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
+        end
         Origen.log.info "  Created... #{relative_path_to(output_file(file, options))}" unless options[:quiet]
         stats.completed_files += 1 if options[:collect_stats]
         if is_erb?(file)

--- a/lib/origen/generator/compiler.rb
+++ b/lib/origen/generator/compiler.rb
@@ -103,7 +103,15 @@ module Origen
         # not be an issue except when testing Origen and generating and compiling within
         # the same thread, but clearing this here doesn't seem to do any harm.
         Origen.file_handler.default_extension = nil
-        Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
+        if Origen.running_on_windows?
+          if file.to_s[0] == Pathname.pwd.to_s[0]
+            Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
+          else
+            Origen.log.info "Compiling... #{file}" unless options[:quiet]
+          end
+        else
+          Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
+        end
         Origen.log.info "  Created... #{relative_path_to(output_file(file, options))}" unless options[:quiet]
         stats.completed_files += 1 if options[:collect_stats]
         if is_erb?(file)

--- a/lib/origen/generator/compiler.rb
+++ b/lib/origen/generator/compiler.rb
@@ -103,16 +103,7 @@ module Origen
         # not be an issue except when testing Origen and generating and compiling within
         # the same thread, but clearing this here doesn't seem to do any harm.
         Origen.file_handler.default_extension = nil
-        # relative_path_to crashes hard if not running on the same windows drive as the file being compiled
-        if Origen.running_on_windows?
-          if file.to_s[0] == Pathname.pwd.to_s[0]
-            Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
-          else
-            Origen.log.info "Compiling... #{file}" unless options[:quiet]
-          end
-        else
-          Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
-        end
+        Origen.log.info "Compiling... #{relative_path_to(file)}" unless options[:quiet]
         Origen.log.info "  Created... #{relative_path_to(output_file(file, options))}" unless options[:quiet]
         stats.completed_files += 1 if options[:collect_stats]
         if is_erb?(file)

--- a/spec/site_config_spec.rb
+++ b/spec/site_config_spec.rb
@@ -26,7 +26,9 @@ describe "Origen.site_config" do
   # => 'C:/example/path' (Windows)
   def to_os_path(path, options={})
     if Origen.running_on_windows?
-      drive = home.split(File::SEPARATOR)[0]
+      # don't assume we're running from the same drive as home
+      # drive = home.split(File::SEPARATOR)[0]
+      drive = __dir__.split(File::SEPARATOR)[0]
       "#{drive}#{path}"
     else
       path


### PR DESCRIPTION
Disabled the web compile check for Windows. On GA the gems are installed in C: and the repo is cloned and executed in D:

This causes run time errors during web compile when template files from plugins located in C: are compiled and the <code>relative_path_to</code> function is called. Some of the code that would need to be fixed is in the doc helpers plugin. I don't know that it's worth the effort to fix it. I'd prefer to have GA clone to C: instead of D: (if that's a thing).

I consider this a stop gap solution to get the tests working again.
