### PR TITLE
Feature/chip package method missing

### DIFF
--- a/lib/origen/chip_package.rb
+++ b/lib/origen/chip_package.rb
@@ -6,7 +6,7 @@ module Origen
     attr_accessor :number_of_rows
     attr_accessor :number_of_columns
     attr_accessor :interconnects
-    attr_accessor :types
+    attr_writer :types
     attr_reader :upper_axes
     attr_reader :lower_axes
     attr_reader :rows
@@ -14,10 +14,11 @@ module Origen
     attr_reader :field
     attr_reader :obj
     attr_reader :groups
-    attr_reader :group_list
+    # attr_reader :group_list       # method is redefined further down
     attr_reader :last_empty_char
     attr_reader :plottable
     attr_writer :name
+
     alias_writer :full_name, :name
     # Returns the owner that $owns the mode (the SoC instance usually)
     attr_accessor :owner
@@ -57,7 +58,7 @@ module Origen
     #
     def prepare_plot
       @plottable = types.any? { |x| /BGA/i =~ x }
-      if  @plottable
+      if @plottable
         @last_empty_char = '.'
         @field = []
         @groups = []
@@ -69,7 +70,7 @@ module Origen
         (1..@number_of_columns).map { |item| @columns << item }
         @upper_axes = []
         @lower_axes = []
-        @columns.each_with_index do|column, index|
+        @columns.each_with_index do |column, index|
           # if index % 2 == 0
           if index.even?
             temp = column.to_s
@@ -96,20 +97,20 @@ module Origen
     #    2. It concatenates the array elements into printable rows, and prints
     #       them.
     #
-    def generate_field(emptyChar = @last_empty_char)
+    def generate_field(empty_char = @last_empty_char)
       if plottable
         new_field = []
         @field.each do |rows|
           rows.each do |items|
             if items.length == 0
-              items.insert(0, "#{emptyChar} ")
-            elsif emptyChar != @last_empty_char && items == ["#{last_empty_char} "]
-              items[0] = "#{emptyChar} "
+              items.insert(0, "#{empty_char} ")
+            elsif empty_char != @last_empty_char && items == ["#{last_empty_char} "]
+              items[0] = "#{empty_char} "
             end
           end
           new_field.insert(-1, rows.join(''))
         end
-        @last_empty_char = emptyChar
+        @last_empty_char = empty_char
         package = (owner.package.nil?) ? 'No package chosen.' : owner.package.to_s
         puts "\nPin field: #{package}\n\n"
         group_display = @groups.join("\n")
@@ -129,13 +130,12 @@ module Origen
         @groups << "#{marker} - Power"
         pin_list.each do |item|
           # puts items,owner.pins[items].location
-          begin
-            coordinates = coordinate(item.location)
-            @field[coordinates[0]][coordinates[1]] = [marker.red + ' ']
-          rescue
-            puts "#{item} doesn't appear to have a physical location in this configuration."
-            puts "Current package = #{owner.package}"
-          end
+
+          coordinates = coordinate(item.location)
+          @field[coordinates[0]][coordinates[1]] = [marker.red + ' ']
+        rescue
+          puts "#{item} doesn't appear to have a physical location in this configuration."
+          puts "Current package = #{owner.package}"
         end
         generate_field
       end
@@ -151,12 +151,10 @@ module Origen
         pin_list = owner.ground_pins.map { |_ken, pin| pin }
         @groups << "#{marker} - Ground"
         pin_list.each do |item|
-          begin
-            coordinates = coordinate(item.location)
-            @field[coordinates[0]][coordinates[1]] = [marker.green + ' ']
-          rescue
-            puts "#{item} doesn't appear to have a physical location in this configuration."
-          end
+          coordinates = coordinate(item.location)
+          @field[coordinates[0]][coordinates[1]] = [marker.green + ' ']
+        rescue
+          puts "#{item} doesn't appear to have a physical location in this configuration."
         end
         generate_field
       end
@@ -183,16 +181,16 @@ module Origen
       if plottable
         puts "\nPLOTTING GROUPS:"
         puts '$dut.package.list_groups <-- to see available group names'
-        puts "$dut.package.plot(\"ddr_interface_1\")"
+        puts '$dut.package.plot("ddr_interface_1")'
         puts "$dut.package.plot_group(\"serdes_1\",'Z') <--denotes custom legend marker, Z"
         puts "\nPLOTTING INDIVIDUAL PINS:"
-        puts "$dut.package.plot(\"d1_mdqs00\")"
+        puts '$dut.package.plot("d1_mdqs00")'
         puts "\nPLOTTING WITH REGEXP:"
-        puts "$dut.package.plot(\"d1_mdqs\") <-- Plot all controller 1 DQS pins."
-        puts "$dut.package.plot(\"d1_mdqs0[0-9]\") <-- Plot d1_mdqs00 - d1_mdqs09."
+        puts '$dut.package.plot("d1_mdqs") <-- Plot all controller 1 DQS pins.'
+        puts '$dut.package.plot("d1_mdqs0[0-9]") <-- Plot d1_mdqs00 - d1_mdqs09.'
         puts "\nADDING POWER/GROUND:"
-        puts "$dut.package.plot(\"grounds\")"
-        puts "$dut.package.plot(\"power\")"
+        puts '$dut.package.plot("grounds")'
+        puts '$dut.package.plot("power")'
         puts "\nVIEW CURRENT PLOT\n"
         puts '$dut.package.show'
       else
@@ -206,7 +204,7 @@ module Origen
       grps = owner.pins.map { |_key, val| val.group }
       grps.uniq!
     rescue
-      return []
+      []
     end
     alias_method :group_list, :list_groups
 
@@ -216,7 +214,7 @@ module Origen
       pin_list[0].compact!
       puts 'No pins found under that group name.' unless pin_list.any?
     rescue
-      return []
+      []
     end
 
     # ##############################################################
@@ -235,6 +233,7 @@ module Origen
       row = location[0..split_index]
       column = location[split_index + 1..-1]
       fail ArgumentError, error unless row.length > 0 && column.length > 0
+
       ## Now convert alphanumeric row to jedec equiv' with to_row() method
       # and return coordinates.
       coordinates = [to_row(row), column.to_i - 1]
@@ -255,6 +254,23 @@ module Origen
       test_string[0, 1]
     end
 
+    def method_missing(m, *args, &block)
+      ivar = "@#{m.to_s.gsub('=', '')}"
+      ivar_sym = ":#{ivar}"
+      if m.to_s =~ /=$/
+        define_singleton_method(m) do |val|
+          instance_variable_set(ivar, val)
+        end
+      elsif instance_variables.include? ivar_sym
+        instance_variable_get(ivar)
+      else
+        define_singleton_method(m) do
+          instance_variable_get(ivar)
+        end
+      end
+      send(m, *args, &block)
+    end
+
     #  .plot can be called explicitly and accepts string arguments with
     #  or without regex styling. For example:
     #
@@ -264,48 +280,46 @@ module Origen
     #    $dut.package.plot("d1_mdq37","$") # plots controller 1 mdq 37, and uses $ as a legend marker
     #    $dut.package.plot("d2_mdq[3-6]0) # plots d2_mdq30, d2_mdq40, d2_md520, and d2_md620
     #
-    def plot(pinName, marker = nil)
+    def plot(pin_name, marker = nil)
       prepare_plot if field.nil?
-      if plottable && pinName.is_a?(String) && /ground/ =~ pinName.downcase
+      if plottable && pin_name.is_a?(String) && /ground/ =~ pin_name.downcase
         add_grounds('G')
-      elsif plottable && pinName.is_a?(String) && /power/ =~ pinName.downcase
+      elsif plottable && pin_name.is_a?(String) && /power/ =~ pin_name.downcase
         add_power('P')
-      elsif plottable && pinName.is_a?(String)
+      elsif plottable && pin_name.is_a?(String)
         found_pins = []
-        owner.pins.map { |pin| found_pins << pin[1] if /#{pinName}/ =~ pin[1].name.to_s || /#{pinName}/ =~ pin[1].group.to_s }
+        owner.pins.map { |pin| found_pins << pin[1] if /#{pin_name}/ =~ pin[1].name.to_s || /#{pin_name}/ =~ pin[1].group.to_s }
         if found_pins.size == 1 && marker.nil?
-          marker = initial(pinName.to_s)
-          while @groups.index { |grpName| grpName =~ /#{marker} -/ }
+          marker = initial(pin_name.to_s)
+          while @groups.index { |grp_name| grp_name =~ /#{marker} -/ }
             marker.next!
             marker = '0' unless marker.size < 2
           end
           coordinates = coordinate(found_pins[0].location)
           @field[coordinates[0]][coordinates[1]] = [marker.white_on_blue + ' ']
-          @groups.delete_if { |group| /#{pinName.to_s}/ =~ group }
+          @groups.delete_if { |group| /#{pin_name}/ =~ group }
           @groups << "#{marker} - #{found_pins[0].name} - #{found_pins[0].location}"
         elsif found_pins.size == 1
           coordinates = coordinate(found_pins[0].location)
           @field[coordinates[0]][coordinates[1]] = [marker.white_on_blue + ' ']
-          @groups.delete_if { |group| /#{pinName.to_s}/ =~ group }
+          @groups.delete_if { |group| /#{pin_name}/ =~ group }
           @groups << "#{marker} - #{found_pins[0].name} - #{found_pins[0].location}"
         else
           if marker.nil?
-            marker = initial(pinName.to_s)
-            while @groups.index { |grpName| grpName =~ /#{marker} -/ }
+            marker = initial(pin_name.to_s)
+            while @groups.index { |grp_name| grp_name =~ /#{marker} -/ }
               marker.next!
               marker = '0' unless marker.size < 2
             end
           end
-          reg_state = quote_regex(pinName)
+          reg_state = quote_regex(pin_name)
           found_pins.each do |item|
-            begin
-              coordinates = coordinate(item.location)
-              @field[coordinates[0]][coordinates[1]] = [marker + ' ']
-              @groups.delete_if { |group| "#{marker} - \"#{reg_state}\"" == group }
-              @groups << "#{marker} - \"#{pinName}\""
-            rescue
-              raise "\n#{item} doesn't appear to have a physical location in this configuration."
-            end
+            coordinates = coordinate(item.location)
+            @field[coordinates[0]][coordinates[1]] = [marker + ' ']
+            @groups.delete_if { |group| "#{marker} - \"#{reg_state}\"" == group }
+            @groups << "#{marker} - \"#{pin_name}\""
+          rescue
+            raise "\n#{item} doesn't appear to have a physical location in this configuration."
           end
         end
         generate_field
@@ -328,20 +342,20 @@ module Origen
           owner.pins.map { |pin| found_pins << pin[1] if coord == pin[1].location.to_s }
           if marker.nil?
             marker = initial(coord.to_s)
-            while @groups.index { |grpName| grpName =~ /#{marker} -/ }
+            while @groups.index { |grp_name| grp_name =~ /#{marker} -/ }
               marker.next!
               marker = '0' unless marker.size < 2
             end
             found_pins.each do |pin|
               coordinates = coordinate(pin.location)
               @field[coordinates[0]][coordinates[1]] = [marker.white_on_blue + ' ']
-              @groups.delete_if { |group| /#{coord.to_s}/ =~ group }
+              @groups.delete_if { |group| /#{coord}/ =~ group }
               @groups << "#{marker} - #{found_pins[0].name} - #{found_pins[0].location}"
             end
           else
             coordinates = coordinate(found_pins[0].location)
             @field[coordinates[0]][coordinates[1]] = [marker.white_on_blue + ' ']
-            @groups.delete_if { |group| /#{coord.to_s}/ =~ group }
+            @groups.delete_if { |group| /#{coord}/ =~ group }
             @groups << "#{marker} - #{found_pins[0].name} - #{found_pins[0].location}"
           end
           if found_pins.size > 0

--- a/spec/import_and_export_spec.rb
+++ b/spec/import_and_export_spec.rb
@@ -25,7 +25,9 @@ describe "Model import and export" do
 
     def initialize(options = {})
       add_package :bga
-      add_package :pcs
+      add_package :pcs do |package|
+        package.insertion_type = :wafer_sort
+      end
       add_pin :pinx
       add_pin :piny, reset: :drive_hi, direction: :output, meta: { a: "1", b: 2 }
       add_pin :tdo, packages: { bga: { location: 'BF32', dib_assignment: [10104] }, pcs: { location: 'BF30', dib_assignment: [31808] } }
@@ -178,6 +180,14 @@ describe "Model import and export" do
     dut.package = :pcs
     dut.pin(:tdo).location.should == 'BF30'
     dut.pin(:tdo).dib_assignment.should == [31808]
+  end
+
+  it "handles package customization" do
+    load_export_model
+    dut.package = :bga
+    dut.package.insertion_type.should == nil
+    dut.package = :pcs
+    dut.package.insertion_type.should == :wafer_sort
   end
 
   it "handles sub-blocks" do


### PR DESCRIPTION
ChipPackage has examples to edit existing instance variables to the class. Adding in the method_missing handle will allow users to define their new identifiers without updating the core.