### PR TITLE
sub block override bug was leaving old blocks in the list of listeners

### DIFF
--- a/lib/origen/sub_blocks.rb
+++ b/lib/origen/sub_blocks.rb
@@ -319,7 +319,11 @@ module Origen
         # Note that override is to recreate an existing sub-block, not adding additional
         # attributes to an existing one
         if options[:override]
-          sub_blocks.delete(name.to_s)
+          # deregister old block as a listener, as it'll stick around otherwise
+          dynamic_listeners = Origen.app.dynamic_resource(:callback_listeners, [])
+          dynamic_listeners -= [sub_blocks.delete(name.to_s)]
+          Origen.app.set_dynamic_resource(:callback_listeners, dynamic_listeners)
+
           if options[:class_name]
             constantizable = !!options[:class_name].safe_constantize
             # this is to handle the case where a previously instantiated subblock wont allow


### PR DESCRIPTION
I had a bug in my original override feature: the block that was being overwritten was never removed from the listeners. This occurs if you first remotely inherited a block that itself had a sub block, and then needed to override that inherited block's sub block.

Now we remove it from the listeners as we're replacing it with a new block, which will take its place in the listener list