### PR TITLE
First call to constantize modifies the environment, hiding namespace errors on subsequent references to that class

### DIFF
--- a/lib/origen/sub_blocks.rb
+++ b/lib/origen/sub_blocks.rb
@@ -319,13 +319,9 @@ module Origen
         # Note that override is to recreate an existing sub-block, not adding additional
         # attributes to an existing one
         if options[:override]
-          sub_blocks.delete(name)
+          sub_blocks.delete(name.to_s)
           if options[:class_name]
-            begin
-              constantizable = !!options[:class_name].constantize
-            rescue NameError
-              constantizable = false
-            end
+            constantizable = !!options[:class_name].safe_constantize
             # this is to handle the case where a previously instantiated subblock wont allow
             # the current class name to exist
             # e.g. NamespaceA::B::C


### PR DESCRIPTION
Original implementation was in place to protect against the valid scenario where a class_name was passed in but that file hadn't yet been loaded (e.g. the file would be loaded later during block materialization). If the class name truly didn't exist, it would error during materialization.

However, this unintentionally hid nested name errors. When the constantize method was called, it attempted to load that namespace. The namespace itself was correct, however its containing file was itself including a new module which did contain a namespace error. This was then squashed by the rescue, allowing the object to be created, and the file the user thought was getting included actually wasn't and didn't report the error either.

swapping to safe_constantize method essentially does the same as before, except it'll only squash name errors if the unknown namespace is part of options[:class_name] (which was the original intent).

For anyone curious:
[safe_constantize source](https://github.com/rails/rails/blob/74fceba29e0911f9a72e4a9335842beaaf556c52/activesupport/lib/active_support/inflector/methods.rb#L315)
[constantize source](https://github.com/rails/rails/blob/74fceba29e0911f9a72e4a9335842beaaf556c52/activesupport/lib/active_support/inflector/methods.rb#L289)