### PR TITLE
locking json gem to 2.10.x as 2.11.x introduced a breaking change to JSON.pretty_generate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'origen_debuggers', '~> 0'
 gem 'ripper-tags'
 # gem 'nokogiri', '1.10.10'  # Lock to this version to enable testing in Ruby 2.2
 gem 'nokogiri', '1.13.10' # Locking to this version to support Ruby 2.6. Will update in a later release
+#  (Can't lock json via ~> as different ruby versions require different json gem versions)
+gem 'json', '< 2.11.0' # Locking to this version to pre 2.11 as a breaking change was introduced register's to_json call as it interacts with JSON.pretty_generate
 
 # Plugins that provide guide pages
 gem "origen_testers", git: "https://github.com/Origen-SDK/origen_testers.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    json (2.7.2)
+    json (2.10.2)
     kramdown (2.4.0)
       rexml
     loco (0.0.7)
@@ -231,6 +231,7 @@ PLATFORMS
 DEPENDENCIES
   byebug (~> 11)
   coveralls
+  json (< 2.11.0)
   loco
   nokogiri (= 1.13.10)
   origen!


### PR DESCRIPTION
json 2.11 was released earlier this week which is causing the failure, I dug a bit into the registers to_json call but wasn't able to figure it out just yet so locking it down for now.