### PR TITLE
Add Error Assistant LLM integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "origen_sim", git: "https://github.com/Origen-SDK/origen_sim.git"
 
 # Required to run the concurrent test case patterns from OrigenSim
 gem 'origen_jtag'
+gem 'origen_llm', "~>0.1.2"
 
 # Pull in the latest and greatest app generator templates so that they can be
 # packaged into Origen releases

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "origen_sim", git: "https://github.com/Origen-SDK/origen_sim.git"
 
 # Required to run the concurrent test case patterns from OrigenSim
 gem 'origen_jtag'
-gem 'origen_llm', "~>0.1.2"
+gem 'origen_llm', "~>0.1.4"
 
 # Pull in the latest and greatest app generator templates so that they can be
 # packaged into Origen releases

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,18 +15,18 @@ GIT
 
 GIT
   remote: https://github.com/Origen-SDK/origen_sim.git
-  revision: a3fb3e32bad2873a8234d1517f604c21f30fa31d
+  revision: dc0e5fccbfeeb4197565a3fbfe310f389b4f9cd0
   specs:
-    origen_sim (0.20.7)
+    origen_sim (0.21.0)
       origen (>= 0.44.0)
       origen_testers (>= 0.21.0)
-      origen_verilog (>= 0.6.2)
+      origen_verilog (>= 0.6.3)
 
 GIT
   remote: https://github.com/Origen-SDK/origen_testers.git
-  revision: f0c1be3a5cb605be505cc39b09a8eb28f4eacde8
+  revision: 9b395246f183749db32c1e29e2f2b6e9d7c37037
   specs:
-    origen_testers (0.52.5)
+    origen_testers (0.52.15)
       ast (~> 2)
       atp (~> 1.1, >= 1.1.3)
       dentaku (~> 3)
@@ -58,6 +58,7 @@ PATH
       nanoc (~> 3.7.0)
       net-ldap (~> 0.13)
       nokogiri (>= 1.11.0)
+      origen_llm (~> 0.1.4)
       pry (~> 0.10)
       rake (~> 10)
       rspec (~> 3)
@@ -77,19 +78,19 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    ast (2.4.2)
+    ast (2.4.3)
     atp (1.1.3)
       ast (~> 2)
       origen (>= 0.2.3)
       sexpistol (~> 0.0)
     base64 (0.3.0)
-    bigdecimal (3.1.8)
+    bigdecimal (4.0.1)
     builder (3.3.0)
     byebug (11.1.3)
     coderay (1.1.3)
     colored (1.2)
     colorize (0.8.1)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.6)
     coveralls (0.7.1)
       multi_json (~> 1.3)
       rest-client
@@ -97,33 +98,36 @@ GEM
       term-ansicolor
       thor
     cri (2.15.12)
-    dentaku (3.5.3)
+    dentaku (3.5.7)
+      bigdecimal
       concurrent-ruby
-    diff-lcs (1.5.1)
-    docile (1.4.0)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     gems (0.8.3)
     highline (1.7.10)
     http-accept (1.7.0)
-    http-cookie (1.0.6)
+    http-cookie (1.1.0)
       domain_name (~> 0.5)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    json (2.7.2)
-    kramdown (2.4.0)
-      rexml
+    io-console (0.8.2)
+    json (2.7.6)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     loco (0.0.7)
+    logger (1.7.0)
     method_source (1.1.0)
-    mime-types (3.5.2)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0702)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0203)
     mini_mime (1.1.5)
-    minitest (5.24.1)
-    mize (0.5.0)
+    minitest (5.25.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     nanoc (3.7.5)
@@ -140,9 +144,7 @@ GEM
     origen_jtag (0.22.3)
       origen (~> 0.7, >= 0.7.35)
       origen_testers (>= 0.13.2)
-    origen_llm (0.1.2)
-      origen (>= 0.60.20)
-      origen_app_generators (>= 2.2.0)
+    origen_llm (0.1.4)
     origen_stil (0.3.0)
       ast (~> 2)
       origen (>= 0.33.3)
@@ -152,44 +154,46 @@ GEM
       origen (>= 0.41.0)
       treetop
     parallel (1.24.0)
-    parser (3.3.4.0)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
     polyglot (0.3.5)
-    pry (0.14.2)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.8.0)
+      reline (>= 0.6.0)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (10.5.0)
-    regexp_parser (2.9.2)
+    regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
     require_all (1.5.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.3.2)
-      strscan
+    rexml (3.4.4)
     ripper-tags (1.0.2)
     rodf (1.2.0)
       builder (>= 3.0)
       rubyzip (>= 1.0)
-    rspec (3.13.0)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-legacy_formatters (1.0.2)
       rspec (~> 3.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.7)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.7)
     rubocop (1.28.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -202,7 +206,7 @@ GEM
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     scrub_rb (1.0.1)
     sexpistol (0.0.7)
     simplecov (0.17.1)
@@ -210,25 +214,21 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    strscan (3.1.0)
     sync (0.5.0)
-    term-ansicolor (1.10.4)
-      mize (~> 0.5)
-      tins (~> 1.0)
+    term-ansicolor (1.11.3)
+      tins (~> 1)
     thor (1.5.0)
     thread_safe (0.3.6)
-    tins (1.33.0)
+    tins (1.43.0)
       bigdecimal
       sync
-    treetop (1.6.12)
+    treetop (1.6.18)
       polyglot (~> 0.3)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.9.1)
-    unicode-display_width (2.5.0)
-    yard (0.9.36)
+    unf (0.2.0)
+    unicode-display_width (2.6.0)
+    yard (0.9.38)
 
 PLATFORMS
   x86_64-linux
@@ -244,10 +244,10 @@ DEPENDENCIES
   origen_debuggers (~> 0)
   origen_doc_helpers
   origen_jtag
-  origen_llm (~> 0.1.2)
+  origen_llm (~> 0.1.4)
   origen_sim!
   origen_testers!
   ripper-tags
 
 BUNDLED WITH
-   2.4.22
+   2.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ PATH
   specs:
     origen (0.60.20)
       activesupport (~> 4.1)
+      base64 (~> 0)
       bundler (> 1.7)
       coderay (~> 1.1)
       colored (~> 1.2)
@@ -65,7 +66,7 @@ PATH
       scrub_rb (~> 1.0)
       simplecov (~> 0.17)
       simplecov-html (~> 0.10)
-      thor (~> 0.19)
+      thor (~> 1)
       yard (~> 0.8)
 
 GEM
@@ -81,6 +82,7 @@ GEM
       ast (~> 2)
       origen (>= 0.2.3)
       sexpistol (~> 0.0)
+    base64 (0.3.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
     byebug (11.1.3)
@@ -138,6 +140,9 @@ GEM
     origen_jtag (0.22.3)
       origen (~> 0.7, >= 0.7.35)
       origen_testers (>= 0.13.2)
+    origen_llm (0.1.2)
+      origen (>= 0.60.20)
+      origen_app_generators (>= 2.2.0)
     origen_stil (0.3.0)
       ast (~> 2)
       origen (>= 0.33.3)
@@ -210,7 +215,7 @@ GEM
     term-ansicolor (1.10.4)
       mize (~> 0.5)
       tins (~> 1.0)
-    thor (0.20.3)
+    thor (1.5.0)
     thread_safe (0.3.6)
     tins (1.33.0)
       bigdecimal
@@ -239,6 +244,7 @@ DEPENDENCIES
   origen_debuggers (~> 0)
   origen_doc_helpers
   origen_jtag
+  origen_llm (~> 0.1.2)
   origen_sim!
   origen_testers!
   ripper-tags

--- a/lib/origen/application.rb
+++ b/lib/origen/application.rb
@@ -25,6 +25,7 @@ module Origen
 
     attr_writer :name                       # attr_accessor leads to a duplicate method
     attr_writer :namespace                  # attr_accessor leads to a duplicate method
+    attr_accessor :error_assistant_enable
 
     class << self
       def inherited(base)

--- a/lib/origen/boot.rb
+++ b/lib/origen/boot.rb
@@ -266,6 +266,8 @@ rescue Exception => e
   else
     puts
     if Origen.app_loaded?
+      require 'origen/error_assistant'
+
       puts 'COMPLETE CALL STACK'
       puts '-------------------'
       puts e.message unless e.is_a?(SystemExit)
@@ -277,15 +279,33 @@ rescue Exception => e
       puts e.message unless e.is_a?(SystemExit)
       # Only print out the application stack trace by default, if verbose logging is
       # enabled then output the full thing
+      application_stack_lines = []
       e.backtrace.each do |line|
         path = Pathname.new(line)
         if path.absolute?
           if line =~ /^#{Origen.root}/ && line !~ /^#{Origen.root}\/lbin/
+            application_stack_lines << line
             puts line
           end
         else
-          puts line unless line =~ /^.\/lbin/
+          unless line =~ /^.\/lbin/
+            application_stack_lines << line
+            puts line
+          end
         end
+      end
+
+      assistant_suggestion = Origen::ErrorAssistant.analyze(
+        exception_message: e.message.to_s,
+        app_stack:         application_stack_lines,
+        app_root:          Origen.root
+      )
+
+      if assistant_suggestion
+        puts
+        puts "POTENTIAL SOLUTION (#{Origen::ErrorAssistant.display_name})"
+        puts '-------------------------------'
+        puts assistant_suggestion
       end
     else
       puts 'COMPLETE CALL STACK'

--- a/lib/origen/error_assistant.rb
+++ b/lib/origen/error_assistant.rb
@@ -1,0 +1,133 @@
+require 'timeout'
+
+module Origen
+  module ErrorAssistant
+    module_function
+
+    DEFAULT_TIMEOUT_SECONDS = 3.0
+    DEFAULT_SITE_MODE = 'off'
+    DEFAULT_PROMPT_MODE = 'default'
+    DEFAULT_DISPLAY_NAME = 'Error Assistant'
+    VALID_SITE_MODES = %w(off opt_in forced).freeze
+    VALID_PROMPT_MODES = %w(default site_template backend_profile).freeze
+
+    def site_mode
+      raw = Origen.site_config.error_assistant_mode.to_s.strip.downcase
+      VALID_SITE_MODES.include?(raw) ? raw : DEFAULT_SITE_MODE
+    rescue
+      DEFAULT_SITE_MODE
+    end
+
+    def app_enable_value
+      return nil unless Origen.app_loaded?
+      return nil unless Origen.app.respond_to?(:error_assistant_enable)
+
+      Origen.app.error_assistant_enable
+    rescue
+      nil
+    end
+
+    def enabled?
+      case site_mode
+      when 'off'
+        false
+      when 'forced'
+        true
+      when 'opt_in'
+        app_enable_value == true
+      else
+        false
+      end
+    end
+
+    def timeout_seconds
+      raw = Origen.site_config.error_assistant_timeout_seconds
+      val = raw.nil? ? DEFAULT_TIMEOUT_SECONDS : raw.to_f
+      val.positive? ? val : DEFAULT_TIMEOUT_SECONDS
+    rescue
+      DEFAULT_TIMEOUT_SECONDS
+    end
+
+    def warning_enabled?
+      val = Origen.site_config.error_assistant_warning_enable
+      val.nil? ? true : val == true
+    rescue
+      true
+    end
+
+    def prompt_mode
+      raw = Origen.site_config.error_assistant_prompt_mode.to_s.strip.downcase
+      VALID_PROMPT_MODES.include?(raw) ? raw : DEFAULT_PROMPT_MODE
+    rescue
+      DEFAULT_PROMPT_MODE
+    end
+
+    def display_name
+      val = Origen.site_config.error_assistant_friendly_name
+      v = val.to_s.strip
+      v.empty? ? DEFAULT_DISPLAY_NAME : v
+    rescue
+      DEFAULT_DISPLAY_NAME
+    end
+
+    def provider_available?
+      ensure_provider_loaded
+      defined?(::OrigenLlm::ErrorAssistant) && ::OrigenLlm::ErrorAssistant.respond_to?(:analyze)
+    end
+
+    def analyze(exception_message:, app_stack:, app_root:)
+      return nil unless enabled?
+      return nil unless provider_available?
+
+      context = {
+        app_root:         app_root.to_s,
+        timeout_seconds:  timeout_seconds,
+        provider_mode:    Origen.site_config.error_assistant_provider_mode,
+        model:            Origen.site_config.error_assistant_model,
+        max_tokens:       Origen.site_config.error_assistant_max_tokens,
+        temperature:      Origen.site_config.error_assistant_temperature,
+        api_url:          Origen.site_config.error_assistant_api_url,
+        api_key_env:      Origen.site_config.error_assistant_api_key_env,
+        auth_mode:        Origen.site_config.error_assistant_auth_mode,
+        auth_header_name: Origen.site_config.error_assistant_auth_header_name,
+        auth_prefix:      Origen.site_config.error_assistant_auth_prefix,
+        extra_headers:    Origen.site_config.error_assistant_extra_headers,
+        prompt_mode:      prompt_mode,
+        prompt_template:  Origen.site_config.error_assistant_prompt_template,
+        backend_profile:  Origen.site_config.error_assistant_backend_profile,
+        backend_context:  Origen.site_config.error_assistant_backend_context
+      }
+
+      result = Timeout.timeout(timeout_seconds) do
+        ::OrigenLlm::ErrorAssistant.analyze(
+          exception_message: exception_message,
+          app_stack:         app_stack,
+          context:           context
+        )
+      end
+
+      result.is_a?(String) && !result.strip.empty? ? result.strip : nil
+    rescue Timeout::Error
+      warn("#{display_name} timed out after #{timeout_seconds}s")
+      nil
+    rescue => e
+      warn("#{display_name} failed: #{e.class}: #{e.message}")
+      nil
+    end
+
+    def warn(message)
+      Origen.log.warn(message) if warning_enabled?
+    end
+    private_class_method :warn
+
+    def ensure_provider_loaded
+      return if @provider_load_attempted
+
+      @provider_load_attempted = true
+      require 'origen_llm'
+    rescue LoadError
+      nil
+    end
+    private_class_method :ensure_provider_loaded
+  end
+end

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -54,5 +54,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri', '>= 1.11.0'
   #spec.add_runtime_dependency 'cri', '~>2.10.0' # Not required by Origen, but add constrain to avoid Ruby 2.3 requirement
   spec.add_runtime_dependency 'concurrent-ruby'
-  spec.add_runtime_dependency 'origen_llm', '~>0.1.2'
+  spec.add_runtime_dependency 'origen_llm', '~>0.1.4'
 end

--- a/origen.gemspec
+++ b/origen.gemspec
@@ -54,4 +54,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri', '>= 1.11.0'
   #spec.add_runtime_dependency 'cri', '~>2.10.0' # Not required by Origen, but add constrain to avoid Ruby 2.3 requirement
   spec.add_runtime_dependency 'concurrent-ruby'
+  spec.add_runtime_dependency 'origen_llm', '~>0.1.2'
 end

--- a/origen_site_config.yml
+++ b/origen_site_config.yml
@@ -156,3 +156,33 @@ gem_use_from_system:
 
 # lsf_debug is needed for spec tests on the core.
 lsf_debug: 'false'
+
+# ERROR ASSISTANT
+#
+# The error assistant can analyze application stack traces and provide a potential fix.
+# It is disabled by default.
+error_assistant_mode: off # valid: off , opt_in, forced. check spec test for more details
+error_assistant_timeout_seconds: 3
+error_assistant_provider_mode: generic
+error_assistant_auth_mode: x_api_key
+error_assistant_prompt_mode: default
+error_assistant_warning_enable: true
+error_assistant_friendly_name: Origen-AI
+
+# Optional settings for backend integration:
+#error_assistant_api_url: "https://ai-backend.example.com/origen/assistant"
+#error_assistant_model: "gpt-4.1-mini"
+#error_assistant_max_tokens: 200
+#error_assistant_temperature: 0.7
+#error_assistant_api_key_env: "ORIGEN_LLM_API_KEY"
+#error_assistant_auth_header_name: "X-API-Key"
+#error_assistant_auth_prefix: "Bearer "
+#error_assistant_extra_headers: {}
+#error_assistant_prompt_template: |
+#  Diagnose this Origen error and propose the safest fix.
+#  Exception: %{exception_message}
+#  App stack:
+#  %{application_stack}
+#error_assistant_backend_profile: "origen_assistant"
+#error_assistant_backend_context:
+#  framework: "Origen-SDK"

--- a/spec/error_assistant_spec.rb
+++ b/spec/error_assistant_spec.rb
@@ -1,0 +1,164 @@
+require 'rspec/core/version'
+require 'etc'
+module RSpec
+  Version = Core::Version unless const_defined?(:Version)
+end
+require 'spec_helper'
+require_relative '../lib/origen/error_assistant'
+
+describe Origen::ErrorAssistant do
+  SITE_KEYS = %w[
+    error_assistant_mode
+    error_assistant_timeout_seconds
+    error_assistant_warning_enable
+    error_assistant_friendly_name
+    error_assistant_prompt_mode
+    error_assistant_prompt_template
+    error_assistant_backend_profile
+    error_assistant_backend_context
+    error_assistant_api_url
+    error_assistant_provider_mode
+    error_assistant_api_key_env
+    error_assistant_auth_mode
+    error_assistant_auth_header_name
+    error_assistant_auth_prefix
+    error_assistant_extra_headers
+    error_assistant_model
+    error_assistant_max_tokens
+    error_assistant_temperature
+  ].freeze
+
+  def reset_site_keys
+    SITE_KEYS.each { |k| Origen.site_config.remove_all_instances(k) }
+  end
+
+  before :each do
+    reset_site_keys
+    Origen.app.error_assistant_enable = nil if Origen.app.respond_to?(:error_assistant_enable=)
+    Origen::ErrorAssistant.instance_variable_set(:@provider_load_attempted, nil)
+  end
+
+  it 'applies mode precedence for off/forced/opt_in' do
+    Origen.site_config.add_as_highest('error_assistant_mode', 'off')
+    Origen.app.error_assistant_enable = true
+    expect(Origen::ErrorAssistant.enabled?).to eq(false)
+
+    Origen.site_config.add_as_highest('error_assistant_mode', 'forced')
+    Origen.app.error_assistant_enable = false
+    expect(Origen::ErrorAssistant.enabled?).to eq(true)
+
+    Origen.site_config.add_as_highest('error_assistant_mode', 'opt_in')
+    Origen.app.error_assistant_enable = true
+    expect(Origen::ErrorAssistant.enabled?).to eq(true)
+    Origen.app.error_assistant_enable = false
+    expect(Origen::ErrorAssistant.enabled?).to eq(false)
+  end
+
+  it 'falls back display name when friendly name missing' do
+    expect(Origen::ErrorAssistant.display_name).to eq('Error Assistant')
+    Origen.site_config.add_as_highest('error_assistant_friendly_name', 'Origen-AI')
+    expect(Origen::ErrorAssistant.display_name).to eq('Origen-AI')
+  end
+
+  it 'times out best effort and returns nil' do
+    Origen.site_config.add_as_highest('error_assistant_mode', 'forced')
+    Origen.site_config.add_as_highest('error_assistant_timeout_seconds', 0.01)
+
+    stub_const('OrigenLlm::ErrorAssistant', Module.new do
+      def self.analyze(exception_message:, app_stack:, context:)
+        sleep 0.1
+        'late answer'
+      end
+    end)
+
+    result = Origen::ErrorAssistant.analyze(
+      exception_message: 'boom',
+      app_stack: ['/tmp/app.rb:1'],
+      app_root: Origen.root
+    )
+    expect(result).to eq(nil)
+  end
+
+  it 'passes site config settings into plugin context' do
+    Origen.site_config.add_as_highest('error_assistant_mode', 'forced')
+    Origen.site_config.add_as_highest('error_assistant_api_url', 'https://example.ai/assistant')
+    Origen.site_config.add_as_highest('error_assistant_provider_mode', 'generic')
+    Origen.site_config.add_as_highest('error_assistant_model', 'test-model')
+    Origen.site_config.add_as_highest('error_assistant_max_tokens', 321)
+    Origen.site_config.add_as_highest('error_assistant_temperature', 0.9)
+    Origen.site_config.add_as_highest('error_assistant_api_key_env', 'ORIGEN_TEST_KEY')
+    Origen.site_config.add_as_highest('error_assistant_auth_mode', 'x_api_key')
+    Origen.site_config.add_as_highest('error_assistant_auth_header_name', 'X-API-Key')
+    Origen.site_config.add_as_highest('error_assistant_prompt_mode', 'backend_profile')
+    Origen.site_config.add_as_highest('error_assistant_backend_profile', 'origen_assistant')
+    Origen.site_config.add_as_highest('error_assistant_backend_context', { 'framework' => 'origen' })
+    ENV['ORIGEN_TEST_KEY'] = 'secret'
+
+    captured_context = nil
+    stub_const('OrigenLlm::ErrorAssistant', Module.new do
+      define_singleton_method(:analyze) do |exception_message:, app_stack:, context:|
+        captured_context = context
+        'suggestion'
+      end
+    end)
+
+    result = Origen::ErrorAssistant.analyze(
+      exception_message: 'boom',
+      app_stack: ['/tmp/app.rb:1'],
+      app_root: Origen.root
+    )
+
+    expect(result).to eq('suggestion')
+    expect(captured_context[:api_url]).to eq('https://example.ai/assistant')
+    expect(captured_context[:provider_mode]).to eq('generic')
+    expect(captured_context[:model]).to eq('test-model')
+    expect(captured_context[:max_tokens]).to eq(321)
+    expect(captured_context[:temperature]).to eq(0.9)
+    expect(captured_context[:api_key_env]).to eq('ORIGEN_TEST_KEY')
+    expect(captured_context[:auth_mode]).to eq('x_api_key')
+    expect(captured_context[:auth_header_name]).to eq('X-API-Key')
+    expect(captured_context[:prompt_mode]).to eq('backend_profile')
+    expect(captured_context[:backend_profile]).to eq('origen_assistant')
+    expect(captured_context[:backend_context]).to eq({ 'framework' => 'origen' })
+  ensure
+    ENV['ORIGEN_TEST_KEY'] = nil
+  end
+
+  it 'live test: raises and requests a real solution (manual)', :manual do
+    unless ENV['RUN_LIVE_ERROR_ASSISTANT'] == '1'
+      skip 'Set RUN_LIVE_ERROR_ASSISTANT=1 to run live endpoint test'
+    end
+
+    Origen.site_config.add_as_highest('error_assistant_mode', 'forced')
+    Origen.site_config.add_as_highest('error_assistant_timeout_seconds', (ENV['ERROR_ASSISTANT_TIMEOUT_SECONDS'] || '60').to_f)
+    Origen.site_config.add_as_highest('error_assistant_provider_mode', ENV['ERROR_ASSISTANT_PROVIDER_MODE'] || 'anthropic_messages')
+    Origen.site_config.add_as_highest('error_assistant_api_url', ENV['ERROR_ASSISTANT_API_URL'] || 'http://llm-gateway-url')
+    Origen.site_config.add_as_highest('error_assistant_model', ENV['ERROR_ASSISTANT_MODEL'] || 'claude-sonnet-4')
+    Origen.site_config.add_as_highest('error_assistant_max_tokens', (ENV['ERROR_ASSISTANT_MAX_TOKENS'] || '200').to_i)
+    Origen.site_config.add_as_highest('error_assistant_temperature', (ENV['ERROR_ASSISTANT_TEMPERATURE'] || '0.7').to_f)
+    Origen.site_config.add_as_highest('error_assistant_auth_mode', 'ocp_apim_subscription_key')
+    Origen.site_config.add_as_highest('error_assistant_api_key_env', ENV['ERROR_ASSISTANT_API_KEY_ENV'] || 'LLM_GATEWAY_KEY')
+    Origen.site_config.add_as_highest('error_assistant_extra_headers', {
+      'anthropic-version' => (ENV['ERROR_ASSISTANT_ANTHROPIC_VERSION'] || '2025-10-16'),
+      'user' => (ENV['ERROR_ASSISTANT_USER'] || Etc.getlogin.to_s)
+    })
+
+    begin
+      raise 'Live test exception for Error Assistant'
+    rescue RuntimeError => e
+      result = Origen::ErrorAssistant.analyze(
+        exception_message: e.message,
+        app_stack: Array(e.backtrace),
+        app_root: Origen.root
+      )
+
+      if result.nil? || result.strip.empty?
+        fail 'Live test did not return a solution. Check endpoint/auth/payload compatibility.'
+      end
+
+      puts "\n[#{Origen::ErrorAssistant.display_name} Response]\n#{result}\n"
+      expect(result).to be_a(String)
+      expect(result.strip).to_not eq('')
+    end
+  end
+end

--- a/templates/web/guides/misc/errorassistant.md.erb
+++ b/templates/web/guides/misc/errorassistant.md.erb
@@ -1,0 +1,205 @@
+% render "layouts/guides.html" do
+
+The Error Assistant is an AI-powered diagnostic tool that analyzes runtime exceptions and provides suggestions to help you resolve errors more quickly.
+
+When enabled, the Error Assistant automatically analyzes exceptions when they occur, providing:
+
+- Most likely root cause (1-2 sentences)
+- Suggested fix steps (up to 5 actionable items)
+- Confidence level (low/medium/high)
+
+#### Configuration Modes
+
+The Error Assistant supports three site configuration modes controlled by `error_assistant_mode` in your site config:
+
+**Off** (default) - Error Assistant is disabled:
+
+~~~yaml
+error_assistant_mode: 'off'
+~~~
+
+**Opt-in** - Applications can individually enable the Error Assistant:
+
+~~~yaml
+error_assistant_mode: 'opt_in'
+~~~
+
+When in opt-in mode, individual applications enable the Error Assistant by setting `error_assistant_enable` in their application config:
+
+~~~ruby
+config.error_assistant_enable = true
+~~~
+
+**Forced** - Error Assistant is enabled for all applications:
+
+~~~yaml
+error_assistant_mode: 'forced'
+~~~
+
+#### Backend Configuration
+
+The Error Assistant requires connection to an LLM backend. Two provider modes are supported:
+
+**Generic Backend** (default) - Connect to any API that accepts error analysis requests:
+
+~~~yaml
+error_assistant_provider_mode: 'generic'
+error_assistant_api_url: 'https://your-backend.example.com/analyze'
+error_assistant_api_key_env: 'YOUR_API_KEY_ENV_VAR'
+~~~
+
+**Anthropic Messages API** - Connect directly to Anthropic's Claude API:
+
+~~~yaml
+error_assistant_provider_mode: 'anthropic_messages'
+error_assistant_api_url: 'https://api.anthropic.com'
+error_assistant_model: 'claude-3-5-sonnet-20241022'
+error_assistant_api_key_env: 'ANTHROPIC_API_KEY'
+~~~
+
+#### Authentication Modes
+
+The Error Assistant supports multiple authentication schemes via `error_assistant_auth_mode`:
+
+**X-API-Key** (default) - Uses a custom API key header:
+
+~~~yaml
+error_assistant_auth_mode: 'x_api_key'
+error_assistant_auth_header_name: 'X-API-Key'  # Optional, defaults to 'X-API-Key'
+~~~
+
+**Bearer Token** - Uses Authorization header with Bearer token:
+
+~~~yaml
+error_assistant_auth_mode: 'bearer'
+error_assistant_auth_header_name: 'Authorization'  # Optional, defaults to 'Authorization'
+error_assistant_auth_prefix: 'Bearer '             # Optional, defaults to 'Bearer '
+~~~
+
+**OCP-APIM-Subscription-Key** - Uses Azure API Management subscription key:
+
+~~~yaml
+error_assistant_auth_mode: 'ocp_apim_subscription_key'
+error_assistant_auth_header_name: 'Ocp-Apim-Subscription-Key'  # Optional
+~~~
+
+**None** - No authentication:
+
+~~~yaml
+error_assistant_auth_mode: 'none'
+~~~
+
+#### Additional Configuration Options
+
+**Timeout** - Maximum time to wait for analysis (default: 3.0 seconds):
+
+~~~yaml
+error_assistant_timeout_seconds: 5.0
+~~~
+
+**Model Parameters** (for Anthropic mode or compatible backends):
+
+~~~yaml
+error_assistant_model: 'claude-3-5-sonnet-20241022'
+error_assistant_max_tokens: 200
+error_assistant_temperature: 0.2
+~~~
+
+**Custom Headers** - Add extra headers to API requests:
+
+~~~yaml
+error_assistant_extra_headers:
+  X-Custom-Header: 'value'
+  Another-Header: 'another-value'
+~~~
+
+**Display Name** - Customize the name shown in messages (default: "Error Assistant"):
+
+~~~yaml
+error_assistant_friendly_name: 'Origen-AI'
+~~~
+
+**Warning Messages** - Control whether timeout/error warnings are displayed (default: true):
+
+~~~yaml
+error_assistant_warning_enable: false
+~~~
+
+#### Prompt Customization
+
+The Error Assistant supports multiple prompt modes via `error_assistant_prompt_mode`:
+
+**Default** - Uses built-in prompt template:
+
+~~~yaml
+error_assistant_prompt_mode: 'default'
+~~~
+
+**Site Template** - Use a custom prompt template with placeholders:
+
+~~~yaml
+error_assistant_prompt_mode: 'site_template'
+error_assistant_prompt_template: |
+  Diagnose this error:
+  Exception: %<exception_message>s
+  Stack: %<application_stack>s
+~~~
+
+**Backend Profile** - Use backend-managed profiles (for compatible backends):
+
+~~~yaml
+error_assistant_prompt_mode: 'backend_profile'
+error_assistant_backend_profile: 'profile-id-123'
+error_assistant_backend_context:
+  custom_key: 'custom_value'
+~~~
+
+#### Example Complete Configuration
+
+Here's a complete example configuration using Anthropic's API:
+
+~~~yaml
+# Enable for all applications
+error_assistant_mode: 'forced'
+
+# Anthropic Messages API configuration
+error_assistant_provider_mode: 'anthropic_messages'
+error_assistant_api_url: 'https://api.anthropic.com'
+error_assistant_model: 'claude-3-5-sonnet-20241022'
+error_assistant_max_tokens: 300
+error_assistant_temperature: 0.2
+
+# Authentication
+error_assistant_auth_mode: 'x_api_key'
+error_assistant_auth_header_name: 'x-api-key'
+error_assistant_api_key_env: 'ANTHROPIC_API_KEY'
+
+# Additional headers
+error_assistant_extra_headers:
+  anthropic-version: '2023-06-01'
+
+# Behavior
+error_assistant_timeout_seconds: 5.0
+error_assistant_friendly_name: 'Origen AI Assistant'
+error_assistant_warning_enable: true
+error_assistant_prompt_mode: 'default'
+~~~
+
+#### Requirements
+
+The Error Assistant functionality is provided by the `origen_llm` plugin. To use the Error Assistant:
+
+1. Add `origen_llm` to your application's dependencies
+2. Configure the site settings as shown above
+3. Set your API key environment variable (e.g., `ANTHROPIC_API_KEY`)
+
+When an exception occurs, the Error Assistant will automatically analyze it and display helpful suggestions in the error output.
+
+#### Security Considerations
+
+- API keys should be stored in environment variables, never committed to version control
+- The Error Assistant sends exception messages and application stack traces to the configured backend
+- Timeout values prevent the Error Assistant from blocking your application if the backend is slow
+- All communication is non-blocking; failures will log warnings but won't prevent your application from running
+
+% end

--- a/templates/web/layouts/_guides.html.erb
+++ b/templates/web/layouts/_guides.html.erb
@@ -101,6 +101,7 @@ title: Origen - Guides
 %   section.page :utilities, heading: "Utilities & Helpers"
 %   section.page :coreext, heading: "Ruby Extensions"
 %   section.page :logger, heading: "Logger"
+%   section.page :errorassistant, heading: "Error Assistant"
 %   section.page :commands, heading: "Adding Commands"
 %   section.page :commandsov, heading: "Overriding Commands"
 %   section.page :callbacks, heading: "Callbacks"


### PR DESCRIPTION
Origen::ErrorAssistant
  applies mode precedence for off/forced/opt_in
  falls back display name when friendly name missing
[WARNING]    0.070[0.070]    || Error Assistant timed out after 0.01s
  times out best effort and returns nil
  passes site config settings into plugin context

```
[Error Assistant Response]
Based on the stack trace provided, here's my diagnosis:

## 1) Most likely root cause
This appears to be a test failure in the Error Assistant functionality within the Origen application's test suite. The exception is occurring at line 147 of the error_assistant_spec.rb file during RSpec test execution, suggesting either a test assertion failure or an unhandled exception within the Error Assistant feature being tested.

## 2) Suggested fix steps
• Check the specific test at line 147 in `spec/error_assistant_spec.rb` to understand what functionality is being tested
• Run the test with verbose output (`rspec --format documentation`) to see the actual error message and test description
• Verify that any dependencies or mock objects required by the Error Assistant are properly set up in the
  live test: raises and requests a real solution (manual)
```

Finished in 7.41 seconds (files took 0.39531 seconds to load)
5 examples, 0 failures