### PR TITLE
Catch flush issues when a logger is closed

### DIFF
--- a/lib/origen/log.rb
+++ b/lib/origen/log.rb
@@ -202,14 +202,12 @@ module Origen
     # Force the logger to write any buffered output to the log files
     def flush
       @open_logs.each do |logger, file|
-        begin
-          file.flush
-        rescue => e
-          if file.is_a?(File)
-            Origen.log.warning "Could not flush log file #{file.path}: #{e.message}"
-          else
-            Origen.log.warning "Could not flush IO buffer: #{e.message}"
-          end
+        file.flush
+      rescue => e
+        if file.is_a?(File)
+          Origen.log.warning "Could not flush log file #{file.path}: #{e.message}"
+        else
+          Origen.log.warning "Could not flush IO buffer: #{e.message}"
         end
       end
       nil

--- a/lib/origen/log.rb
+++ b/lib/origen/log.rb
@@ -202,7 +202,15 @@ module Origen
     # Force the logger to write any buffered output to the log files
     def flush
       @open_logs.each do |logger, file|
-        file.flush
+        begin
+          file.flush
+        rescue => e
+          if file.is_a?(File)
+            Origen.log.warning "Could not flush log file #{file.path}: #{e.message}"
+          else
+            Origen.log.warning "Could not flush IO buffer: #{e.message}"
+          end
+        end
       end
       nil
     end


### PR DESCRIPTION
If using multiple shells in the same workspace, there's chance logger files will step on each other, particularly `last`, and particularly noticeable with simulations. This will generate an exception, but doesn't affect a single pattern. However, this will kill a `flow` simulation prematurely if it occurs.

This is a quick fix to just catch any errors flushing to a log file and print them to the user, without propagating the exception.

For example, instead of seeing this:

![image](https://github.com/Origen-SDK/origen/assets/13453967/9409b394-429a-4977-894f-67882889a31b)

You'll see:

![image](https://github.com/Origen-SDK/origen/assets/13453967/ba14cae8-23f1-4498-94de-c59507b6e8e6)

Note the `warnings` here - just saying stale log file, which is expected, but now results in the warning instead of an exception.
