### PR TITLE
support for remote block inheritance and overriding existing blocks

### DIFF
--- a/config/commands.rb
+++ b/config/commands.rb
@@ -17,7 +17,7 @@ when "tags"
 when "specs"
   Origen.app.session.origen_core[:mode] = 'debug'
   require "rspec"
-  exit RSpec::Core::Runner.run(['spec'])
+  exit RSpec::Core::Runner.run($ARGV.empty? ? ['spec'] : $ARGV)
 
 when "examples", "test"  
   Origen.app.session.origen_core[:mode] = 'debug'

--- a/lib/origen/loader.rb
+++ b/lib/origen/loader.rb
@@ -116,62 +116,75 @@ module Origen
 
     # If a block definition exists for the given model, then this will load it and apply it to
     # the model.
+    # if options[:inherit] is passed, it will first try to load the files for the class name contained
+    # in that option, even if its from a plugin app
     # Returns true if a model is found and loaded, otherwise nil.
     def self.load_block(model, options = {})
       model = model.model  # Ensure we have a handle on the model and not its controller
       loaded = nil
-      if app = options[:app] || model.app
+      if local_app = options[:app] || model.app
         if options[:path]
-          full_paths = Array(options[:path])
+          local_full_paths = Array(options[:path])
         else
-          full_paths = model.class.to_s.split('::')
-          full_paths.shift  # Throw away the app namespace
-          full_paths = [full_paths.join('/')]
+          local_full_paths = model.class.to_s.split('::')
+          local_full_paths.shift  # Throw away the app namespace
+          local_full_paths = [local_full_paths.join('/')]
         end
-        full_paths.each do |full_path|
-          paths = full_path.to_s.split('/')
-          key = ''
-          only = Array(options[:only]) if options[:only]
-          except = Array(options[:except]) if options[:except]
-          path = paths.map(&:underscore).join('/')
-          # If the path refers to a nested sub-block then don't load the full hierarchy since they
-          # don't support inheritance or derivatives, modify the paths array so that only the sub-block
-          # level will be loaded and nothing else.
-          paths = [path] if app.blocks_files[path] && app.blocks_files[path][:_sub_block]
-          # These will be loaded first, followed by the rest in an undefined order.
-          # Attributes and parameters are first so that they may be referenced in the other files.
-          # Sub-blocks was added early due to a corner case issue that could be encountered if the pins or
-          # regs imported an Origen exported file that defined a module with the same name as a sub-block
-          # class, in that case the sub-block class would not be auto-loaded.
-          load_first = [:attributes, :parameters, :sub_blocks]
+        app_paths_map = { local_app => local_full_paths }
+        if options[:inherit]
+          inherit_full_paths = options[:inherit].split('::')
+          inherit_app = Origen.app(inherit_full_paths.shift.underscore.to_sym)
+          inherit_full_paths = [inherit_full_paths.join('/')]
+          # merge to get inherit ordered in the beginning
+          app_paths_map = { inherit_app => inherit_full_paths }.merge(app_paths_map)
+        end
+        # load the inherit files, then the current app's block files
+        app_paths_map.each do |app, full_paths|
+          full_paths.each do |full_path|
+            paths = full_path.to_s.split('/')
+            key = ''
+            only = Array(options[:only]) if options[:only]
+            except = Array(options[:except]) if options[:except]
+            path = paths.map(&:underscore).join('/')
+            # If the path refers to a nested sub-block then don't load the full hierarchy since they
+            # don't support inheritance or derivatives, modify the paths array so that only the sub-block
+            # level will be loaded and nothing else.
+            paths = [path] if app.blocks_files[path] && app.blocks_files[path][:_sub_block]
+            # These will be loaded first, followed by the rest in an undefined order.
+            # Attributes and parameters are first so that they may be referenced in the other files.
+            # Sub-blocks was added early due to a corner case issue that could be encountered if the pins or
+            # regs imported an Origen exported file that defined a module with the same name as a sub-block
+            # class, in that case the sub-block class would not be auto-loaded.
+            load_first = [:attributes, :parameters, :sub_blocks]
 
-          load_first.each do |type|
-            unless (only && !only.include?(type)) || (except && except.include?(type))
-              with_parameters_transaction(type) do
-                paths.each_with_index do |path, i|
-                  key = i == 0 ? path.underscore : "#{key}/#{path.underscore}"
-                  if app.blocks_files[key] && app.blocks_files[key][type]
-                    app.blocks_files[key][type].each do |f|
-                      if type == :attributes
-                        success = load_attributes(f, model)
-                      else
-                        success = load_block_file(f, model)
+            load_first.each do |type|
+              unless (only && !only.include?(type)) || (except && except.include?(type))
+                with_parameters_transaction(type) do
+                  paths.each_with_index do |path, i|
+                    key = i == 0 ? path.underscore : "#{key}/#{path.underscore}"
+                    if app.blocks_files[key] && app.blocks_files[key][type]
+                      app.blocks_files[key][type].each do |f|
+                        if type == :attributes
+                          success = load_attributes(f, model)
+                        else
+                          success = load_block_file(f, model)
+                        end
+                        loaded ||= success
                       end
-                      loaded ||= success
                     end
                   end
                 end
               end
             end
-          end
 
-          # Now load the rest
-          paths.each_with_index do |path, i|
-            key = i == 0 ? path.underscore : "#{key}/#{path.underscore}"
-            if app.blocks_files[key]
-              app.blocks_files[key].each do |type, files|
-                unless type == :_sub_block || load_first.include?(type) || (only && !only.include?(type)) || (except && except.include?(type))
-                  files.each { |f| success = load_block_file(f, model); loaded ||= success }
+            # Now load the rest
+            paths.each_with_index do |path, i|
+              key = i == 0 ? path.underscore : "#{key}/#{path.underscore}"
+              if app.blocks_files[key]
+                app.blocks_files[key].each do |type, files|
+                  unless type == :_sub_block || load_first.include?(type) || (only && !only.include?(type)) || (except && except.include?(type))
+                    files.each { |f| success = load_block_file(f, model); loaded ||= success }
+                  end
                 end
               end
             end

--- a/lib/origen/model_initializer.rb
+++ b/lib/origen/model_initializer.rb
@@ -48,7 +48,7 @@ module Origen
         end
         if x.respond_to?(:is_an_origen_model?)
           x.send(:_initialized)
-          Origen::Loader.load_block(x)
+          Origen::Loader.load_block(x, options)
         end
         if x.respond_to?(:register_callback_listener)
           Origen.after_app_loaded do |app|

--- a/lib/origen/sub_blocks.rb
+++ b/lib/origen/sub_blocks.rb
@@ -321,17 +321,24 @@ module Origen
         # attributes to an existing one
         if options[:override]
           sub_blocks.delete(name)
-          # this is to handle the case where a previously instantiated subblock wont allow
-          # the current class name to exist
-          # e.g. NamespaceA:B:C
-          # =>  NameSpaceX:Y:Z
-          # After requiring the files, constants become sane again:
-          # e.g. NamespaceA:B:C
-          # =>  NameSpaceA:B:C
-          if options[:class_name] != options[:class_name].constantize.to_s
-            block_dir = options[:block_file] || _find_block_dir(options)
-            Dir.glob("#{block_dir}/*.rb").each do |file|
-              require file
+          if options[:class_name]
+            begin
+              constantizable = !!options[:class_name].constantize
+            rescue NameError
+              constantizable = false
+            end
+            # this is to handle the case where a previously instantiated subblock wont allow
+            # the current class name to exist
+            # e.g. NamespaceA::B::C
+            # =>  NameSpaceX::Y::Z
+            # After requiring the files, constants become sane again:
+            # e.g. NamespaceA::B::C
+            # =>  NameSpaceA::B::C
+            if constantizable && (options[:class_name] != options[:class_name].constantize.to_s)
+              block_dir = options[:block_file] || _find_block_dir(options)
+              Dir.glob("#{block_dir}/*.rb").each do |file|
+                require file
+              end
             end
           end
         else

--- a/spec/sub_block_spec.rb
+++ b/spec/sub_block_spec.rb
@@ -5,17 +5,35 @@ module SubBlocksSpec
   class Top
     include Origen::Model
 
-    def initialize
+    def initialize(options = {})
       @path = "ftf2"
       domain :ips
       domain :ahb, endian: :little
 
-      sub_block :sub1, class_name: "Sub1", base_address: 0x1000_0000, path: "ci.ci_regs"
-      sub_block :sub3, base_address: 0x3000_0000, path: "blah", domain: :ahb, some_attr: "hello"
-      sub_block :sub4
-      sub_block :sub5, class_name: "Sub3", abs_path: "ftf3.blah"
-      sub_block :sub6, class_name: "Sub3"
-      sub_block :sub7, class_name: "Sub2", path: :hidden, base_address: 0x7000_0000
+      if options[:override]
+        sub_block :sub1, class_name: "Sub2", base_address: 0x1001_0000, path: "blah"
+        # Need to remove the definition of Sub1Controller class to reset state to be a real usecase
+        # Without this, the placeholder block sub1.class returns Sub1Controller instead of Sub1 (failing one of the specs)
+        # This isn't a consequence of the new inherit/override functionality, this just occurs if you try to loop over
+        # the specs again once they've been instantiated and lazy == false (immediate instantiation twice, first instantiation
+        # brings Controller class in scope)
+        # You can confirm this by setting the override setting loop to [false] and the lazy setting loop to [false, false]
+        # (aka, remove the new functionality from the equation)
+        # Additionally, setting the override_setting to [true] and commenting out the below line will also pass specs
+        Object.const_get(:SubBlocksSpec).send(:remove_const, :Sub1Controller) if Object.const_get(:SubBlocksSpec).const_defined?(:Sub1Controller)
+        sub_block :sub3, base_address: 0x3003_3000, path: "path.ci.regs", domain: :ips, some_attr: "goodbye"
+        sub_block :sub4
+        sub_block :sub5, class_name: "Sub2", abs_path: "ftf3.blahblah"
+        sub_block :sub6, class_name: "Sub2"
+        sub_block :sub7, class_name: "Sub1", path: :shown, base_address: 0x7000_0007
+      end
+
+      sub_block :sub1, class_name: "Sub1", base_address: 0x1000_0000, path: "ci.ci_regs", override: options[:override]
+      sub_block :sub3, base_address: 0x3000_0000, path: "blah", domain: :ahb, some_attr: "hello", override: options[:override]
+      sub_block :sub4, override: options[:override]
+      sub_block :sub5, class_name: "Sub3", abs_path: "ftf3.blah", override: options[:override]
+      sub_block :sub6, class_name: "Sub3", override: options[:override]
+      sub_block :sub7, class_name: "Sub2", path: :hidden, base_address: 0x7000_0000, override: options[:override]
 
       sub_block_group :subgroups, class_name: "SubBlocksSpec::Subs" do
         sub_block :subitem0, class_name: "SubItem0", base_address: 0x000, some_attr: "There are two kinds of people"
@@ -108,474 +126,519 @@ module SubBlocksSpec
     end
   end
 
-  # Run all of these specs twice, once with immediately instantiating sub-blocks and once with lazy instantiation
-  [false, true].each do |lazy_setting|
+  # Run all of these specs twice, once with default behavior, once with overriding existing sub blocks
+  [false, true].each do |override_setting|
 
-    describe "Register base addressing and hierarchy with #{lazy_setting ? 'LAZY' : 'IMMEDIATE'} instantiation" do
+    # Run all of these specs twice, once with immediately instantiating sub-blocks and once with lazy instantiation
+    [false, true].each do |lazy_setting|
 
-      before :all do
-        Origen::SubBlocks.lazy = lazy_setting
-      end
+      describe "Register base addressing and hierarchy with #{lazy_setting ? 'LAZY' : 'IMMEDIATE'} instantiation and override behavior #{override_setting ? 'ON' : 'OFF'}" do
 
-      it "sub-block placeholders should look like the underlying sub-block to users" do
-        c = Top.new
-        c.sub1.is_a?(Origen::SubBlocks::Placeholder).should == lazy_setting
-        c.sub1.is_a?(Sub1).should == true
-        c.sub1.class.should == Sub1
-        c.sub1.is_a?(Origen::SubBlocks::Placeholder).should == lazy_setting
-        c.sub1.reg1
-        c.sub1.is_a?(Origen::SubBlocks::Placeholder).should == false
-        c.sub1.is_a?(Sub1).should == true
-      end
-
-      it "sub-block placeholders should pass equality comparison with their materialized self (and vice versa)" do
-        c = Top.new
-        placeholder = c.sub1
-        c.sub1.reg1
-        materialized = c.sub1
-        placeholder.is_a?(Origen::SubBlocks::Placeholder).should == lazy_setting
-        materialized.is_a?(Origen::SubBlocks::Placeholder).should == false
-        (placeholder == materialized).should == true
-        result = (materialized == placeholder)
-        result.should == true
-        
-      end
-
-      it "owner and parent methods work" do
-        c = Top.new
-        b = c.sub1
-        b.owner.should == c
-        b.parent.should == c
-      end
-
-      it "multiple instances can be declared" do
-        class Top2
-          include Origen::Model
-          def initialize
-            sub_block  :vreg, class_name: "Sub1", base_address: 0x1000_0000
-            sub_blocks :atd, instances: 2, class_name: "Sub1", base_address: 0x2000_0000
-            sub_blocks :osc, instances: 2, class_name: "Sub1", base_address: 0x3000_0000, base_address_step: 0x1000
-            sub_blocks :pmc, instances: 2, class_name: "Sub1", base_address: [0x4000_0000, 0x4001_0000]
-          end
-        end
-
-        c = Top2.new
-        c.vreg.base_address.should == 0x1000_0000
-        c.atd0.base_address.should == 0x2000_0000
-        c.atd1.base_address.should == 0x2000_0000
-        c.atd0.reg1.write(0x55)
-        c.atd0.reg1.data.should == 0x55
-        c.atd1.reg1.data.should == 0x00
-        c.atd1.reg1.write(0xAA)
-        c.atd0.reg1.data.should == 0x55
-        c.atd1.reg1.data.should == 0xAA
-        c.atds.size.should == 2
-        c.osc0.base_address.should == 0x3000_0000
-        c.osc1.base_address.should == 0x3000_1000
-        c.pmc0.base_address.should == 0x4000_0000
-        c.pmc1.base_address.should == 0x4001_0000
-      end
-
-      it "base address attribute can be set when instantiating a register owner" do
-        c = Top.new
-        c.respond_to?(:sub1).should == true
-        c.sub1.reg_base_address.should == 0x1000_0000
-        c.sub1.base_address.should == 0x1000_0000
-      end
-
-      it "can properly route get pass/fail for has_reg? method" do
-        c = Top.new
-        c.sub1.has_reg?(:reg1).should == true
-        c.sub1.has_reg?(:reg1000).should == false # This previously returned an Exception
-      end
-
-      it "base addresses get applied to registers" do
-        c = Top.new
-        c.sub1.reg(:reg1).address(relative: true).should == 0x100
-        c.sub1.reg(:reg1).offset.should == 0x100
-        c.sub1.reg(:reg1).address.should == 0x1000_0100
-      end
-
-      it "base addresses can be built in stages" do
-        Top.new.sub2.sub3.reg(:reg1).address.should == 0x2001_0100
-      end
-
-      it "children should know their parents" do
-        c = Top.new
-        c.sub1.parent.should == c
-        c.sub2.sub3.parent.should == c.children[:sub2]
-        c.sub2.sub3.parent.parent.should == c
-      end
-
-      it "(hdl) paths can be constructed" do
-        c = Top.new
-        c.path.should == "ftf2"
-        c.sub1.path.should == "ftf2.ci.ci_regs"
-        c.sub1.path(relative_to: c).should == "ci.ci_regs"
-        c.sub2.path.should == "ftf2.sub2"
-        c.sub2.sub3.path.should == "ftf2.sub2.sub3"
-        c.sub7.sub3.path.should == "ftf2.sub3"
-        c.sub2.sub3.reg(:reg1).path.should == "ftf2.sub2.sub3.reg1"
-        c.sub2.sub3.reg(:reg1).path(relative_to: c).should == "sub2.sub3.reg1"
-        c.sub7.sub3.reg(:reg1).path.should == "ftf2.sub3.reg1"
-        c.sub7.sub3.reg(:reg1).path(relative_to: c).should == "sub3.reg1"
-        c.sub1.reg(:reg1).path.should == "ftf2.ci.ci_regs.reg1"
-        c.sub1.reg(:reg1).path(relative_to: c).should == "ci.ci_regs.reg1"
-        c.sub1.reg(:reg1).path(relative_to: c.sub1).should == "reg1"
-        c.sub1.reg(:reg1).bits(:data).path.should == "ftf2.ci.ci_regs.reg1[31:0]"
-        c.sub1.reg(:reg1).bits(:data).path(relative_to: c).should == "ci.ci_regs.reg1[31:0]"
-        c.sub1.reg(:reg1).bits(:data).path(relative_to: c.sub1.reg(:reg1)).should == "[31:0]"
-      end
-
-      it "full paths can be set" do
-        c = Top.new
-        c.sub1.reg(:reg1).path.should == "ftf2.ci.ci_regs.reg1"
-        c.sub1.reg(:reg1).full_path = "blah.blah"
-        c.sub1.reg(:reg1).path.should == "blah.blah"
-      end
-
-      it "absolute paths can be set on objects in the tree and this will stop further look up" do
-        c = Top.new
-        c.sub5.path.should == "ftf3.blah"
-        c.sub5.reg(:reg1).path.should == "ftf3.blah.reg1_reg"
-        c.sub5.reg(:reg1).path.should == "ftf3.blah.reg1_reg"
-        c.sub5.reg(:reg1).hdl_path.should == "ftf3.blah.reg1_reg"
-        c.sub6.path.should == "ftf2.sub6"
-        c.sub6.reg(:reg1).path.should == "ftf2.sub6.reg1_reg"
-
-        b = c.sub5.reg(:reg1).bits(:d6)
-        b.path.should == "blah.d6_reg"
-        c.sub5.reg(:reg1).bits(:d7).path.should == "ftf3.blah.reg1_reg[11:10]"
-        c.sub5.reg(:reg1).bits(:d5).path.should == "ftf3.blah.d5_reg"
-        c.sub5.reg(:reg1).bits(:d4).path.should == "ftf3.blah.reg1_reg.d4_reg"
-        c.sub5.reg(:reg1).bits(:d3).path.should == "ftf3.blah.reg1_reg[3]"
-        c.sub5.reg(:reg1).bits(:d2).path.should == "blah.d2_reg"
-        c.sub5.reg(:reg1).bits(:d1).path.should == "ftf3.blah.d1_reg"
-        c.sub5.reg(:reg1).bits(:d0).path.should == "ftf3.blah.reg1_reg.d0"
-      end
-
-      it "default sub blocks will be generated when no class name is specified" do
-        c = Top.new
-        c.sub3.add_reg :reg1, 0x30, 32, data: { pos: 0, bits: 32 }
-        c.sub3.reg(:reg1).address.should == 0x3000_0030
-        c.sub3.reg(:reg1).path.should == "ftf2.blah.reg1"
-        c.sub4.path.should == "ftf2.sub4"
-        c.sub4.base_address.should == 0
-      end
-
-      it "default sub blocks can have attributes defined on the fly" do
-        c = Top.new
-        c.sub3.blah = 10
-        c.sub3.blah.should == 10
-      end
-
-      it "the block form of adding registers works" do
-        c = Top.new
-        c.sub3.reg :reg1, 0x30 do |o|
-          o.bits 31..0, :data, reset: 0xFFFF_FFFF
-        end
-        c.sub3.reg(:reg1).data.should == 0xFFFF_FFFF
-      end
-
-      it "additional options are passed to the class if specified" do
-        Top.new.sub2.some_attr.should == "hello"
-      end
-
-      it "additional options are added as attributes to anonymous sub blocks" do
-        Top.new.sub3.some_attr.should == "hello"
-      end
-
-      describe "register domains" do
-        it "should be empty by default" do
-          Sub2.new.sub3.reg(:reg1).domains.empty?.should == true
-        end
-
-        it "if not specified the register should inherit all domains from the parent" do
-          c = Top.new
-          c.sub1.reg(:reg1).domains.should == c.domains
-        end
-
-        it "if specified then only that subset of domains should be returned" do
-          c = Top.new
-          c.sub3.domains.should == {ahb: c.domains[:ahb]}.with_indifferent_access
-          c.sub3.add_reg :reg1, 0x30, 32, data: { pos: 0, bits: 32 }
-          c.sub3.reg(:reg1).domains.should == {ahb: c.domains[:ahb]}.with_indifferent_access
-        end
-
-        it "base addresses can be applied per domain" do
-          class BATop
-            include Origen::TopLevel
-
-            def initialize
-              domain :ips
-              domain :ahb
-
-              sub_block :sub1, class_name: "BASub1", base_address: 0x1000_0000
-              sub_block :sub2, class_name: "BASub1", base_address: { ips: 0x2000_0000, ahb: 0x3000_0000 }
-            end
-          end
-
-          class BASub1
-            include Origen::Model
-
-            def initialize
-              reg :reg1, 0x200 do
-                bits 31..0, :data
-              end
-              sub_block :sub1, class_name: "BASub2", domain: :ips
-              sub_block :sub2, class_name: "BASub2", domain: :ahb
-            end
-          end
-
-          class BASub2
-            include Origen::Model
-
-            def initialize
-              reg :reg1, 0x200 do
-                bits 31..0, :data
-              end
-              sub_block :sub1, class_name: "BASub3", base_address: 0x100_0000
-            end
-          end
-
-          class BASub3
-            include Origen::Model
-
-            def initialize
-              reg :reg1, 0x200 do
-                bits 31..0, :data
-              end
-            end
-          end
-
-          Origen.app.unload_target!
-
-          BATop.new
-
-          # Test that domains inherit properly
-          $dut.domains.should == {ahb: $dut.domains[:ahb], ips: $dut.domains[:ips]}.with_indifferent_access
-          $dut.sub1.domains.should == {ahb: $dut.domains[:ahb], ips: $dut.domains[:ips]}.with_indifferent_access
-          $dut.sub2.domains.should == {ahb: $dut.domains[:ahb], ips: $dut.domains[:ips]}.with_indifferent_access
-          $dut.sub1.sub1.domains.should == {ips: $dut.domains[:ips]}.with_indifferent_access
-          $dut.sub1.sub2.domains.should == {ahb: $dut.domains[:ahb]}.with_indifferent_access
-          $dut.sub1.sub1.reg1.domains.should == {ips: $dut.domains[:ips]}.with_indifferent_access
-          $dut.sub1.sub2.reg1.domains.should == {ahb: $dut.domains[:ahb]}.with_indifferent_access
-
-          $dut.sub1.sub1.reg1.address.should == 0x1000_0200
-          $dut.sub1.sub2.reg1.address.should == 0x1000_0200
-          $dut.sub1.sub1.sub1.reg1.address.should == 0x1100_0200
-          $dut.sub1.sub2.sub1.reg1.address.should == 0x1100_0200
-          $dut.sub2.sub1.reg1.address.should == 0x2000_0200
-          $dut.sub2.sub2.reg1.address.should == 0x3000_0200
-          $dut.sub2.sub1.sub1.reg1.address.should == 0x2100_0200
-          $dut.sub2.sub2.sub1.reg1.address.should == 0x3100_0200
-          $dut.sub1.reg1.address(domain: :ips).should == 0x1000_0200
-          $dut.sub1.reg1.address(domain: :ahb).should == 0x1000_0200
-          $dut.sub2.reg1.address(domain: :ips).should == 0x2000_0200
-          # Address is cached here, causing fail...
-          $dut.sub2.reg1.address(domain: :ahb).should == 0x3000_0200
-        end
-
-        it "bit index is output correctly when a parent register's path is hidden" do
-          class BITop
-            include Origen::TopLevel
-
-            def initialize
-              @path = :hidden
-              sub_block :sub1, class_name: "BISub"
-            end
-          end
-
-          class BISub
-            include Origen::Model
-
-            def initialize
-              reg :dr, 0, path: :hidden do |reg|
-                bits 31..0, :data
-              end
-            end
-          end
-
-          Origen.app.unload_target!
-
-          BITop.new
-
-          $dut.sub1.dr[0].path.should == "sub1[0]"
-          $dut.sub1.dr[7..0].path.should == "sub1[7:0]"
-        end
-
-        it 'options passed to sub_block definitions are applied when the class is named' do
-          class Top1
-            include Origen::TopLevel
-
-            def initialize
-              sub_block :sub1, class_name: "Sub1", x: 5, y: 10
-            end
-          end
-
-          class Sub1
-            include Origen::Model
-            attr_accessor :x
-            attr_reader :y
-          end
-
-          Origen.app.unload_target!
-
-          Top1.new
-
-          $dut.sub1.x.should == 5
-          $dut.sub1.y.should == 10
-        end
-
-        it 'on_create callbacks in sub_block models get called' do
-          class TopLevel
-            include Origen::TopLevel
-
-            def initialize
-              sub_block :sub1, class_name: "Sub1"
-            end
-          end
-
-          class Sub1
-            include Origen::Model
-            attr_reader :on_create_called
-
-            def on_create
-              @on_create_called ||= 0
-              @on_create_called += 1
-            end
-          end
-
-          class Sub1Controller
-            include Origen::Controller
-            attr_reader :controller_on_create_called
-
-            def wrapped?
-              true
-            end
-
-            def on_create
-              @controller_on_create_called ||= 0
-              @controller_on_create_called += 1
-            end
-          end
-
-          Origen.app.unload_target!
-          Origen.target.temporary = -> { TopLevel.new }
-          Origen.load_target
-
-          dut.sub1.on_create_called.should == 1
-          dut.sub1.wrapped?.should == true
-          dut.sub1.controller_on_create_called.should == 1
-        end
-      end
-
-      describe "block loading" do
-        it "can be done from within the sub-block class's initialize method" do
-          Origen.app.unload_target!
-          OrigenCoreSupport::MySOC.new
-          dut.my_sub_block_1.params.param1.should == 100
-          dut.my_sub_block_1.params.param2.should == 20
-          dut.my_sub_block_1.params.param3.should == 300
-        end
-
-        it "can be done via a load_block argument passed to sub_block" do
-          Origen.app.unload_target!
-          OrigenCoreSupport::MySOC.new
-          dut.my_sub_block_2.params.param1.should == 10
-          dut.my_sub_block_2.params.param2.should == 200
-          dut.my_sub_block_2.params.param3.should == 300
-        end
-      end
-
-      describe "sub block groups" do
         before :all do
+          Origen::SubBlocks.lazy = lazy_setting
         end
 
-        it "subgroups container and sub-items exist as expected" do
-          c = Top.new
-          c.subgroups.is_a?(SubBlocksSpec::Subs).should == true
-          c.subgroups.count.should == 3
-          c.subgroups[0].is_a?(SubItem0).should == true
-          c.subgroups[1].is_a?(SubItem1).should == true
-          c.subgroups[2].is_a?(SubItem2).should == true
+        it "sub-block placeholders should look like the underlying sub-block to users" do
+          c = Top.new(override: override_setting)
+          c.sub1.is_a?(Origen::SubBlocks::Placeholder).should == lazy_setting
+          c.sub1.is_a?(Sub1).should == true
+          c.sub1.class.should == Sub1
+          c.sub1.is_a?(Origen::SubBlocks::Placeholder).should == lazy_setting
+          c.sub1.reg1
+          c.sub1.is_a?(Origen::SubBlocks::Placeholder).should == false
+          c.sub1.is_a?(Sub1).should == true
         end
 
-        it "sub_block_groups hash acts as expected" do
-          c = Top.new
+        it "sub-block placeholders should pass equality comparison with their materialized self (and vice versa)" do
+          c = Top.new(override: override_setting)
+          placeholder = c.sub1
+          c.sub1.reg1
+          materialized = c.sub1
+          placeholder.is_a?(Origen::SubBlocks::Placeholder).should == lazy_setting
+          materialized.is_a?(Origen::SubBlocks::Placeholder).should == false
+          (placeholder == materialized).should == true
+          result = (materialized == placeholder)
+          result.should == true
 
-          # check that cannot handle arguments, only
-          # block or no arguments
-          expect {
-            c.sub_block_groups(:check_args)
-          }.to raise_exception(RuntimeError)
-
-          c.sub_block_groups.count.should == 1
-          c.sub_block_groups.keys[0].should == "subgroups"
-          c.sub_block_groups["subgroups"].is_a?(SubBlocksSpec::Subs) == true
-          c.sub_block_groups["subgroups"].count.should == 3
-          c.sub_block_groups["subgroups"][0].is_a?(SubItem0).should == true
-          c.sub_block_groups["subgroups"][1].is_a?(SubItem1).should == true
-          c.sub_block_groups["subgroups"][2].is_a?(SubItem2).should == true
         end
 
-        it "subitems exist standalone from container" do 
-          c = Top.new
-          c.subitem0.is_a?(SubItem0).should == true
-          c.subitem1.is_a?(SubItem1).should == true
-          c.subitem2.is_a?(SubItem2).should == true
+        it "owner and parent methods work" do
+          c = Top.new(override: override_setting)
+          b = c.sub1
+          b.owner.should == c
+          b.parent.should == c
         end
 
-        it "subitems have correct attributes and regs" do
-          c = Top.new
-          c.subgroups[0].base_address.should == 0x000
-          c.subgroups[1].base_address.should == 0x200
-          c.subgroups[2].base_address.should == 0x400
-          c.subgroups[0].some_attr.should == "There are two kinds of people"
-          c.subgroups[1].some_attr.should == "in the world.  Those who can "
-          c.subgroups[2].some_attr.should == "extrapolate from incomplete data"
-        end
-
-        it "subitem registers are writeable and no naming conflicts" do
-          c = Top.new
-          c.subgroups[0].reg1
-          c.subgroups[1].reg1
-          c.subgroups[2].reg1
-          c.subgroups[0].reg1.write(0x55)
-          c.subgroups[0].reg1.data.should == 0x55
-          c.subgroups[1].reg1.data.should == 0x00
-          c.subgroups[2].reg1.data.should == 0x00
-          c.subgroups[1].reg1.write(0xAA)
-          c.subgroups[0].reg1.data.should == 0x55
-          c.subgroups[1].reg1.data.should == 0xAA
-          c.subgroups[2].reg1.data.should == 0x00
-          c.subgroups[2].reg1.write(0xBB)
-          c.subgroups[0].reg1.data.should == 0x55
-          c.subgroups[1].reg1.data.should == 0xAA
-          c.subgroups[2].reg1.data.should == 0xBB
-        end
-
-        it "default to Array if no container class provided" do
+        it "multiple instances can be declared" do
           class Top2
             include Origen::Model
             def initialize
-              sub_block_group :subgroups do
-                sub_block :subitem0, class_name: "SubItem0", base_address: 0x000, some_attr: "never"
-                sub_block :subitem1, class_name: "SubItem1", base_address: 0x200, some_attr: "forget"
-                sub_block :subitem2, class_name: "SubItem2", base_address: 0x400, some_attr: "the"
-              end
+              sub_block  :vreg, class_name: "Sub1", base_address: 0x1000_0000
+              sub_blocks :atd, instances: 2, class_name: "Sub1", base_address: 0x2000_0000
+              sub_blocks :osc, instances: 2, class_name: "Sub1", base_address: 0x3000_0000, base_address_step: 0x1000
+              sub_blocks :pmc, instances: 2, class_name: "Sub1", base_address: [0x4000_0000, 0x4001_0000]
             end
           end
-          d = Top2.new
-          d.subgroups.is_a?(Array).should == true
-          d.subgroups.count.should == 3
-          d.subgroups[0].is_a?(SubItem0).should == true
-          d.subgroups[1].is_a?(SubItem1).should == true
-          d.subgroups[2].is_a?(SubItem2).should == true
+
+          c = Top2.new
+          c.vreg.base_address.should == 0x1000_0000
+          c.atd0.base_address.should == 0x2000_0000
+          c.atd1.base_address.should == 0x2000_0000
+          c.atd0.reg1.write(0x55)
+          c.atd0.reg1.data.should == 0x55
+          c.atd1.reg1.data.should == 0x00
+          c.atd1.reg1.write(0xAA)
+          c.atd0.reg1.data.should == 0x55
+          c.atd1.reg1.data.should == 0xAA
+          c.atds.size.should == 2
+          c.osc0.base_address.should == 0x3000_0000
+          c.osc1.base_address.should == 0x3000_1000
+          c.pmc0.base_address.should == 0x4000_0000
+          c.pmc1.base_address.should == 0x4001_0000
         end
 
-        it "adding a sub_block_group should override an existing method of that name" do
-          class SB1
+        it "base address attribute can be set when instantiating a register owner" do
+          c = Top.new(override: override_setting)
+          c.respond_to?(:sub1).should == true
+          c.sub1.reg_base_address.should == 0x1000_0000
+          c.sub1.base_address.should == 0x1000_0000
+        end
+
+        it "can properly route get pass/fail for has_reg? method" do
+          c = Top.new(override: override_setting)
+          c.sub1.has_reg?(:reg1).should == true
+          c.sub1.has_reg?(:reg1000).should == false # This previously returned an Exception
+        end
+
+        it "base addresses get applied to registers" do
+          c = Top.new(override: override_setting)
+          c.sub1.reg(:reg1).address(relative: true).should == 0x100
+          c.sub1.reg(:reg1).offset.should == 0x100
+          c.sub1.reg(:reg1).address.should == 0x1000_0100
+        end
+
+        it "base addresses can be built in stages" do
+          Top.new(override: override_setting).sub2.sub3.reg(:reg1).address.should == 0x2001_0100
+        end
+
+        it "children should know their parents" do
+          c = Top.new(override: override_setting)
+          c.sub1.parent.should == c
+          c.sub2.sub3.parent.should == c.children[:sub2]
+          c.sub2.sub3.parent.parent.should == c
+        end
+
+        it "(hdl) paths can be constructed" do
+          c = Top.new(override: override_setting)
+          c.path.should == "ftf2"
+          c.sub1.path.should == "ftf2.ci.ci_regs"
+          c.sub1.path(relative_to: c).should == "ci.ci_regs"
+          c.sub2.path.should == "ftf2.sub2"
+          c.sub2.sub3.path.should == "ftf2.sub2.sub3"
+          c.sub7.sub3.path.should == "ftf2.sub3"
+          c.sub2.sub3.reg(:reg1).path.should == "ftf2.sub2.sub3.reg1"
+          c.sub2.sub3.reg(:reg1).path(relative_to: c).should == "sub2.sub3.reg1"
+          c.sub7.sub3.reg(:reg1).path.should == "ftf2.sub3.reg1"
+          c.sub7.sub3.reg(:reg1).path(relative_to: c).should == "sub3.reg1"
+          c.sub1.reg(:reg1).path.should == "ftf2.ci.ci_regs.reg1"
+          c.sub1.reg(:reg1).path(relative_to: c).should == "ci.ci_regs.reg1"
+          c.sub1.reg(:reg1).path(relative_to: c.sub1).should == "reg1"
+          c.sub1.reg(:reg1).bits(:data).path.should == "ftf2.ci.ci_regs.reg1[31:0]"
+          c.sub1.reg(:reg1).bits(:data).path(relative_to: c).should == "ci.ci_regs.reg1[31:0]"
+          c.sub1.reg(:reg1).bits(:data).path(relative_to: c.sub1.reg(:reg1)).should == "[31:0]"
+        end
+
+        it "full paths can be set" do
+          c = Top.new(override: override_setting)
+          c.sub1.reg(:reg1).path.should == "ftf2.ci.ci_regs.reg1"
+          c.sub1.reg(:reg1).full_path = "blah.blah"
+          c.sub1.reg(:reg1).path.should == "blah.blah"
+        end
+
+        it "absolute paths can be set on objects in the tree and this will stop further look up" do
+          c = Top.new(override: override_setting)
+          c.sub5.path.should == "ftf3.blah"
+          c.sub5.reg(:reg1).path.should == "ftf3.blah.reg1_reg"
+          c.sub5.reg(:reg1).path.should == "ftf3.blah.reg1_reg"
+          c.sub5.reg(:reg1).hdl_path.should == "ftf3.blah.reg1_reg"
+          c.sub6.path.should == "ftf2.sub6"
+          c.sub6.reg(:reg1).path.should == "ftf2.sub6.reg1_reg"
+
+          b = c.sub5.reg(:reg1).bits(:d6)
+          b.path.should == "blah.d6_reg"
+          c.sub5.reg(:reg1).bits(:d7).path.should == "ftf3.blah.reg1_reg[11:10]"
+          c.sub5.reg(:reg1).bits(:d5).path.should == "ftf3.blah.d5_reg"
+          c.sub5.reg(:reg1).bits(:d4).path.should == "ftf3.blah.reg1_reg.d4_reg"
+          c.sub5.reg(:reg1).bits(:d3).path.should == "ftf3.blah.reg1_reg[3]"
+          c.sub5.reg(:reg1).bits(:d2).path.should == "blah.d2_reg"
+          c.sub5.reg(:reg1).bits(:d1).path.should == "ftf3.blah.d1_reg"
+          c.sub5.reg(:reg1).bits(:d0).path.should == "ftf3.blah.reg1_reg.d0"
+        end
+
+        it "default sub blocks will be generated when no class name is specified" do
+          c = Top.new(override: override_setting)
+          c.sub3.add_reg :reg1, 0x30, 32, data: { pos: 0, bits: 32 }
+          c.sub3.reg(:reg1).address.should == 0x3000_0030
+          c.sub3.reg(:reg1).path.should == "ftf2.blah.reg1"
+          c.sub4.path.should == "ftf2.sub4"
+          c.sub4.base_address.should == 0
+        end
+
+        it "default sub blocks can have attributes defined on the fly" do
+          c = Top.new(override: override_setting)
+          c.sub3.blah = 10
+          c.sub3.blah.should == 10
+        end
+
+        it "the block form of adding registers works" do
+          c = Top.new(override: override_setting)
+          c.sub3.reg :reg1, 0x30 do |o|
+            o.bits 31..0, :data, reset: 0xFFFF_FFFF
+          end
+          c.sub3.reg(:reg1).data.should == 0xFFFF_FFFF
+        end
+
+        it "additional options are passed to the class if specified" do
+          Top.new(override: override_setting).sub2.some_attr.should == "hello"
+        end
+
+        it "additional options are added as attributes to anonymous sub blocks" do
+          Top.new(override: override_setting).sub3.some_attr.should == "hello"
+        end
+
+        describe "register domains" do
+          it "should be empty by default" do
+            Sub2.new.sub3.reg(:reg1).domains.empty?.should == true
+          end
+
+          it "if not specified the register should inherit all domains from the parent" do
+            c = Top.new(override: override_setting)
+            c.sub1.reg(:reg1).domains.should == c.domains
+          end
+
+          it "if specified then only that subset of domains should be returned" do
+            c = Top.new(override: override_setting)
+            c.sub3.domains.should == {ahb: c.domains[:ahb]}.with_indifferent_access
+            c.sub3.add_reg :reg1, 0x30, 32, data: { pos: 0, bits: 32 }
+            c.sub3.reg(:reg1).domains.should == {ahb: c.domains[:ahb]}.with_indifferent_access
+          end
+
+          it "base addresses can be applied per domain" do
+            class BATop
+              include Origen::TopLevel
+
+              def initialize
+                domain :ips
+                domain :ahb
+
+                sub_block :sub1, class_name: "BASub1", base_address: 0x1000_0000
+                sub_block :sub2, class_name: "BASub1", base_address: { ips: 0x2000_0000, ahb: 0x3000_0000 }
+              end
+            end
+
+            class BASub1
+              include Origen::Model
+
+              def initialize
+                reg :reg1, 0x200 do
+                  bits 31..0, :data
+                end
+                sub_block :sub1, class_name: "BASub2", domain: :ips
+                sub_block :sub2, class_name: "BASub2", domain: :ahb
+              end
+            end
+
+            class BASub2
+              include Origen::Model
+
+              def initialize
+                reg :reg1, 0x200 do
+                  bits 31..0, :data
+                end
+                sub_block :sub1, class_name: "BASub3", base_address: 0x100_0000
+              end
+            end
+
+            class BASub3
+              include Origen::Model
+
+              def initialize
+                reg :reg1, 0x200 do
+                  bits 31..0, :data
+                end
+              end
+            end
+
+            Origen.app.unload_target!
+
+            BATop.new
+
+            # Test that domains inherit properly
+            $dut.domains.should == {ahb: $dut.domains[:ahb], ips: $dut.domains[:ips]}.with_indifferent_access
+            $dut.sub1.domains.should == {ahb: $dut.domains[:ahb], ips: $dut.domains[:ips]}.with_indifferent_access
+            $dut.sub2.domains.should == {ahb: $dut.domains[:ahb], ips: $dut.domains[:ips]}.with_indifferent_access
+            $dut.sub1.sub1.domains.should == {ips: $dut.domains[:ips]}.with_indifferent_access
+            $dut.sub1.sub2.domains.should == {ahb: $dut.domains[:ahb]}.with_indifferent_access
+            $dut.sub1.sub1.reg1.domains.should == {ips: $dut.domains[:ips]}.with_indifferent_access
+            $dut.sub1.sub2.reg1.domains.should == {ahb: $dut.domains[:ahb]}.with_indifferent_access
+
+            $dut.sub1.sub1.reg1.address.should == 0x1000_0200
+            $dut.sub1.sub2.reg1.address.should == 0x1000_0200
+            $dut.sub1.sub1.sub1.reg1.address.should == 0x1100_0200
+            $dut.sub1.sub2.sub1.reg1.address.should == 0x1100_0200
+            $dut.sub2.sub1.reg1.address.should == 0x2000_0200
+            $dut.sub2.sub2.reg1.address.should == 0x3000_0200
+            $dut.sub2.sub1.sub1.reg1.address.should == 0x2100_0200
+            $dut.sub2.sub2.sub1.reg1.address.should == 0x3100_0200
+            $dut.sub1.reg1.address(domain: :ips).should == 0x1000_0200
+            $dut.sub1.reg1.address(domain: :ahb).should == 0x1000_0200
+            $dut.sub2.reg1.address(domain: :ips).should == 0x2000_0200
+            # Address is cached here, causing fail...
+            $dut.sub2.reg1.address(domain: :ahb).should == 0x3000_0200
+          end
+
+          it "bit index is output correctly when a parent register's path is hidden" do
+            class BITop
+              include Origen::TopLevel
+
+              def initialize
+                @path = :hidden
+                sub_block :sub1, class_name: "BISub"
+              end
+            end
+
+            class BISub
+              include Origen::Model
+
+              def initialize
+                reg :dr, 0, path: :hidden do |reg|
+                  bits 31..0, :data
+                end
+              end
+            end
+
+            Origen.app.unload_target!
+
+            BITop.new
+
+            $dut.sub1.dr[0].path.should == "sub1[0]"
+            $dut.sub1.dr[7..0].path.should == "sub1[7:0]"
+          end
+
+          it 'options passed to sub_block definitions are applied when the class is named' do
+            class Top1
+              include Origen::TopLevel
+
+              def initialize
+                sub_block :sub1, class_name: "Sub1", x: 5, y: 10
+              end
+            end
+
+            class Sub1
+              include Origen::Model
+              attr_accessor :x
+              attr_reader :y
+            end
+
+            Origen.app.unload_target!
+
+            Top1.new
+
+            $dut.sub1.x.should == 5
+            $dut.sub1.y.should == 10
+          end
+
+          it 'on_create callbacks in sub_block models get called' do
+            class TopLevel
+              include Origen::TopLevel
+
+              def initialize
+                sub_block :sub1, class_name: "Sub1"
+              end
+            end
+
+            class Sub1
+              include Origen::Model
+              attr_reader :on_create_called
+
+              def on_create
+                @on_create_called ||= 0
+                @on_create_called += 1
+              end
+            end
+
+            class Sub1Controller
+              include Origen::Controller
+              attr_reader :controller_on_create_called
+
+              def wrapped?
+                true
+              end
+
+              def on_create
+                @controller_on_create_called ||= 0
+                @controller_on_create_called += 1
+              end
+            end
+
+            Origen.app.unload_target!
+            Origen.target.temporary = -> { TopLevel.new }
+            Origen.load_target
+
+            dut.sub1.on_create_called.should == 1
+            dut.sub1.wrapped?.should == true
+            dut.sub1.controller_on_create_called.should == 1
+          end
+        end
+
+        describe "block loading" do
+          it "can be done from within the sub-block class's initialize method" do
+            Origen.app.unload_target!
+            OrigenCoreSupport::MySOC.new
+            dut.my_sub_block_1.params.param1.should == 100
+            dut.my_sub_block_1.params.param2.should == 20
+            dut.my_sub_block_1.params.param3.should == 300
+          end
+
+          it "can be done via a load_block argument passed to sub_block" do
+            Origen.app.unload_target!
+            OrigenCoreSupport::MySOC.new
+            dut.my_sub_block_2.params.param1.should == 10
+            dut.my_sub_block_2.params.param2.should == 200
+            dut.my_sub_block_2.params.param3.should == 300
+          end
+        end
+
+        describe "sub block groups" do
+          before :all do
+          end
+
+          it "subgroups container and sub-items exist as expected" do
+            c = Top.new(override: override_setting)
+            c.subgroups.is_a?(SubBlocksSpec::Subs).should == true
+            c.subgroups.count.should == 3
+            c.subgroups[0].is_a?(SubItem0).should == true
+            c.subgroups[1].is_a?(SubItem1).should == true
+            c.subgroups[2].is_a?(SubItem2).should == true
+          end
+
+          it "sub_block_groups hash acts as expected" do
+            c = Top.new(override: override_setting)
+
+            # check that cannot handle arguments, only
+            # block or no arguments
+            expect {
+              c.sub_block_groups(:check_args)
+            }.to raise_exception(RuntimeError)
+
+            c.sub_block_groups.count.should == 1
+            c.sub_block_groups.keys[0].should == "subgroups"
+            c.sub_block_groups["subgroups"].is_a?(SubBlocksSpec::Subs) == true
+            c.sub_block_groups["subgroups"].count.should == 3
+            c.sub_block_groups["subgroups"][0].is_a?(SubItem0).should == true
+            c.sub_block_groups["subgroups"][1].is_a?(SubItem1).should == true
+            c.sub_block_groups["subgroups"][2].is_a?(SubItem2).should == true
+          end
+
+          it "subitems exist standalone from container" do 
+            c = Top.new(override: override_setting)
+            c.subitem0.is_a?(SubItem0).should == true
+            c.subitem1.is_a?(SubItem1).should == true
+            c.subitem2.is_a?(SubItem2).should == true
+          end
+
+          it "subitems have correct attributes and regs" do
+            c = Top.new(override: override_setting)
+            c.subgroups[0].base_address.should == 0x000
+            c.subgroups[1].base_address.should == 0x200
+            c.subgroups[2].base_address.should == 0x400
+            c.subgroups[0].some_attr.should == "There are two kinds of people"
+            c.subgroups[1].some_attr.should == "in the world.  Those who can "
+            c.subgroups[2].some_attr.should == "extrapolate from incomplete data"
+          end
+
+          it "subitem registers are writeable and no naming conflicts" do
+            c = Top.new(override: override_setting)
+            c.subgroups[0].reg1
+            c.subgroups[1].reg1
+            c.subgroups[2].reg1
+            c.subgroups[0].reg1.write(0x55)
+            c.subgroups[0].reg1.data.should == 0x55
+            c.subgroups[1].reg1.data.should == 0x00
+            c.subgroups[2].reg1.data.should == 0x00
+            c.subgroups[1].reg1.write(0xAA)
+            c.subgroups[0].reg1.data.should == 0x55
+            c.subgroups[1].reg1.data.should == 0xAA
+            c.subgroups[2].reg1.data.should == 0x00
+            c.subgroups[2].reg1.write(0xBB)
+            c.subgroups[0].reg1.data.should == 0x55
+            c.subgroups[1].reg1.data.should == 0xAA
+            c.subgroups[2].reg1.data.should == 0xBB
+          end
+
+          it "default to Array if no container class provided" do
+            class Top2
+              include Origen::Model
+              def initialize
+                sub_block_group :subgroups do
+                  sub_block :subitem0, class_name: "SubItem0", base_address: 0x000, some_attr: "never"
+                  sub_block :subitem1, class_name: "SubItem1", base_address: 0x200, some_attr: "forget"
+                  sub_block :subitem2, class_name: "SubItem2", base_address: 0x400, some_attr: "the"
+                end
+              end
+            end
+            d = Top2.new
+            d.subgroups.is_a?(Array).should == true
+            d.subgroups.count.should == 3
+            d.subgroups[0].is_a?(SubItem0).should == true
+            d.subgroups[1].is_a?(SubItem1).should == true
+            d.subgroups[2].is_a?(SubItem2).should == true
+          end
+
+          it "adding a sub_block_group should override an existing method of that name" do
+            class SB1
+              include Origen::Model
+
+              def blah
+                1
+              end
+            end
+
+            m = SB1.new
+            m.blah.should == 1
+            m.sub_block_group :blah do
+              m.sub_block :my_blah
+            end
+            m.blah.should_not == 1
+          end
+
+          it 'returns all instances of a subblock class if a Class object is given' do
+            c = Top.new(override: override_setting)
+            c.sub_block(:testa, class_name: 'SubBlocksSpec::Sub1')
+            c.sub_block(:testb, class_name: 'SubBlocksSpec::Sub1')
+            expect(c.sub_blocks(SubBlocksSpec::Sub1)).to eql({
+              'sub1' => c.sub1,
+              'testa' => c.testa,
+              'testb' => c.testb
+            })
+
+            expect(c.sub_blocks(Integer)).to eql({})
+          end
+
+          it 'returns all instances matching the class, if an instance of a subblock is given' do
+            c = Top.new(override: override_setting)
+            c.sub_block(:testa, class_name: 'SubBlocksSpec::Sub1')
+            c.sub_block(:testb, class_name: 'SubBlocksSpec::Sub1')
+            expect(c.sub_blocks(c.sub1)).to eql({
+              'sub1' => c.sub1,
+              'testa' => c.testa,
+              'testb' => c.testb
+            })
+          end
+        end
+
+        it "adding a sub_block should override an existing method of that name" do
+          class SB2
             include Origen::Model
 
             def blah
@@ -583,57 +646,16 @@ module SubBlocksSpec
             end
           end
 
-          m = SB1.new
+          m = SB2.new
           m.blah.should == 1
-          m.sub_block_group :blah do
-            m.sub_block :my_blah
-          end
+          m.sub_block :blah
           m.blah.should_not == 1
+          m.blah.is_a?(Origen::SubBlock).should == true
+          m.sub_block[:blah].is_a?(Origen::SubBlock).should == true
+          m.sub_blocks[:blah].is_a?(Origen::SubBlock).should == true
         end
 
-        it 'returns all instances of a subblock class if a Class object is given' do
-          c = Top.new
-          c.sub_block(:testa, class_name: 'SubBlocksSpec::Sub1')
-          c.sub_block(:testb, class_name: 'SubBlocksSpec::Sub1')
-          expect(c.sub_blocks(SubBlocksSpec::Sub1)).to eql({
-            'sub1' => c.sub1,
-            'testa' => c.testa,
-            'testb' => c.testb
-          })
-          
-          expect(c.sub_blocks(Integer)).to eql({})
-        end
-
-        it 'returns all instances matching the class, if an instance of a subblock is given' do
-          c = Top.new
-          c.sub_block(:testa, class_name: 'SubBlocksSpec::Sub1')
-          c.sub_block(:testb, class_name: 'SubBlocksSpec::Sub1')
-          expect(c.sub_blocks(c.sub1)).to eql({
-            'sub1' => c.sub1,
-            'testa' => c.testa,
-            'testb' => c.testb
-          })
-        end
       end
-
-      it "adding a sub_block should override an existing method of that name" do
-        class SB2
-          include Origen::Model
-
-          def blah
-            1
-          end
-        end
-
-        m = SB2.new
-        m.blah.should == 1
-        m.sub_block :blah
-        m.blah.should_not == 1
-        m.blah.is_a?(Origen::SubBlock).should == true
-        m.sub_block[:blah].is_a?(Origen::SubBlock).should == true
-        m.sub_blocks[:blah].is_a?(Origen::SubBlock).should == true
-      end
-
     end
   end
 end

--- a/templates/web/guides/models/defining.md.erb
+++ b/templates/web/guides/models/defining.md.erb
@@ -408,5 +408,63 @@ $dut = SOC::EAGLE_M352.new
 $dut.nvm.memories.size    # => 4
 ~~~  
 
+#### Overriding and Inheriting
+
+<mark><b>WARNING: </b>This is a beta feature, there still may be some bugs/undefined behavior when overriding or inheriting blocks.</mark>
+
+Ideally, you will not need to override or inherit blocks. But if you need to make some application
+specific overrides to methods defined in blocks that were instantiated in another application that
+you don't have control over, overriding may be the solution. Similarly, if you need to make an
+application specific derivative of a block thats been defined in another app, and it doesn't make
+sense to define the derivative in that app, then you may want to utilize the inherit functionality.
+
+##### Override
+
+Override allows you to recreate a block that already existed.
+For example, lets say that your dut included a sub block called 'dummy_block' of class
+`OtherApp::Block::BlockA` which was created in another app, and it instantiated a sub block
+called 'dummy_sub' of class `OtherApp::Block::BlockA::Sub1`.
+
+~~~ruby
+# file: app/blocks/dut/my_dut/sub_blocks.rb
+sub_block :dummy_block, class_name: 'OtherApp::Block::BlockA'
+~~~
+
+Which you can now access dummy_sub via `dut.dummy_block.dummy_sub`. But now lets say that your
+application needs a different sub block under dummy block, `MyApp::DUT::MyDut::Sub2`.
+
+You could override the existing `dut.dummy_block.dummy_sub` like so:
+
+~~~ruby
+# file: app/blocks/dut/my_dut/sub_blocks.rb
+sub_block :dummy_block, class_name: 'OtherApp::Block::BlockA'
+dummy_block.sub_block :dummy_sub, class_name: 'MyApp::DUT::MyDut::Sub2', override: true
+~~~
+
+##### Inherit
+
+Continuing the above example from Override, lets now say that you want your new
+`MyApp::DUT::MyDut::Sub2` sub block to inherit `OtherApp::Block::BlockA::Sub1` as a starting point.
+You can already mostly accomplish this the same way that derivatives operate by setting your class
+definitions in your model.rb and controller.rb files of `MyApp::DUT::MyDut::Sub2` to inherit the class
+of `OtherApp::Block::BlockA::Sub1`'s model.rb and controller.rb:
+
+~~~ruby
+# file: app/blocks/dut/my_dut/sub_blocks/sub2/model.rb
+class MyAPP::DUT::MyDut::Sub2 < OtherApp::Block::BlockA::Sub1
+
+# file: app/blocks/dut/my_dut/sub_blocks/sub2/controller.rb
+class MyAPP::DUT::MyDut::Sub2Controller < OtherApp::Block::BlockA::Sub1Controller
+~~~
+
+But what this does not do, is inherit the block files (attributes.rb, parameters.rb, etc...) associated
+with `OtherApp::Block::BlockA::Sub1`. To do that, you can also pass the inherit option to `sub_block`, which
+will instruct the block loader to pick up those files as well:
+
+~~~ruby
+# file: app/blocks/dut/my_dut/sub_blocks.rb
+sub_block :dummy_block, class_name: 'OtherApp::Block::BlockA'
+dummy_block.sub_block :dummy_sub, class_name: 'MyApp::DUT::MyDut::Sub2', override: true, inherit: 'OtherApp::Block::BlockA'
+~~~
 
 % end


### PR DESCRIPTION
This is to support the direction we're heading in for supporting a chiplet based distributed architecture. 

The application structure consists of 3 layers: IP -> Chiplet -> Product

So say for example theres a PCIe App, an I/O App, and an app for Product A.

The PCIe app instantiates a pcie block and derivative: app/blocks/pcie/derivatives/pcie4

The I/O app instantiates an iod that uses pcie4: app/blocks/iod/derivatives/my_iod
```
# app/blocks/iod/derivatives/my_iod/sub_blocks.rb
sub_block :pcie, class_name: 'PcieApp::Pcie::Pcie4'
```
And then the product app instantiates an iod sub block:
```
# app/blocks/dut/derivatives/product_a/sub_blocks.rb
sub_block :iod, class_name: 'IodApp::Iod::MyIod'
```
-----
Up to this point, if I understand the distributed architecture correctly, then nothing out of the norm at this point.

However, we need to be able to support product level and chiplet level customizations. Now we could try to just pass options upstream, but a requirement at our company is that the product app has final say on the contents of the test program. 

This PR enhances the sub_block API with the `inherit` and `override` functionality.
`inherit` takes an argument similar to `class_name` but of another block's class_name. It essentially just ensures that the block loader includes the block files of the inherited block. For example, if the IO App wanted to create its own pcie sub block to customize the pcie4 block from the pcie app:
```
# app/blocks/iod/derivatives/my_iod/sub_blocks.rb
sub_block :pcie, class_name: 'IodApp::Iod::MyIod::Pcie', inherit: 'PcieApp::Pcie::Pcie4'
```
Now we can build up chiplets to be re-used across products and customize them as needed.

But now we want to customize the dut.iod.pcie block within the product app, except now that block already exists. To do that:
```
# app/blocks/dut/derivatives/product_a/sub_blocks/iod/sub_blocks.rb
sub_block :pcie, class_name: 'ProductApp::DUT::ProductA::Iod::Pcie', inherit: 'IodApp::Iod::MyIod::Pcie', override: true
```
-----
Leaving this as a draft so this can be reviewed while I add unit tests and documentation