### PR TITLE
Enforcing this rule would lead to lots of rework

### DIFF
--- a/config/rubocop/strict.yml
+++ b/config/rubocop/strict.yml
@@ -3109,7 +3109,7 @@ Style/ClassAndModuleChildren:
   # have the knowledge to perform either operation safely and thus requires
   # manual oversight.
   SafeAutoCorrect: false
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.19'
   #
   # Basically there are two different styles:


### PR DESCRIPTION
Applications generated by Origen with the new structure fail this rule and auto correct breaks applications. Probably best to just turn it off.