### PR TITLE
Allow remotes to disable version prefix; git branch comparator corrected

### DIFF
--- a/lib/origen/revision_control/git.rb
+++ b/lib/origen/revision_control/git.rb
@@ -47,7 +47,9 @@ module Origen
 
         version = options[:version] || current_branch
 
-        if version == 'HEAD'
+        # Not trying to do a VersionString comparison, just determine if the
+        # string literal value of version == HEAD, hence the .to_s call
+        if version.to_s == 'HEAD'
           puts "Sorry, but you are not currently on a branch and I don't know which branch you want to checkout"
           puts 'Please supply a branch name as the version to checkout the latest version of it, e.g. origen rc co -v develop'
           exit 1

--- a/templates/web/guides/misc/remotes.md.erb
+++ b/templates/web/guides/misc/remotes.md.erb
@@ -46,6 +46,12 @@ config.remotes = [
     rc_url: "git@github.com:Origen-SDK/artwork.git",
     version: "master",
     development: true
+  },
+  {
+    dir: "third_party_remote",
+    rc_url: "https://github.com/third-party/remote.git",
+    version: "1.2.3",
+    disable_tag_prefix: true # repo is tagged as 1.2.3, not v1.2.3
   }  
 ]
 ~~~
@@ -57,6 +63,12 @@ remotes defined by an application's plugins, except for those which have been ma
 Setting `development: true`, indicates to Origen that the remote is only required when developing
 the plugin within a standalone workspace, and that it is not required when the plugin is being
 used by a top-level application.
+
+Origen follows the philosophy that version control tags should prepend a 'v' to the semantic version
+to communicate that the following numbers are a semantic version, e.g. 1.2.3 has a git tag of v1.2.3
+(see [SemVer documenation](https://semver.org/#is-v123-a-semantic-version)). However, sometimes you
+do not have control over the tagging conventions another repo is using and need to opt out of the
+tag prefixing. Set `disable_tag_prefix: false` for each remote that needs to query a tag without the leading 'v'.
 
 #### Location
 


### PR DESCRIPTION
Ran into a scenario where I needed to use a remote from a repo controlled by another team. They tag their repo as '1.2.3' not 'v1.2.3', so this update lets remotes disable that prefixing.

Additionally ran into an error where `version == 'HEAD'` was using the VersionString#equal? instead of String#equal?,
which it would fail because it didnt know how to compare the version of 'HEAD', so I forced the string literal comparison with a .to_s call