### PR TITLE
Remote block inheritance improvement and lazy block double on_create fix

### DIFF
--- a/lib/origen/callbacks.rb
+++ b/lib/origen/callbacks.rb
@@ -12,7 +12,12 @@ module Origen
       # If this object has been instantiated after on_create has already been called,
       # then invoke it now
       if Origen.app.on_create_called?
-        on_create if respond_to?(:on_create)
+        if respond_to?(:on_create)
+          unless @_on_create_called
+            @_on_create_called = true
+            on_create
+          end
+        end
       end
     end
   end

--- a/lib/origen/model_initializer.rb
+++ b/lib/origen/model_initializer.rb
@@ -68,10 +68,20 @@ module Origen
           if x.try(:is_a_model_and_controller)
             m = x.model
             c = x.controller
-            m.on_create if m.respond_to_directly?(:on_create)
+            if m.respond_to_directly?(:on_create)
+              unless m_on_create_called = m.instance_variable_get(:@_on_create_called)
+                m.instance_variable_set(:@_on_create_called, true)
+                m.on_create
+              end
+            end
             c.on_create if c.respond_to_directly?(:on_create)
           else
-            x.on_create if x.respond_to?(:on_create)
+            if x.respond_to?(:on_create)
+              unless x_on_create_called = x.instance_variable_get(:@_on_create_called)
+                x.instance_variable_set(:@_on_create_called, true)
+                x.on_create
+              end
+            end
           end
         end
         if is_top_level

--- a/lib/origen/sub_blocks.rb
+++ b/lib/origen/sub_blocks.rb
@@ -296,6 +296,10 @@ module Origen
         return sub_block(name.class)
       end
 
+      if sub_blocks[name] && model.instance_variable_get(:@_inherited_sub_blocks_mode)
+        return
+      end
+
       if i = options.delete(:instances)
         # permit creating multiple instances of a particular sub_block class
         # can pass array for base_address, which will be processed above

--- a/spec/sub_block_spec.rb
+++ b/spec/sub_block_spec.rb
@@ -38,6 +38,7 @@ module SubBlocksSpec
       sub_block :sub9, class_name: "Sub7", override: options[:override], inherit: 'SubBlocksSpec::Sub5'
       sub_block :sub10, class_name: "Sub8", override: options[:override], inherit: 'SubBlocksSpec::Sub4', disable_bug_inheritance: true
       sub_block :sub11, class_name: "Sub9", override: options[:override], inherit: 'SubBlocksSpec::Sub5', disable_feature_inheritance: true
+      sub_block :single_create, class_name: "SingleCreate"
 
       sub_block_group :subgroups, class_name: "SubBlocksSpec::Subs" do
         sub_block :subitem0, class_name: "SubItem0", base_address: 0x000, some_attr: "There are two kinds of people"
@@ -150,7 +151,19 @@ module SubBlocksSpec
     end
   end
 
+  class SingleCreate
+    include Origen::Model
 
+    attr_accessor :counter
+
+    def initialize
+      @counter = 0
+    end
+
+    def on_create
+      @counter += 1
+    end
+  end
 
   class Subs < ::Array
     def <<(sub_block)
@@ -721,6 +734,15 @@ module SubBlocksSpec
           m.blah.is_a?(Origen::SubBlock).should == true
           m.sub_block[:blah].is_a?(Origen::SubBlock).should == true
           m.sub_blocks[:blah].is_a?(Origen::SubBlock).should == true
+        end
+
+        it 'only calls on_create once' do
+          Origen.app.unload_target!
+          Origen.target.temporary = lambda do
+            $single_create_dut = Top.new(override: override_setting)
+          end
+          Origen.load_target
+          $single_create_dut.single_create.counter.should == 1
         end
 
         describe 'sub_block inheritance' do 


### PR DESCRIPTION
For remote inheritance there was a couple issues:
* remote blocks' sub blocks ended up getting double instantiated. This was at the time handled via override feature that would throw away the block and replace it later, but this was causing issues when the instantiation was editing data structures external to the block itself.
    * Now when the remote block files are inherited, it first delays handling the remote sub_blocks.rb file until after the current block is fully booted. Then, when parsing the remote sub_blocks.rb, any sub_block that already exists for the current block is skipped.
* bugs and features weren't correctly propagating with lazy loading if those bugs/features were sourced from the remote blocks ancestors
    * remote inheritance now sources the remote blocks ancestry chain to collect all features and bugs. Priority is given to the closest ancestor if a conflict were to occur.

Additionally, lazily loaded blocks that were instantiated after the typical on_create hook call would end up calling on_create twice (once via register_callback and again via model_initializer).
* Now if either of those points call on_create, the object will set an instance variable to signal that it has been called and skip the call on the next encounter.