### PR TITLE
block inheritance feature can now propagate bugs and features

### DIFF
--- a/spec/sub_block_spec.rb
+++ b/spec/sub_block_spec.rb
@@ -34,6 +34,10 @@ module SubBlocksSpec
       sub_block :sub5, class_name: "Sub3", abs_path: "ftf3.blah", override: options[:override]
       sub_block :sub6, class_name: "Sub3", override: options[:override]
       sub_block :sub7, class_name: "Sub2", path: :hidden, base_address: 0x7000_0000, override: options[:override]
+      sub_block :sub8, class_name: "Sub6", override: options[:override], inherit: 'SubBlocksSpec::Sub4'
+      sub_block :sub9, class_name: "Sub7", override: options[:override], inherit: 'SubBlocksSpec::Sub5'
+      sub_block :sub10, class_name: "Sub8", override: options[:override], inherit: 'SubBlocksSpec::Sub4', disable_bug_inheritance: true
+      sub_block :sub11, class_name: "Sub9", override: options[:override], inherit: 'SubBlocksSpec::Sub5', disable_feature_inheritance: true
 
       sub_block_group :subgroups, class_name: "SubBlocksSpec::Subs" do
         sub_block :subitem0, class_name: "SubItem0", base_address: 0x000, some_attr: "There are two kinds of people"
@@ -83,6 +87,70 @@ module SubBlocksSpec
       end
     end
   end
+
+  class Sub4
+    include Origen::Model
+
+    bug :sub4_bug
+
+    def initialize
+    end
+  end
+
+  class Sub5
+    include Origen::Model
+
+    feature :sub5_feature
+
+    def initialize
+    end
+  end
+
+  class Sub6
+    include Origen::Model
+
+    feature :default_feature
+    bug :default_bug
+
+    def initialize
+      @version = 0
+    end
+  end
+
+  class Sub7
+    include Origen::Model
+
+    feature :default_feature
+    bug :default_bug
+
+    def initialize
+      @version = 0
+    end
+  end
+
+  class Sub8
+    include Origen::Model
+
+    feature :default_feature
+    bug :default_bug
+
+    def initialize
+      @version = 0
+    end
+  end
+
+  class Sub9
+    include Origen::Model
+
+    feature :default_feature
+    bug :default_bug
+
+    def initialize
+      @version = 0
+    end
+  end
+
+
 
   class Subs < ::Array
     def <<(sub_block)
@@ -653,6 +721,45 @@ module SubBlocksSpec
           m.blah.is_a?(Origen::SubBlock).should == true
           m.sub_block[:blah].is_a?(Origen::SubBlock).should == true
           m.sub_blocks[:blah].is_a?(Origen::SubBlock).should == true
+        end
+
+        describe 'sub_block inheritance' do 
+
+          it 'can inherit bugs' do
+            c = Top.new(override: override_setting)
+            b = c.sub8
+            b.has_bug?(:sub4_bug).should == true
+            b.has_bug?(:default_bug).should == true
+            b.has_feature?(:sub5_feature).should == false
+            b.has_feature?(:default_feature).should == true
+          end
+
+          it 'can disable inheritance of bugs' do
+            c = Top.new(override: override_setting)
+            b = c.sub10
+            b.has_bug?(:sub4_bug).should == false
+            b.has_bug?(:default_bug).should == true
+            b.has_feature?(:sub5_feature).should == false
+            b.has_feature?(:default_feature).should == true
+          end
+
+          it 'can inherit features' do
+            c = Top.new(override: override_setting)
+            b = c.sub9
+            b.has_bug?(:sub4_bug).should == false
+            b.has_bug?(:default_bug).should == true
+            b.has_feature?(:sub5_feature).should == true
+            b.has_feature?(:default_feature).should == true
+          end
+
+          it 'can disable inheritance of features' do
+            c = Top.new(override: override_setting)
+            b = c.sub11
+            b.has_bug?(:sub4_bug).should == false
+            b.has_bug?(:default_bug).should == true
+            b.has_feature?(:sub5_feature).should == false
+            b.has_feature?(:default_feature).should == true
+          end
         end
 
       end

--- a/templates/web/guides/models/defining.md.erb
+++ b/templates/web/guides/models/defining.md.erb
@@ -498,4 +498,14 @@ sub_block :dummy_block, class_name: 'OtherApp::Block::BlockA'
 dummy_block.sub_block :dummy_sub, class_name: 'MyApp::DUT::MyDut::Sub2', override: true, inherit: 'OtherApp::Block::BlockA'
 ~~~
 
+##### Bug and Feature inheritance
+
+By default, if the inherit option is passed it will attempt to propagate any features and bugs from the class specified in the inherit option to the sub block being defined.
+If you'd like to prevent either from happening, then you can pass either disable_bug_inheritance and/or disable_feature_inheritance options to the sub_block method:
+
+~~~ruby
+dummy_block.sub_block :dummy_sub, class_name: 'MyApp::DUT::MyDut::Sub2', override: true, inherit: 'OtherApp::Block::BlockA', disable_bug_inheritance: true, disable_feature_inheritance: true
+~~~
+
+
 % end


### PR DESCRIPTION
When using the sub block inheritance feature, bugs and features can now propagate. This enables us along with the existing remote inheritance functionality to split bug/feature definitions into apps that are targeted towards modeling some IP, while apps that are targeted towards testing some aspect of an IP can focus on handling bugs/features in their flows when encountered.

```ruby
class MyIPBlock
  include Origen::Model
  feature :my_feature
end

class MySocBlock < MyIPBlock
  include Origen::Model
end

class MyTop
  include Origen::TopLevel

  def initialize(options = {})
    sub_block :my_block, class_name: 'MySocBlock', inherit: 'MyIPBlock'
  end
end

dut.my_block.has_feature?(:my_feature)
=> true
```

The above works the same for bugs. You can disable bugs and/or feature inheritance by passing either/both `disable_bug_inheritance` or `disable_feature_inheritance` options to the sub_block method:

```ruby
sub_block :my_block, class_name: 'MySocBlock', inherit: 'MyIPBlock', disable_feature_inheritance: true

dut.my_block.has_feature?(:my_feature)
=> false
```
