### PR TITLE
Initial ruby 3.4 support

### DIFF
--- a/lib/origen.rb
+++ b/lib/origen.rb
@@ -31,6 +31,7 @@ unless defined? RGen::ORIGENTRANSITION
   require 'bundler'
   require 'origen/undefined'
   require 'origen/componentable'
+  require 'base64'
 
   autoload :PatSeq, 'origen/generator/pattern_sequencer'
 

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -29,13 +29,14 @@ Gem::Specification.new do |spec|
   # based on Ruby version.
   # Rubygems / Bundler do not support this and you will need to find another way around it.
   spec.add_runtime_dependency "activesupport", "~>4.1"
+  spec.add_runtime_dependency "base64", '~>0'
   spec.add_runtime_dependency "colored", "~>1.2"
   spec.add_runtime_dependency "net-ldap", "~>0.13"
   spec.add_runtime_dependency "httparty", "~>0.13"
   spec.add_runtime_dependency "bundler", ">1.7"
   spec.add_runtime_dependency "rspec", "~>3"
   spec.add_runtime_dependency "rspec-legacy_formatters", "~>1"
-  spec.add_runtime_dependency "thor", "~>0.19"
+  spec.add_runtime_dependency "thor", "~>1"
   spec.add_runtime_dependency "nanoc", "~>3.7.0"
   spec.add_runtime_dependency "kramdown", "~>2.4"
   spec.add_runtime_dependency "rubocop", "1.28"


### PR DESCRIPTION
Hi everyone,

We've been using Origen with 2.7 and 3.1 and I've recently looked into supporting 3.4 (we have 3.4.2 specifically).

I tried to find what the minimum changes would be to get Origen to boot up and run in our applications with 3.4. Doesn't look like there's much, and I've not noticed any problems with these changes in 2.7 or 3.1.

1. The new `thor` version is needed to run `origen new`.
2. The LDAP was the first thing I encountered that needed `base64` required beforehand (but there could be more), otherwise Origen won't boot. This is part of 2.7 already, but I haven't noticed any problems including it. I had it installed globally 3.1, which was fine, but 3.4 seems to also need it `required` earlier on. Could be an underlying library change that was including it was updated (I didn't fully backtrack it), but it seemed easy enough and safe to have it be part of Origen.

With these, I'm able to run some basic generations and simulations in our apps. More might pop up, but I'd like to get a release out for the minimum I've seen before, install it globally so our apps at least boot, then see if anything else comes up once others start using it.

Various deprecation warnings will pop up, and I also had Bundler 4.0.2 trialed, which has some ugly 'warnings-as-errors' but these aren't needed to just get our apps working, which was the focus for now.