### PR TITLE
Add net smtp runtime dependency

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -4,12 +4,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         # For some reason ruby 2.7 checks on the GA machine
         # wind up in an infinite loop on origen -v
         # this doesn't happen on local machines
         # ruby-version: [2.5, 2.6, 2.7, 3.0.4, 3.1]
-        ruby-version: [2.5, 2.6, 3.0.4, 3.1]
+        ruby-version: [2.6, 2.7]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby-version: [2.5, 2.6, 3.0.4, 3.1]
+        ruby-version: [2.5, 2.6, 2.7, 3.0.4, 3.1]
 
     runs-on: ${{ matrix.os }}
 
@@ -21,8 +21,8 @@ jobs:
       run: gem install bundler -v '> 2'
     - name: Remove Gemfile.lock
       run: rm Gemfile.lock
-    - name: Install dependencies
-      run: bundle install  
+    # - name: Install dependencies
+    #   run: bundle install  
       
     # Work around Ruby 3 gem install issue
     - name: Build Origen Gem - Ruby 3 work around

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -17,8 +17,14 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Update Env
       run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-    - name: Install Bundler
+
+    - name: Install Bundler - Ruby 2
+      if: matrix.ruby-version == '2.5' || matrix.ruby-version == '2.6' || matrix.ruby-version == '2.7'
       run: gem install bundler -v '> 2'
+    - name: Install Bundler - Ruby 3
+      if: matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
+      run: gem install bundler -v '> 2'
+
     - name: Remove Gemfile.lock
       run: rm Gemfile.lock
     - name: Install dependencies
@@ -26,10 +32,10 @@ jobs:
       
     # Work around Ruby 3 gem install issue
     - name: Build Origen Gem - Ruby 3 work around
-      if: matrix.ruby-version == '2.7' || matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
+      if: matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
       run: gem build origen.gemspec --output origen.gem    
     - name: Gem Install Origen - Ruby 3 work around 
-      if: matrix.ruby-version == '2.7' || matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
+      if: matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
       run: gem install origen.gem 
       
     # Normal way of installing origen

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -21,8 +21,8 @@ jobs:
       run: gem install bundler -v '> 2'
     - name: Remove Gemfile.lock
       run: rm Gemfile.lock
-    # - name: Install dependencies
-    #   run: bundle install  
+    - name: Install dependencies
+      run: bundle install  
       
     # Work around Ruby 3 gem install issue
     - name: Build Origen Gem - Ruby 3 work around

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -5,7 +5,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby-version: [2.5, 2.6, 2.7, 3.0.4, 3.1]
+        # For some reason ruby 2.7 checks on the GA machine
+        # wind up in an infinite loop on origen -v
+        # this doesn't happen on local machines
+        # ruby-version: [2.5, 2.6, 2.7, 3.0.4, 3.1]
+        ruby-version: [2.5, 2.6, 3.0.4, 3.1]
 
     runs-on: ${{ matrix.os }}
 
@@ -17,14 +21,8 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Update Env
       run: echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-
-    - name: Install Bundler - Ruby 2
-      if: matrix.ruby-version == '2.5' || matrix.ruby-version == '2.6' || matrix.ruby-version == '2.7'
+    - name: Install Bundler
       run: gem install bundler -v '> 2'
-    - name: Install Bundler - Ruby 3
-      if: matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
-      run: gem install bundler -v '> 2'
-
     - name: Remove Gemfile.lock
       run: rm Gemfile.lock
     - name: Install dependencies

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -26,10 +26,10 @@ jobs:
       
     # Work around Ruby 3 gem install issue
     - name: Build Origen Gem - Ruby 3 work around
-      if: matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
+      if: matrix.ruby-version == '2.7' || matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
       run: gem build origen.gemspec --output origen.gem    
     - name: Gem Install Origen - Ruby 3 work around 
-      if: matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
+      if: matrix.ruby-version == '2.7' || matrix.ruby-version == '3.0.4' || matrix.ruby-version == '3.1'
       run: gem install origen.gem 
       
     # Normal way of installing origen

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby-version: [2.5, 2.6, 2.7, 3.0.4, 3.1]
+        ruby-version: [2.5, 2.6, 3.0.4, 3.1]
 
     runs-on: ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /lbin/*.bat
 
 # RGen local files
+/app
 /.bundle
 /target/.default
 /environment/.default

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ PATH
       kramdown (~> 2.4)
       nanoc (~> 3.7.0)
       net-ldap (~> 0.13)
+      net-smtp
       nokogiri (>= 1.11.0)
       pry (~> 0.10)
       rake (~> 10)
@@ -96,6 +97,7 @@ GEM
     dentaku (3.5.0)
       concurrent-ruby
     diff-lcs (1.5.0)
+    digest (3.1.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -123,6 +125,12 @@ GEM
     nanoc (3.7.5)
       cri (~> 2.3)
     net-ldap (0.17.0)
+    net-protocol (0.1.3)
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     netrc (0.11.0)
     nokogiri (1.13.6-x64-mingw-ucrt)
       racc (~> 1.4)
@@ -204,6 +212,7 @@ GEM
       tins (~> 1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    timeout (0.3.0)
     tins (1.31.1)
       sync
     treetop (1.6.11)

--- a/lib/origen/boot/app.rb
+++ b/lib/origen/boot/app.rb
@@ -157,6 +157,7 @@ end
           begin
             Bundler.setup
           rescue Gem::LoadError, Bundler::BundlerError => e
+		    puts "\n\n------TEMP - Bundle.setup error:"
             puts e
             puts
             if exec_remote

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -53,4 +53,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri', '>= 1.11.0'
   #spec.add_runtime_dependency 'cri', '~>2.10.0' # Not required by Origen, but add constrain to avoid Ruby 2.3 requirement
   spec.add_runtime_dependency 'concurrent-ruby'
+  #spec.add_runtime_dependency 'net-smtp'
 end

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -53,5 +53,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri', '>= 1.11.0'
   #spec.add_runtime_dependency 'cri', '~>2.10.0' # Not required by Origen, but add constrain to avoid Ruby 2.3 requirement
   spec.add_runtime_dependency 'concurrent-ruby'
-  #spec.add_runtime_dependency 'net-smtp'
+  spec.add_runtime_dependency 'net-smtp'
 end

--- a/spec/utility_spec.rb
+++ b/spec/utility_spec.rb
@@ -41,4 +41,10 @@ describe "Utilities" do
     dut.d1[3..0].read
     u.read_hex(dut.d1).should == "0xXXXXXXXX0"
   end
+  
+  it "Can create net smtp object" do
+	require 'net/smtp'
+	smtp = Net::SMTP.new('dummy', '0.0')
+	smtp.is_a?(Net::SMTP).should == true
+  end
 end


### PR DESCRIPTION
Without this the mailer utility has a runtime error at the <code>require 'net/smtp'</code> on line 1. This happens with Ruby 3.1 only. I didn't stumble across it until I tried to release origen.