### PR TITLE
skip requiring non essential block files, updated docs for sub block override

### DIFF
--- a/lib/origen/sub_blocks.rb
+++ b/lib/origen/sub_blocks.rb
@@ -336,7 +336,11 @@ module Origen
             # =>  NameSpaceA::B::C
             if constantizable && (options[:class_name] != options[:class_name].constantize.to_s)
               block_dir = options[:block_file] || _find_block_dir(options)
+              # files that aren't initializing a new namespace and have special loading shouldn't be required
+              # the code they contain may try to call methods that dont exist yet
+              skip_require_files = options[:skip_require_files] || %w(attributes parameters pins registers sub_blocks timesets)
               Dir.glob("#{block_dir}/*.rb").each do |file|
+                next if skip_require_files.include?(Pathname.new(file).basename('.rb').to_s)
                 require file
               end
             end

--- a/templates/web/guides/models/defining.md.erb
+++ b/templates/web/guides/models/defining.md.erb
@@ -408,9 +408,12 @@ $dut = SOC::EAGLE_M352.new
 $dut.nvm.memories.size    # => 4
 ~~~  
 
-#### Overriding and Inheriting
+### Overriding and Inheriting
 
-<mark><b>WARNING: </b>This is a beta feature, there still may be some bugs/undefined behavior when overriding or inheriting blocks.</mark>
+<div class="alert alert-warning">
+  <strong>WARNING: </strong>This is a beta feature, there still may be some bugs/undefined behavior when overriding or inheriting blocks.
+</div>
+
 
 Ideally, you will not need to override or inherit blocks. But if you need to make some application
 specific overrides to methods defined in blocks that were instantiated in another application that
@@ -418,7 +421,7 @@ you don't have control over, overriding may be the solution. Similarly, if you n
 application specific derivative of a block thats been defined in another app, and it doesn't make
 sense to define the derivative in that app, then you may want to utilize the inherit functionality.
 
-##### Override
+#### Override
 
 Override allows you to recreate a block that already existed.
 For example, lets say that your dut included a sub block called 'dummy_block' of class
@@ -441,7 +444,35 @@ sub_block :dummy_block, class_name: 'OtherApp::Block::BlockA'
 dummy_block.sub_block :dummy_sub, class_name: 'MyApp::DUT::MyDut::Sub2', override: true
 ~~~
 
-##### Inherit
+##### skip_require_files
+
+When overriding, previously instantiated subblocks have already initialzed some namespaces, which can result in some funny constant behavior:
+
+~~~ruby
+NamespaceA::B::C
+=>  NameSpaceX::Y::Z
+~~~
+
+To get around this the override feature will require the relevant block files which returns the constant behavior back to sanity:
+
+~~~ruby
+NamespaceA::B::C
+=>  NameSpaceA::B::C
+~~~
+
+However, there are many block files which aren't meant to be required directly (e.g attributes.rb) as they could contain method calls which wouldn't
+be available at the time they are required. So by default, these kinds of block files are skipped.
+Specifically: attributes.rb, parameters.rb, pins.rb, registers.rb, sub_blocks.rb, and timesets.rb
+
+If you have other block files in your modeling that you need require to skip, you can do so by passing an array of files (without the extension) to the sub_block method as an option of `skip_require_files`:
+
+~~~ruby
+dummy_block.sub_block :dummy_sub, class_name: 'MyApp::DUT::MyDut::Sub2', override: true, skip_require_files: %w(file1 file2 file3)
+~~~
+
+Note however that you'll likely need to include the files that are skipped by default in your custom skip_require_files option as this will override the default array.
+
+#### Inherit
 
 Continuing the above example from Override, lets now say that you want your new
 `MyApp::DUT::MyDut::Sub2` sub block to inherit `OtherApp::Block::BlockA::Sub1` as a starting point.


### PR DESCRIPTION
the requires that were helping make the constants sane starting getting troublesome when it tried to require say an attributes.rb file that called code that only worked after the blocks above it were set

Now only require files that should develop a namespace (ie model.rb/controller.rb by default), also allow for user to customize if they need to.

See the guides update for more detail