### PR TITLE
Variable max lsf jobs

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby-version: [2.5, 2.6, 2.7, 3.0.4, 3.1]
+        ruby-version: [2.6, 2.7, 3.0.4, 3.1]
 
     runs-on: ${{ matrix.os }}
 

--- a/lib/origen/application/lsf.rb
+++ b/lib/origen/application/lsf.rb
@@ -42,6 +42,7 @@ module Origen
           @queue = Origen.site_config.lsf_queue
           @debug = Origen.site_config.lsf_debug
           @cores = Origen.site_config.lsf_cores
+          @max_jobs = Origen.site_config.lsf_max_jobs || 400
         end
       end
 
@@ -152,7 +153,7 @@ module Origen
       def limit_job_submissions
         @local_job_count ||= 0
         if @local_job_count == 100
-          while remote_jobs_count > 400
+          while remote_jobs_count > @max_jobs
             puts 'Waiting for submitted jobs count to fall below limit...'
             sleep 5
           end


### PR DESCRIPTION
Allow ability to modify the max job count before origen lsf handler sleeps to submit jobs

Edit: Update - Added ability to only check the current queue rather than all submitted jobs, as we have a service account that submits lots of jobs, and werent able to submit any origen jobs as there were a few thousand running in a different queue